### PR TITLE
Perception foundation: LiDAR, depth camera and odom to base_link in sim

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -156,6 +156,49 @@ RUN mkdir -p /opt/onnxruntime && \
 RUN apt-get update && apt-get install -y ros-humble-teleop-twist-keyboard \
     && rm -rf /var/lib/apt/lists/*
 
+# --- Milestone 4: perception sim track ---------------------------------------
+
+# ros-controls/mujoco_ros2_control, built from source into its own overlay. This is the
+# SECOND simulation track (sensors + a simplified mobility body); unitree_mujoco is
+# untouched and stays the source of truth for arm/locomotion fidelity.
+#
+# Pinned 2026-08-02 to main, NOT to a release tag. Release 0.0.3 is apt-installable but
+# ships no 3D lidar -- only a 2D LaserScan -- which does not match the robot's Mid360.
+# The 3D PointCloud2 lidar exists only on main. Risk accepted deliberately: main is
+# unreleased and was recently restructured, so this SHA is a snapshot, not a moving target.
+# Verified to build on Humble at this SHA before pinning.
+ARG MUJOCO_ROS2_CONTROL_SHA=ae0b235affe8792cf8584cb7074e10038f26f57b
+RUN apt-get update && apt-get install -y \
+        ros-humble-mujoco-vendor \
+        ros-humble-ros2-control-cmake \
+        ros-humble-backward-ros \
+        ros-humble-control-toolbox \
+        ros-humble-transmission-interface \
+        ros-humble-tinyxml2-vendor \
+        ros-humble-velocity-controllers \
+    && rm -rf /var/lib/apt/lists/*
+
+# mujoco_ros2_control_demos/_tests are skipped: they pull extra deps and ship example
+# robots we don't use. The mujoco_3d_lidar extension registers itself under the
+# ament resource index key "mujoco_plugins", which the node scans at startup via
+# ament_index_cpp -- so no MUJOCO_PLUGIN_DIR is needed (and it does not work anyway).
+RUN mkdir -p /opt/mujoco_ros2_control_ws/src && \
+    git init -q /opt/mujoco_ros2_control_ws/src/mujoco_ros2_control && \
+    cd /opt/mujoco_ros2_control_ws/src/mujoco_ros2_control && \
+    git remote add origin https://github.com/ros-controls/mujoco_ros2_control.git && \
+    git fetch --depth 1 origin ${MUJOCO_ROS2_CONTROL_SHA} && \
+    git checkout -q FETCH_HEAD && \
+    rm -rf .git && \
+    cd /opt/mujoco_ros2_control_ws && \
+    . /opt/ros/humble/setup.sh && \
+    colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
+        --packages-skip mujoco_ros2_control_demos mujoco_ros2_control_tests && \
+    rm -rf build log src
+
+# Overlay it for every shell. 99- already sorts after the base image's 10-ros-env.sh.
+RUN printf '. /opt/mujoco_ros2_control_ws/install/setup.sh\n' \
+      >> /etc/profile.d/99-grove-g1-env.sh
+
 # Ensure default workspace exists (mounted from host: ./workspace -> /root/workspace)
 RUN mkdir -p /root/workspace/src
 RUN mkdir -p /root/data/

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -178,8 +178,14 @@ vendored and are not needed.
 - **Joint order:** identical to the Unitree DDS motor order (0-28), so `motor_state[i]` and
   `motor_cmd[i]` map straight through. Asserted at startup and in `test_walk_policy`.
 - **Base linear velocity comes from `/sportmodestate`,** not `/lowstate`, which carries no such
-  field. This is why the policy is structurally sim-only: on the real robot that topic is served by
-  the onboard motion service, which is off whenever this stack owns the low-level channel.
+  field. This is why the policy is structurally sim-only, and the reason is stronger than "that
+  service is switched off": **the field does not exist on hardware at all.** `unitree_mujoco`
+  publishes the **go2** `SportModeState` (16 fields, with `position` and `velocity` filled from
+  MuJoCo `framepos`/`framelinvel` on the pelvis `imu` site) regardless of which robot is simulated.
+  The real G1 publishes `unitree_hg::SportModeState_` on the same topic name, and that type carries
+  only `fsm_id`, `fsm_mode`, `task_id` and `task_time`. No pose, no velocity. `rt/odommodestate` does
+  not exist anywhere in Unitree's code. Supplying this observation on hardware needs real state
+  estimation, which is a future milestone (see `g1_state_estimation`).
 - Inference runs at 50 Hz on its own timer, about 0.02 ms per call.
 
 Armature matching turned out not to matter. Ablating armature, frictionloss and damping against

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -10,6 +10,22 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt). This
+  # package is the most Python-heavy in the repo, so its absence here was hiding real
+  # errors behind a green suite.
+  find_program(RUFF_EXECUTABLE ruff)
+  set(_ruff_config "${CMAKE_CURRENT_SOURCE_DIR}/../../ruff.toml")
+  if(RUFF_EXECUTABLE AND EXISTS "${_ruff_config}")
+    add_test(
+      NAME ruff_check_g1_sim
+      COMMAND ${RUFF_EXECUTABLE} check --config ${_ruff_config}
+        ${CMAKE_CURRENT_SOURCE_DIR}/launch
+        ${CMAKE_CURRENT_SOURCE_DIR}/test
+    )
+  else()
+    message(WARNING "ruff and/or workspace ruff.toml not found; skipping ruff_check_g1_sim test")
+  endif()
+
   find_package(ament_cmake_pytest REQUIRED)
 
   # The MJCF and URDF necessarily carry the same mount numbers; this guards the drift.

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -28,8 +28,10 @@ if(BUILD_TESTING)
     TARGET test_lidar_stream TIMEOUT 300)
   add_launch_test(test/test_camera_stream.launch.py
     TARGET test_camera_stream TIMEOUT 300)
+  add_launch_test(test/test_odom_ground_truth.launch.py
+    TARGET test_odom_ground_truth TIMEOUT 300)
   set_tests_properties(test_perception_sim_bringup test_lidar_stream test_camera_stream
-    PROPERTIES RESOURCE_LOCK g1_sim)
+    test_odom_ground_truth PROPERTIES RESOURCE_LOCK g1_sim)
 endif()
 
 ament_package()

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -21,9 +21,15 @@ if(BUILD_TESTING)
   # Note ctest parallelises across packages, so a full-workspace sweep still needs
   # `colcon test --parallel-workers 1`.
   find_package(launch_testing_ament_cmake REQUIRED)
+  # Each of these starts its own MuJoCo, so they share the lock rather than overlap.
   add_launch_test(test/test_perception_sim_bringup.launch.py
     TARGET test_perception_sim_bringup TIMEOUT 240)
-  set_tests_properties(test_perception_sim_bringup PROPERTIES RESOURCE_LOCK g1_sim)
+  add_launch_test(test/test_lidar_stream.launch.py
+    TARGET test_lidar_stream TIMEOUT 300)
+  add_launch_test(test/test_camera_stream.launch.py
+    TARGET test_camera_stream TIMEOUT 300)
+  set_tests_properties(test_perception_sim_bringup test_lidar_stream test_camera_stream
+    PROPERTIES RESOURCE_LOCK g1_sim)
 endif()
 
 ament_package()

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -9,6 +9,12 @@ install(DIRECTORY mjcf urdf config launch DESTINATION share/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_pytest REQUIRED)
+
+  # The MJCF and URDF necessarily carry the same mount numbers; this guards the drift.
+  # No sim and no ROS -- it just parses both files, plus the vendored G1 URDF they derive from.
+  ament_add_pytest_test(test_sensor_mount_consistency test/test_sensor_mount_consistency.py)
 endif()
 
 ament_package()

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -10,9 +10,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt). This
-  # package is the most Python-heavy in the repo, so its absence here was hiding real
-  # errors behind a green suite.
+  # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt).
   find_program(RUFF_EXECUTABLE ruff)
   set(_ruff_config "${CMAKE_CURRENT_SOURCE_DIR}/../../ruff.toml")
   if(RUFF_EXECUTABLE AND EXISTS "${_ruff_config}")

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -15,6 +15,15 @@ if(BUILD_TESTING)
   # The MJCF and URDF necessarily carry the same mount numbers; this guards the drift.
   # No sim and no ROS -- it just parses both files, plus the vendored G1 URDF they derive from.
   ament_add_pytest_test(test_sensor_mount_consistency test/test_sensor_mount_consistency.py)
+
+  # Headless sim integration. RESOURCE_LOCK g1_sim is the SAME lock name g1_bringup uses:
+  # both tracks start a real MuJoCo and starve each other on CPU if run concurrently.
+  # Note ctest parallelises across packages, so a full-workspace sweep still needs
+  # `colcon test --parallel-workers 1`.
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/test_perception_sim_bringup.launch.py
+    TARGET test_perception_sim_bringup TIMEOUT 240)
+  set_tests_properties(test_perception_sim_bringup PROPERTIES RESOURCE_LOCK g1_sim)
 endif()
 
 ament_package()

--- a/workspace/src/g1_sim/CMakeLists.txt
+++ b/workspace/src/g1_sim/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_sim)
+
+find_package(ament_cmake REQUIRED)
+
+# No compiled targets: this package is MJCF, URDF, config, launch and tests.
+install(DIRECTORY mjcf urdf config launch DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/workspace/src/g1_sim/README.md
+++ b/workspace/src/g1_sim/README.md
@@ -46,6 +46,15 @@ dependence, and no motion distortion. Anything whose correctness depends on the 
 such as Livox-tuned LIO feature extraction or de-skewing, is **not** validated here. The real
 driver's `CustomMsg` format is not produced either; this publishes `PointCloud2`.
 
+**Known plugin artifact: rays leak through walls.** Roughly 4% of returns (about 440 of 11,520) pass
+straight through a wall and land on the floor plane outside the room. It is a contiguous band of
+downward rays, grid rows 9 to 13, about 10 to 18 degrees below horizontal, which would strike the
+wall below z ~= 0.55 m. Rays crossing the same wall higher up are blocked correctly, and the camera
+renders those same walls as solid at those same heights, so this is the plugin's raycast rather than
+the scene geometry. Consequence for downstream work: **a costmap fed directly from this cloud will
+see phantom obstacles outside the room.** `test_lidar_stream` asserts only that the great majority of
+returns land inside the room, so a real regression still fails while this artifact does not.
+
 The camera is `848x480 @ fovy 58`, about 87 degrees horizontal, matching the real D435i **depth**
 stream. One MuJoCo camera cannot carry two intrinsics, so the colour stream is wider than a real
 D435i colour stream. Matched to depth, which is what this track is for. No depth noise, no stereo
@@ -63,3 +72,9 @@ symmetric field of view, is why the asymmetric Mid360 band needs no compensating
 
 The plugin registers itself under the ament resource index key `mujoco_plugins`, which the node
 scans at startup. No `MUJOCO_PLUGIN_DIR` is needed, and setting it does not work.
+
+`config/mujoco_plugins.yaml` must be keyed to **`mujoco_ros2_control_node`**, a second node living
+inside the same process as `controller_manager`. Key it to `controller_manager` and the parameters
+reach the wrong node: the log says `No 'mujoco_plugins' parameter found!`, the LiDAR never publishes
+at all, and the camera quietly auto-registers on default topics at the default rate. Key it to `/**`
+and it also matches every controller, shadowing their own sections.

--- a/workspace/src/g1_sim/README.md
+++ b/workspace/src/g1_sim/README.md
@@ -1,0 +1,65 @@
+# g1_sim
+
+**SIM-ONLY.** The perception simulation track: a simplified mobile body carrying a 3D LiDAR and an
+RGB-D camera in MuJoCo, run through `mujoco_ros2_control`.
+
+This is a **second, independent simulation track**. `unitree_mujoco` (driven by `g1_bringup`) is
+untouched and remains the source of truth for arm and locomotion fidelity. The two are never run at
+the same time.
+
+## This is not the G1
+
+The body here is a deliberately non-physical mobility stand-in: a cylinder on three planar joints
+(slide-x, slide-y, hinge-z). It cannot topple and is commanded directly through `ros2_control`.
+
+Early perception work does not need bipedal dynamics to be correct, and a 29-DoF humanoid with no
+balance controller would only topple or need a weld. Nothing here commands a motor on the G1 model,
+so no new writer appears on any low-level control channel.
+
+**What is real:** the sensor mount poses. They are taken from Unitree's own vendored URDF
+(`g1_description`, joints `mid360_joint` and `d435_joint`), with `torso_link`'s offset from `pelvis`
+folded in, and `base_link` sits at the pelvis spawn height of 0.793 m. So the sensors sit where they
+sit on the robot.
+
+## Scene
+
+An 8 x 8 m room, walls with inner faces at +/-4.0 m, floor at z = 0, and three obstacles at known
+poses. The geometry is deliberate: every sensor assertion in the integration tests is a geometric
+fact of `mjcf/g1_perception_base.xml`, so the tests measure something real rather than checking that
+data merely arrives.
+
+## Sensors
+
+| | Mount vs `base_link` | Notes |
+|---|---|---|
+| `livox_frame` | xyz `-0.00368 0.00003 0.472434`, rpy `pi 0.05112069 0` | **Roll is exactly pi: the Mid360 is mounted upside down on the real G1.** Replicated here, because missing it inverts every point cloud relative to hardware. |
+| `camera_link` | xyz `0.05366 0.01753 0.473870`, rpy `0 0.83077672 0` | **Pitched 47.6 degrees downward.** That makes it a manipulation / near-ground camera, not a forward-looking navigation one. |
+
+LiDAR is configured to the real Mid360 envelope: 360 degrees azimuth, -7 to +52 degrees elevation,
+40 m range, 10 Hz, at 360 x 32 resolution (11,520 rays, about 115k pts/s against the real sensor's
+~200k).
+
+**What this LiDAR is not.** It is a uniform azimuth/elevation grid raycast, not the Mid360's
+non-repetitive rosette scan. Point density is uniform where the real sensor's is time-varying. There
+is no intensity, no per-point timestamps, no ring field, no noise, no dropout, no reflectivity
+dependence, and no motion distortion. Anything whose correctness depends on the real scan pattern,
+such as Livox-tuned LIO feature extraction or de-skewing, is **not** validated here. The real
+driver's `CustomMsg` format is not produced either; this publishes `PointCloud2`.
+
+The camera is `848x480 @ fovy 58`, about 87 degrees horizontal, matching the real D435i **depth**
+stream. One MuJoCo camera cannot carry two intrinsics, so the colour stream is wider than a real
+D435i colour stream. Matched to depth, which is what this track is for. No depth noise, no stereo
+dropout on textureless surfaces, no IR projector behaviour.
+
+## MJCF plugin API
+
+The 3D LiDAR is a MuJoCo **engine plugin**, configured in `<extension><instance>` and referenced
+from `<sensor>`. Config keys are `resolution`, `azimuth_range`, `elevation_range`, `max_range`,
+`min_range`, `update_rate`, `async`.
+
+The upstream README documents an older API (`mujoco.sensor.lidar` with `size` and `fov`) that does
+**not** work at the pinned commit. `elevation_range` being an explicit min/max, rather than a
+symmetric field of view, is why the asymmetric Mid360 band needs no compensating sensor pitch.
+
+The plugin registers itself under the ament resource index key `mujoco_plugins`, which the node
+scans at startup. No `MUJOCO_PLUGIN_DIR` is needed, and setting it does not work.

--- a/workspace/src/g1_sim/README.md
+++ b/workspace/src/g1_sim/README.md
@@ -28,6 +28,14 @@ poses. The geometry is deliberate: every sensor assertion in the integration tes
 fact of `mjcf/g1_perception_base.xml`, so the tests measure something real rather than checking that
 data merely arrives.
 
+## Frames
+
+`base_link` spawns at **0.793 m**, the G1's pelvis height, so the sensors sit at realistic heights.
+That number lives in `config/sensor_mounts.yaml` as `base_link.spawn_z` and nowhere else:
+`test_sensor_mount_consistency` pins it to the MJCF, and `perception_sim.launch.py` hands it to
+`g1_odometry_publisher` as `base_height_m`. That makes **`odom` the ground plane** rather than a
+frame floating at the spawn height, so a cloud transformed into `odom` has its floor at z = 0.
+
 ## Sensors
 
 | | Mount vs `base_link` | Notes |

--- a/workspace/src/g1_sim/config/controllers.yaml
+++ b/workspace/src/g1_sim/config/controllers.yaml
@@ -1,0 +1,20 @@
+# Controllers for the perception-track body. SIM-ONLY.
+controller_manager:
+  ros__parameters:
+    update_rate: 200
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    # Velocity control of the three planar joints. A stock controller commanded with
+    # Float64MultiArray [vx, vy, wz], so moving the robot in a test is one publish and
+    # needs no code of our own. A Twist adapter belongs with the deferred Nav2 work.
+    base_velocity_controller:
+      type: velocity_controllers/JointGroupVelocityController
+
+base_velocity_controller:
+  ros__parameters:
+    joints:
+      - base_x_joint
+      - base_y_joint
+      - base_yaw_joint

--- a/workspace/src/g1_sim/config/mujoco_plugins.yaml
+++ b/workspace/src/g1_sim/config/mujoco_plugins.yaml
@@ -1,0 +1,35 @@
+# mujoco_ros2_control plugins for the perception track. SIM-ONLY.
+#
+# Plugins load from parameters under `mujoco_plugins`, each entry keyed by an arbitrary
+# name with a `type` naming the pluginlib class. Within a sensor plugin, the sub-key must
+# match the sensor or camera NAME IN THE MJCF (`mid360`, `d435i` here).
+#
+# Topic and frame names deliberately match the real drivers' defaults, so swapping to
+# hardware is a driver launch rather than a pile of remaps.
+# Scoped to controller_manager, NOT the `/**` wildcard the upstream demo uses. A
+# wildcard block matches every node in the process, including each controller, and
+# because this file is loaded after controllers.yaml it shadows their own node-keyed
+# sections -- which shows up as "'joints' parameter was empty" and a controller stuck
+# in `unconfigured`.
+controller_manager:
+  ros__parameters:
+    mujoco_plugins:
+      # Publishes every mujoco.plugin.lidar sensor. PointCloud2 for multi-row (3D)
+      # sensors, LaserScan for single-row. Ours is 360x32, so PointCloud2.
+      mujoco_3d_lidar_plugin:
+        type: "mujoco_ros2_control_plugins/Mujoco3dLidarPlugin"
+        mid360:
+          # livox_ros_driver2's own default frame id.
+          frame_name: "livox_frame"
+          topic: "/livox/lidar"
+
+      # RGB + depth + camera_info, on realsense2_camera's conventional topic names.
+      mujoco_camera_plugin:
+        type: "mujoco_ros2_control_plugins/CameraPlugin"
+        camera_publish_rate: 15.0
+        d435i:
+          policy: streaming
+          frame_name: "camera_color_optical_frame"
+          info_topic: "/camera/color/camera_info"
+          image_topic: "/camera/color/image_raw"
+          depth_topic: "/camera/aligned_depth_to_color/image_raw"

--- a/workspace/src/g1_sim/config/mujoco_plugins.yaml
+++ b/workspace/src/g1_sim/config/mujoco_plugins.yaml
@@ -6,12 +6,15 @@
 #
 # Topic and frame names deliberately match the real drivers' defaults, so swapping to
 # hardware is a driver launch rather than a pile of remaps.
-# Scoped to controller_manager, NOT the `/**` wildcard the upstream demo uses. A
-# wildcard block matches every node in the process, including each controller, and
-# because this file is loaded after controllers.yaml it shadows their own node-keyed
-# sections -- which shows up as "'joints' parameter was empty" and a controller stuck
-# in `unconfigured`.
-controller_manager:
+# Keyed to mujoco_ros2_control_node, the node that actually reads `mujoco_plugins`. It is
+# a second node living inside the same process as controller_manager, so the key matters:
+#   - `/**` (what the upstream demo uses) also matches every controller, and since this
+#     file loads after controllers.yaml it shadows their sections. Symptom: "'joints'
+#     parameter was empty" and a controller stuck in `unconfigured`.
+#   - `controller_manager` reaches the wrong node of the two. Symptom is quieter and worse:
+#     "No 'mujoco_plugins' parameter found!", the lidar plugin never loads at all, and the
+#     camera silently auto-registers on default topics at the default rate.
+mujoco_ros2_control_node:
   ros__parameters:
     mujoco_plugins:
       # Publishes every mujoco.plugin.lidar sensor. PointCloud2 for multi-row (3D)

--- a/workspace/src/g1_sim/config/sensor_mounts.yaml
+++ b/workspace/src/g1_sim/config/sensor_mounts.yaml
@@ -1,0 +1,44 @@
+# Sensor mount poses for the perception-track body.
+#
+# THESE ARE NOT INVENTED. Every value below is derived from Unitree's own vendored URDF
+# (g1_description/urdf/g1_29dof_with_hand_rev_1_0.urdf), joints `mid360_joint` and
+# `d435_joint`, which are children of `torso_link`. Our `base_link` stands in for
+# `pelvis`, so `torso_link`'s own offset from `pelvis` -- xyz (-0.0039635, 0, 0.044) via
+# the waist chain at zero pose -- is folded into the numbers here.
+#
+# Source values, for anyone re-deriving them:
+#   mid360_joint: xyz "0.0002835 0.00003 0.428434"  rpy "3.141592653589793 0.05112069379091391 0"
+#   d435_joint:   xyz "0.0576235  0.01753 0.42987"  rpy "0 0.8307767239493009 0"
+#
+# HARDWARE RE-VALIDATION: the vendored URDF is a design model. Confirm against the
+# physical robot at bring-up before trusting these for extrinsics.
+#
+# mjcf/g1_perception_base.xml carries the same numbers in MuJoCo's own quaternion form.
+# test_sensor_mount_consistency asserts the two agree, so edit both or neither.
+
+livox_frame:
+  parent: base_link
+  # Roll is exactly pi: the Mid360 is mounted UPSIDE DOWN on the G1. Missing this
+  # inverts every point cloud relative to hardware.
+  xyz: [-0.00368, 0.00003, 0.472434]
+  rpy: [3.141592653589793, 0.05112069379091391, 0.0]
+
+camera_link:
+  parent: base_link
+  # Pitched 0.8308 rad = 47.6 degrees DOWNWARD. A manipulation / near-ground camera,
+  # not a forward-looking navigation one.
+  xyz: [0.05366, 0.01753, 0.473870]
+  rpy: [0.0, 0.8307767239493009, 0.0]
+
+# REP-103/145 optical frames: z forward, x right, y down. Get this wrong and every
+# projected point cloud is rotated 90 degrees.
+camera_color_optical_frame:
+  parent: camera_link
+  xyz: [0.0, 0.0, 0.0]
+  rpy: [-1.5707963267948966, 0.0, -1.5707963267948966]
+
+camera_depth_optical_frame:
+  parent: camera_link
+  # 15 mm baseline offset from the colour frame, matching the D435i's physical layout.
+  xyz: [0.0, 0.015, 0.0]
+  rpy: [-1.5707963267948966, 0.0, -1.5707963267948966]

--- a/workspace/src/g1_sim/config/sensor_mounts.yaml
+++ b/workspace/src/g1_sim/config/sensor_mounts.yaml
@@ -16,17 +16,9 @@
 # mjcf/g1_perception_base.xml carries the same numbers in MuJoCo's own quaternion form.
 # test_sensor_mount_consistency asserts the two agree, so edit both or neither.
 
-# CANONICAL height of base_link above the floor. This is the one place it is written.
-#
-# It is what makes `odom` the GROUND PLANE rather than a frame floating at the spawn
-# height: g1_odometry_publisher publishes it as the z of odom -> base_link, so a floor
-# return transformed into odom lands at z = 0 and Nav2's obstacle height bands mean what
-# they say. Leave it out and every consumer has to subtract it by hand, which is exactly
-# how it went wrong the first time.
-#
-# The MJCF spawns the base body at this height; test_sensor_mount_consistency asserts the
-# two agree. perception_sim.launch.py reads it from here and passes it to the node, so
-# nothing downstream carries its own copy.
+# Canonical height of base_link above the floor, and the only place it is written.
+# g1_odometry_publisher publishes it as the z of odom -> base_link, which is what puts
+# `odom` on the ground plane. Checked against the MJCF by test_sensor_mount_consistency.
 base_link:
   spawn_z: 0.793
 

--- a/workspace/src/g1_sim/config/sensor_mounts.yaml
+++ b/workspace/src/g1_sim/config/sensor_mounts.yaml
@@ -16,6 +16,20 @@
 # mjcf/g1_perception_base.xml carries the same numbers in MuJoCo's own quaternion form.
 # test_sensor_mount_consistency asserts the two agree, so edit both or neither.
 
+# CANONICAL height of base_link above the floor. This is the one place it is written.
+#
+# It is what makes `odom` the GROUND PLANE rather than a frame floating at the spawn
+# height: g1_odometry_publisher publishes it as the z of odom -> base_link, so a floor
+# return transformed into odom lands at z = 0 and Nav2's obstacle height bands mean what
+# they say. Leave it out and every consumer has to subtract it by hand, which is exactly
+# how it went wrong the first time.
+#
+# The MJCF spawns the base body at this height; test_sensor_mount_consistency asserts the
+# two agree. perception_sim.launch.py reads it from here and passes it to the node, so
+# nothing downstream carries its own copy.
+base_link:
+  spawn_z: 0.793
+
 livox_frame:
   parent: base_link
   # Roll is exactly pi: the Mid360 is mounted UPSIDE DOWN on the G1. Missing this

--- a/workspace/src/g1_sim/launch/perception_sim.launch.py
+++ b/workspace/src/g1_sim/launch/perception_sim.launch.py
@@ -1,0 +1,216 @@
+"""Perception sim track: MuJoCo + mujoco_ros2_control with a 3D LiDAR and RGB-D camera.
+
+SIM-ONLY, and the SECOND simulation track. `g1_bringup`'s sim.launch.py drives
+unitree_mujoco for arm and locomotion fidelity; this one drives a simplified mobility
+body for sensors. They share ROS_DOMAIN_ID=1 and must never run at the same time, which
+_check_environment below enforces rather than trusts.
+
+See g1_sim/README.md for what this body is and is not.
+"""
+
+import os
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+    Shutdown,
+    TimerAction,
+)
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
+
+# g1_bringup owns :133. A separate display so a stray process from either track cannot
+# collide with the other's.
+XVFB_DISPLAY = ":134"
+
+# The camera renders, so MUJOCO_GL=disable is not an option here and a real GL context is
+# required. The container has the NVIDIA runtime, so this is hardware-accelerated.
+SIM_START_DELAY_S = 2.0
+
+
+def _check_environment(context, *args, **kwargs):
+    """Refuse to start on a misconfigured environment, or alongside the other sim track.
+
+    Same fail-fast principle as g1_bringup's sim.launch.py: an empty or crosstalking ROS
+    graph is far harder to debug than an explicit error here.
+    """
+    problems = []
+
+    rmw = os.environ.get("RMW_IMPLEMENTATION")
+    if rmw != "rmw_cyclonedds_cpp":
+        problems.append(
+            f"RMW_IMPLEMENTATION={rmw!r}, expected 'rmw_cyclonedds_cpp'."
+        )
+    if not os.environ.get("CYCLONEDDS_URI"):
+        problems.append(
+            "CYCLONEDDS_URI is unset -- expected the container-baked cyclonedds.xml."
+        )
+    domain_id = os.environ.get("ROS_DOMAIN_ID")
+    if domain_id != "1":
+        problems.append(
+            f"ROS_DOMAIN_ID={domain_id!r}, expected '1'. Both sim tracks share domain 1 "
+            "deliberately; see g1_sim/README.md."
+        )
+
+    if problems:
+        raise RuntimeError(
+            "g1_sim/perception_sim.launch.py: refusing to start, environment "
+            "precondition(s) failed:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+            + "\nThese are set container-wide by .devcontainer/Dockerfile; a fresh "
+            "'manage.sh recreate' is the usual fix."
+        )
+
+    # The two tracks share a domain, so a running unitree_mujoco would inject a second
+    # /robot_description, a second controller_manager and a competing /tf writer into
+    # this graph. Cheaper to detect than to debug: /lowstate is unique to that track.
+    import rclpy
+    from rclpy.node import Node as RclpyNode
+
+    already_running = False
+    rclpy_was_ours = not rclpy.ok()
+    try:
+        if rclpy_was_ours:
+            rclpy.init()
+        probe = RclpyNode("g1_sim_track_conflict_probe")
+        # One short spin: DDS discovery is not instant, and a false negative here only
+        # costs the confusing failure this check exists to prevent.
+        end = time.time() + 2.0
+        while time.time() < end and not already_running:
+            rclpy.spin_once(probe, timeout_sec=0.1)
+            already_running = probe.count_publishers("/lowstate") > 0
+        probe.destroy_node()
+    finally:
+        if rclpy_was_ours and rclpy.ok():
+            rclpy.shutdown()
+
+    if already_running:
+        raise RuntimeError(
+            "g1_sim/perception_sim.launch.py: refusing to start -- a publisher on "
+            "/lowstate means g1_bringup's unitree_mujoco track is already running on "
+            "this domain. The two tracks share ROS_DOMAIN_ID=1 and must not overlap: "
+            "they would both publish /robot_description and /tf and both run a node "
+            "named controller_manager.\n"
+            "Stop it first (Ctrl-C its launch), then confirm nothing survived:\n"
+            "  pkill -x unitree_mujoco; pkill -x motion_service_; pkill -x Xvfb\n"
+            "(never pkill -f: the container shares the host PID namespace)"
+        )
+    return []
+
+
+def _launch_setup(context, *args, **kwargs):
+    pkg_share = get_package_share_directory("g1_sim")
+    headless = LaunchConfiguration("headless").perform(context).lower() == "true"
+
+    robot_description_str = Command(
+        [
+            FindExecutable(name="xacro"),
+            " ",
+            os.path.join(pkg_share, "urdf", "g1_perception_base.urdf.xacro"),
+        ]
+    ).perform(context)
+    robot_description = {
+        "robot_description": ParameterValue(value=robot_description_str, value_type=str)
+    }
+
+    controllers_file = os.path.join(pkg_share, "config", "controllers.yaml")
+    plugins_file = os.path.join(pkg_share, "config", "mujoco_plugins.yaml")
+
+    # mujoco_ros2_control drives simulated time, so every node in this track reads it.
+    # A TF publisher on a different clock than its data is the classic cause of
+    # "extrapolation into the future" from tf2.
+    use_sim_time = {"use_sim_time": True}
+
+    actions = []
+    node_env = dict(os.environ)
+    if headless:
+        actions.append(
+            ExecuteProcess(
+                cmd=["Xvfb", XVFB_DISPLAY, "-screen", "0", "1280x1024x24", "-nolisten", "tcp"],
+                name="xvfb",
+                output="screen",
+            )
+        )
+        node_env["DISPLAY"] = XVFB_DISPLAY
+
+    actions.append(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[robot_description, use_sim_time],
+        )
+    )
+
+    # Package-qualified deliberately: controller_manager ships an executable of the same
+    # name, and picking the wrong one silently gives a sim-less controller_manager.
+    #
+    # /joint_states is remapped away so the three planar pseudo-joints never reach
+    # robot_state_publisher (they are not in the kinematic tree, by design). The
+    # odometry publisher consumes /base_joint_states instead.
+    actions.append(
+        TimerAction(
+            period=SIM_START_DELAY_S if headless else 0.0,
+            actions=[
+                Node(
+                    package="mujoco_ros2_control",
+                    executable="ros2_control_node",
+                    # No name= override. Setting it puts __node:= on the process, which
+                    # renames EVERY node created in it -- including each controller -- so
+                    # their node-keyed parameter sections never match and they come up
+                    # with empty params. The node already calls itself controller_manager.
+                    emulate_tty=True,
+                    output="both",
+                    env=node_env,
+                    parameters=[
+                        use_sim_time,
+                        ParameterFile(controllers_file),
+                        ParameterFile(plugins_file),
+                    ],
+                    remappings=[
+                        ("~/robot_description", "/robot_description"),
+                        ("/joint_states", "/base_joint_states"),
+                    ],
+                    on_exit=Shutdown(reason="mujoco_ros2_control node exited"),
+                )
+            ],
+        )
+    )
+
+    for controller in ("joint_state_broadcaster", "base_velocity_controller"):
+        actions.append(
+            Node(
+                package="controller_manager",
+                executable="spawner",
+                # No --param-file here: controllers read their parameters from the file
+                # given to the controller_manager above. Passing it again on the spawner
+                # sets a competing `params_file` override and the controller comes up with
+                # an empty `joints` list.
+                arguments=[controller],
+                parameters=[use_sim_time],
+                output="both",
+            )
+        )
+
+    return actions
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            OpaqueFunction(function=_check_environment),
+            DeclareLaunchArgument(
+                "headless",
+                default_value="true",
+                description="Render into our own managed Xvfb instead of a visible window. "
+                "The camera requires a real GL context either way, so there is no "
+                "render-nothing mode here.",
+            ),
+            OpaqueFunction(function=_launch_setup),
+        ]
+    )

--- a/workspace/src/g1_sim/launch/perception_sim.launch.py
+++ b/workspace/src/g1_sim/launch/perception_sim.launch.py
@@ -15,14 +15,21 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
     ExecuteProcess,
     OpaqueFunction,
+    RegisterEventHandler,
     Shutdown,
     TimerAction,
 )
+from launch.event_handlers import OnProcessStart
+from launch.events import matches_action
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration
-from launch_ros.actions import Node
+from launch_ros.actions import LifecycleNode, Node
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.events.lifecycle import ChangeState
 from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
+from lifecycle_msgs.msg import Transition
 
 # g1_bringup owns :133. A separate display so a stray process from either track cannot
 # collide with the other's.
@@ -196,6 +203,55 @@ def _launch_setup(context, *args, **kwargs):
                 output="both",
             )
         )
+
+    # odom -> base_link. sim_ground_truth is set here rather than left to the package
+    # default, which is `hardware` and refuses to configure on purpose.
+    odometry_params = os.path.join(
+        get_package_share_directory("g1_state_estimation"), "config", "g1_odometry_publisher.yaml"
+    )
+    odometry_node = LifecycleNode(
+        package="g1_state_estimation",
+        executable="g1_odometry_publisher",
+        name="g1_odometry_publisher",
+        namespace="",
+        output="both",
+        parameters=[odometry_params, use_sim_time],
+        remappings=[("~/base_state", "/base_joint_states")],
+    )
+    actions.append(odometry_node)
+
+    # Event-chained rather than delayed, same shape as g1_bringup's loco.launch.py.
+    actions.append(
+        RegisterEventHandler(
+            OnProcessStart(
+                target_action=odometry_node,
+                on_start=[
+                    EmitEvent(
+                        event=ChangeState(
+                            lifecycle_node_matcher=matches_action(odometry_node),
+                            transition_id=Transition.TRANSITION_CONFIGURE,
+                        )
+                    )
+                ],
+            )
+        )
+    )
+    actions.append(
+        RegisterEventHandler(
+            OnStateTransition(
+                target_lifecycle_node=odometry_node,
+                goal_state="inactive",
+                entities=[
+                    EmitEvent(
+                        event=ChangeState(
+                            lifecycle_node_matcher=matches_action(odometry_node),
+                            transition_id=Transition.TRANSITION_ACTIVATE,
+                        )
+                    )
+                ],
+            )
+        )
+    )
 
     return actions
 

--- a/workspace/src/g1_sim/launch/perception_sim.launch.py
+++ b/workspace/src/g1_sim/launch/perception_sim.launch.py
@@ -11,6 +11,7 @@ See g1_sim/README.md for what this body is and is not.
 import os
 import time
 
+import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
@@ -209,13 +210,18 @@ def _launch_setup(context, *args, **kwargs):
     odometry_params = os.path.join(
         get_package_share_directory("g1_state_estimation"), "config", "g1_odometry_publisher.yaml"
     )
+    # base_height_m comes from the same file the MJCF spawn height is checked against, so
+    # `odom` is the ground plane and nothing downstream has to subtract a magic number.
+    with open(os.path.join(pkg_share, "config", "sensor_mounts.yaml")) as mounts_file:
+        base_height = yaml.safe_load(mounts_file)["base_link"]["spawn_z"]
+
     odometry_node = LifecycleNode(
         package="g1_state_estimation",
         executable="g1_odometry_publisher",
         name="g1_odometry_publisher",
         namespace="",
         output="both",
-        parameters=[odometry_params, use_sim_time],
+        parameters=[odometry_params, use_sim_time, {"base_height_m": base_height}],
         remappings=[("~/base_state", "/base_joint_states")],
     )
     actions.append(odometry_node)

--- a/workspace/src/g1_sim/mjcf/g1_perception_base.xml
+++ b/workspace/src/g1_sim/mjcf/g1_perception_base.xml
@@ -13,7 +13,7 @@
   (g1_description/urdf/g1_29dof_with_hand_rev_1_0.urdf, joints mid360_joint and
   d435_joint), with torso_link's own offset from pelvis folded in. base_link stands in
   for the pelvis and sits at its 0.793 m spawn height, so the sensors end up at
-  realistic heights. Keep these in sync with config/sensor_mounts.yaml --
+  realistic heights. Keep these in sync with config/sensor_mounts.yaml 
   test_sensor_mount_consistency asserts they match.
 
   Room geometry is deliberate and known: every sensor assertion in the integration tests
@@ -102,7 +102,7 @@
       <!--
         Mid360. rpy roll is exactly pi: the sensor is mounted UPSIDE DOWN on the real G1
         (mid360_joint in the vendored URDF; corroborated by the FAST_LIO humanoid work,
-        which sets roll 180 for the reversed Mid360). Replicating it matters -- miss it
+        which sets roll 180 for the reversed Mid360). Replicating it matters, miss it
         and every point cloud is inverted relative to hardware.
         quat below is rpy (3.14159265, 0.05112069, 0) as w x y z.
       -->

--- a/workspace/src/g1_sim/mjcf/g1_perception_base.xml
+++ b/workspace/src/g1_sim/mjcf/g1_perception_base.xml
@@ -1,0 +1,141 @@
+<!--
+  SIM-ONLY perception scene: a simplified mobile body carrying a Livox Mid360-shaped
+  3D LiDAR and a RealSense D435i-shaped RGB-D camera.
+
+  This is NOT the G1. It is a deliberately non-physical mobility stand-in: three planar
+  joints (slide-x, slide-y, hinge-z) so it cannot topple and is directly commandable
+  through ros2_control. Early perception work does not need bipedal dynamics to be
+  correct, and a 29-DoF humanoid with no balance controller would only topple or need a
+  weld. The unitree_mujoco track remains the source of truth for arm and locomotion
+  fidelity.
+
+  Sensor MOUNT POSES ARE REAL: taken from Unitree's own vendored URDF
+  (g1_description/urdf/g1_29dof_with_hand_rev_1_0.urdf, joints mid360_joint and
+  d435_joint), with torso_link's own offset from pelvis folded in. base_link stands in
+  for the pelvis and sits at its 0.793 m spawn height, so the sensors end up at
+  realistic heights. Keep these in sync with config/sensor_mounts.yaml --
+  test_sensor_mount_consistency asserts they match.
+
+  Room geometry is deliberate and known: every sensor assertion in the integration tests
+  is a geometric fact of this file (walls at +/-4 m, floor at z=0), so the tests measure
+  something real rather than merely checking that data arrives.
+-->
+<mujoco model="g1_perception_base">
+  <compiler angle="radian"/>
+
+  <!--
+    200 Hz. Nothing here is dynamics-critical (no contact-rich locomotion, no balance),
+    so this is about giving the controllers and sensors a steady tick, not fidelity.
+  -->
+  <option timestep="0.005" integrator="implicitfast" gravity="0 0 -9.81"/>
+
+  <!--
+    3D LiDAR engine plugin. The config keys below are the ones 3dlidar.cpp actually
+    parses: resolution / azimuth_range / elevation_range / max_range / min_range /
+    update_rate / async. The upstream README documents an older API (size / fov) that
+    does not work at the pinned commit.
+
+    elevation_range is an explicit min/max, NOT a symmetric field of view, so the real
+    Mid360's asymmetric -7..+52 deg band goes in directly and the sensor site needs no
+    compensating pitch.
+  -->
+  <extension>
+    <plugin plugin="mujoco.plugin.lidar">
+      <instance name="mid360_cfg">
+        <!-- 360 x 32 = 11520 rays; at 10 Hz that is ~115k pts/s against the real
+             sensor's ~200k. Raising vertical resolution costs raycasts linearly. -->
+        <config key="resolution" value="360 32"/>
+        <config key="azimuth_range" value="-3.14159265 3.14159265"/>
+        <!-- -7 deg .. +52 deg, the real Mid360 band. -->
+        <config key="elevation_range" value="-0.12217305 0.90757121"/>
+        <config key="max_range" value="40.0"/>
+        <config key="min_range" value="0.1"/>
+        <config key="update_rate" value="10.0"/>
+        <config key="async" value="0"/>
+      </instance>
+    </plugin>
+  </extension>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0"
+             width="512" height="512"/>
+    <texture type="2d" name="groundplane" builtin="checker" rgb1="0.2 0.3 0.4"
+             rgb2="0.25 0.35 0.45" width="256" height="256"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="8 8"/>
+    <material name="wall" rgba="0.75 0.75 0.72 1"/>
+    <material name="obstacle" rgba="0.8 0.4 0.3 1"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 4" dir="0 0 -1" diffuse="0.8 0.8 0.8"/>
+    <light pos="-3 3 3" dir="0.5 -0.5 -1" diffuse="0.4 0.4 0.4"/>
+
+    <geom name="floor" type="plane" size="20 20 0.05" material="groundplane"/>
+
+    <!-- 8 x 8 m room. Inner wall faces sit at +/-4.0 m; the tests assert against that. -->
+    <geom name="wall_px" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" type="box" size="4.0 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" type="box" size="4.0 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+
+    <!-- Obstacles at known poses: give the point cloud and depth image structure to see. -->
+    <geom name="obstacle_box" type="box" size="0.3 0.3 0.5" pos="2.0 1.0 0.5"
+          material="obstacle"/>
+    <geom name="obstacle_cyl" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+          material="obstacle"/>
+    <geom name="obstacle_low" type="box" size="0.4 0.4 0.15" pos="1.2 -1.8 0.15"
+          material="obstacle"/>
+
+    <!--
+      base_link at the G1 pelvis spawn height so sensor heights are realistic.
+      Joint order is load-bearing: slide-x, slide-y, then hinge-z gives world-frame
+      translation with in-place yaw. Hinge-first would make yaw swing the body about the
+      world origin in an arc instead.
+    -->
+    <body name="base_link" pos="0 0 0.793">
+      <joint name="base_x_joint" type="slide" axis="1 0 0" damping="20"/>
+      <joint name="base_y_joint" type="slide" axis="0 1 0" damping="20"/>
+      <joint name="base_yaw_joint" type="hinge" axis="0 0 1" damping="10"/>
+      <inertial mass="30.0" pos="0 0 0" diaginertia="2.0 2.0 1.0"/>
+      <geom name="torso" type="cylinder" size="0.15 0.35" pos="0 0 0" rgba="0.4 0.45 0.5 1"/>
+
+      <!--
+        Mid360. rpy roll is exactly pi: the sensor is mounted UPSIDE DOWN on the real G1
+        (mid360_joint in the vendored URDF; corroborated by the FAST_LIO humanoid work,
+        which sets roll 180 for the reversed Mid360). Replicating it matters -- miss it
+        and every point cloud is inverted relative to hardware.
+        quat below is rpy (3.14159265, 0.05112069, 0) as w x y z.
+      -->
+      <site name="livox_frame" pos="-0.00368 0.00003 0.472434"
+            quat="0.0 0.99967335 0.0 -0.02555756" size="0.015" rgba="1 0 0 1"/>
+
+      <!--
+        D435i, pitched 0.8308 rad = 47.6 deg DOWNWARD (d435_joint in the vendored URDF).
+        That makes it a manipulation / near-ground camera, not a forward-looking
+        navigation one. The MuJoCo camera looks down its own -z with +y up, so the quat
+        below composes the URDF mount pitch with the optical-frame convention.
+      -->
+      <body name="camera_link" pos="0.05366 0.01753 0.473870"
+            quat="0.91495967 0.0 0.40354530 0.0">
+        <inertial mass="0.05" pos="0 0 0" diaginertia="1e-5 1e-5 1e-5"/>
+        <!-- 848x480 @ fovy 58 deg gives ~87 deg horizontal: the real D435i DEPTH stream.
+             One MuJoCo camera cannot hold two intrinsics, so colour is wider than a real
+             D435i colour stream. Matched to depth, which is what this track is for. -->
+        <camera name="d435i" mode="fixed" fovy="58" resolution="848 480"
+                pos="0 0 0" quat="-0.5 -0.5 0.5 0.5"/>
+      </body>
+    </body>
+  </worldbody>
+
+  <sensor>
+    <plugin name="mid360" instance="mid360_cfg" objtype="site" objname="livox_frame"/>
+  </sensor>
+
+  <actuator>
+    <!-- Velocity actuators on the three planar joints. Claimed by
+         velocity_controllers/JointGroupVelocityController; see config/controllers.yaml. -->
+    <velocity name="base_x" joint="base_x_joint" kv="60"/>
+    <velocity name="base_y" joint="base_y_joint" kv="60"/>
+    <velocity name="base_yaw" joint="base_yaw_joint" kv="30"/>
+  </actuator>
+</mujoco>

--- a/workspace/src/g1_sim/mjcf/g1_perception_base.xml
+++ b/workspace/src/g1_sim/mjcf/g1_perception_base.xml
@@ -72,11 +72,15 @@
 
     <geom name="floor" type="plane" size="20 20 0.05" material="groundplane"/>
 
-    <!-- 8 x 8 m room. Inner wall faces sit at +/-4.0 m; the tests assert against that. -->
+    <!-- 8 x 8 m room. Inner wall faces sit at +/-4.0 m; the tests assert against that.
+         The y walls run to +/-4.1 in x so they cover the x walls' full thickness: at 4.0
+         the four boxes met along an edge and left an open square in each corner. Sealing
+         it did not change the stray points the lidar plugin returns outside the room;
+         that is a plugin artifact rather than this gap, see g1_sim/README.md. -->
     <geom name="wall_px" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
     <geom name="wall_nx" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
-    <geom name="wall_py" type="box" size="4.0 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
-    <geom name="wall_ny" type="box" size="4.0 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+    <geom name="wall_py" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
 
     <!-- Obstacles at known poses: give the point cloud and depth image structure to see. -->
     <geom name="obstacle_box" type="box" size="0.3 0.3 0.5" pos="2.0 1.0 0.5"

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_sim</name>
+  <version>0.1.0</version>
+  <description>
+    SIM-ONLY perception simulation track: a simplified mobile body carrying a 3D LiDAR
+    and an RGB-D camera in MuJoCo, run through mujoco_ros2_control. Separate from the
+    unitree_mujoco track, which remains the source of truth for arm and locomotion
+    fidelity. See README for the operating procedure.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>mujoco_ros2_control</exec_depend>
+  <exec_depend>mujoco_ros2_control_plugins</exec_depend>
+  <exec_depend>mujoco_3d_lidar</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>velocity_controllers</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>g1_state_estimation</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>xvfb</exec_depend>
+
+  <!-- ament_lint_common is intentionally not used (see g1_bringup's package.xml for the
+       rationale): clang-format/ruff run as plain CTests instead. -->
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>tf2_ros</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -43,6 +43,7 @@
   <test_depend>std_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>tf2_ros</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>g1_state_estimation</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>xvfb</exec_depend>

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>xvfb</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
 
   <!-- ament_lint_common is intentionally not used (see g1_bringup's package.xml for the
        rationale): clang-format/ruff run as plain CTests instead. -->
@@ -44,6 +45,9 @@
   <test_depend>geometry_msgs</test_depend>
   <test_depend>tf2_ros</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
+  <test_depend>python3-numpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>g1_state_estimation</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>xvfb</exec_depend>

--- a/workspace/src/g1_sim/package.xml
+++ b/workspace/src/g1_sim/package.xml
@@ -35,7 +35,10 @@
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
+  <test_depend>g1_description</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>

--- a/workspace/src/g1_sim/test/perception_sim_fixture.py
+++ b/workspace/src/g1_sim/test/perception_sim_fixture.py
@@ -1,0 +1,144 @@
+"""Shared launch and driving helpers for the perception-track stream tests.
+
+Imported by test_lidar_stream and test_camera_stream, which both need to bring the sim
+up and move the base to a known place before measuring. Kept out of the test files so
+the assertions stay readable.
+"""
+
+import math
+import os
+import time
+
+import launch_testing
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from rclpy.node import Node
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+# Loading MuJoCo, registering the engine plugin, spawning controllers and starting the
+# render loop. Generous so a loaded machine cannot flake it.
+BRINGUP_TIMEOUT_S = 45.0
+
+# base_link -> livox_frame and the camera pose, from config/sensor_mounts.yaml. Duplicated
+# deliberately, same reason as test_perception_sim_bringup: a test that reads the file it
+# is checking passes no matter what the value becomes. test_perception_sim_bringup is what
+# proves TF actually carries these.
+LIVOX_XYZ = (-0.00368, 0.00003, 0.472434)
+LIVOX_RPY = (math.pi, 0.05112069, 0.0)
+CAMERA_XYZ = (0.05366, 0.01753, 0.473870)
+CAMERA_PITCH = 0.83077672
+
+# base_link spawn height in the MJCF. Turns base_link coordinates into world ones, which
+# is where the scene geometry (floor at 0, walls at +/-4) is stated.
+BASE_SPAWN_Z = 0.793
+
+# Sensor streams are best-effort: matching the publisher matters more than it looks, a
+# reliable subscriber simply receives nothing here.
+SENSOR_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT, history=HistoryPolicy.KEEP_LAST, depth=10
+)
+
+
+def perception_sim_description():
+    """Launch the track under test, then hand over to the test node."""
+    sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("g1_sim"), "launch", "perception_sim.launch.py"
+            )
+        )
+    )
+    return (
+        LaunchDescription(
+            [sim, TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()])]
+        ),
+        {},
+    )
+
+
+def rpy_to_matrix(rpy):
+    """Extrinsic XYZ (URDF rpy) to a rotation matrix."""
+    r, p, y = rpy
+    cr, sr = math.cos(r), math.sin(r)
+    cp, sp = math.cos(p), math.sin(p)
+    cy, sy = math.cos(y), math.sin(y)
+    return (
+        (cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr),
+        (sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr),
+        (-sp, cp * sr, cp * cr),
+    )
+
+
+class PerceptionSimTestNode(Node):
+    """Test-side node with the base-driving loop the stream tests share."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        # This track runs on simulated time.
+        self.set_parameters(
+            [rclpy.parameter.Parameter("use_sim_time", rclpy.Parameter.Type.BOOL, True)]
+        )
+        self._joint_state = None
+        self.create_subscription(JointState, "/base_joint_states", self._on_joints, 10)
+        self._cmd = self.create_publisher(
+            Float64MultiArray, "/base_velocity_controller/commands", 10
+        )
+
+    def _on_joints(self, msg):
+        self._joint_state = msg
+
+    def spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self, timeout_sec=0.05)
+
+    def wait_until(self, predicate, timeout_s=BRINGUP_TIMEOUT_S):
+        end = time.time() + timeout_s
+        while time.time() < end:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if predicate():
+                return True
+        return False
+
+    def joint(self, name):
+        js = self._joint_state
+        if js is None or name not in js.name:
+            return None
+        return js.position[js.name.index(name)]
+
+    def drive_to_x(self, target, speed=0.6, timeout_s=45.0):
+        """Drive the base to a world x and return where it actually stopped.
+
+        Closed loop on purpose. Open-loop timing undershoots badly here (a commanded
+        0.5 m/s for 2 s travels about 0.75 m), so a test that assumed the commanded
+        distance would be measuring the velocity ramp rather than the sensor. Callers
+        assert against the returned position, not the target.
+        """
+        cmd = Float64MultiArray()
+        end = time.time() + timeout_s
+        while time.time() < end:
+            x = self.joint("base_x_joint")
+            if x is None:
+                rclpy.spin_once(self, timeout_sec=0.05)
+                continue
+            error = target - x
+            if abs(error) < 0.01:
+                break
+            # Taper near the goal so it settles instead of hunting.
+            cmd.data = [math.copysign(min(speed, abs(error) * 2.0 + 0.05), error), 0.0, 0.0]
+            self._cmd.publish(cmd)
+            rclpy.spin_once(self, timeout_sec=0.02)
+            time.sleep(0.02)
+
+        cmd.data = [0.0, 0.0, 0.0]
+        for _ in range(5):
+            self._cmd.publish(cmd)
+            self.spin(0.05)
+        # Let the base coast to rest and a fresh sensor frame arrive.
+        self.spin(1.5)
+        return self.joint("base_x_joint")

--- a/workspace/src/g1_sim/test/perception_sim_fixture.py
+++ b/workspace/src/g1_sim/test/perception_sim_fixture.py
@@ -34,10 +34,8 @@ LIVOX_XYZ = (-0.00368, 0.00003, 0.472434)
 CAMERA_XYZ = (0.05366, 0.01753, 0.473870)
 CAMERA_PITCH = 0.83077672
 
-# There is deliberately no base-height constant here. `odom` is the ground plane (the
-# odometry publisher puts base_link's height into odom -> base_link, from the canonical
-# spawn_z in config/sensor_mounts.yaml), so world coordinates come from a TF lookup
-# against odom. Carrying the height in test code is what let it drift in the first place.
+# No base-height constant here on purpose: `odom` is the ground plane, so world
+# coordinates come from a TF lookup against odom rather than a hand-carried offset.
 
 # Sensor streams are best-effort: matching the publisher matters more than it looks, a
 # reliable subscriber simply receives nothing here.
@@ -107,12 +105,7 @@ class PerceptionSimTestNode(Node):
         return False
 
     def odom_from(self, frame):
-        """(R, t) taking a point in `frame` to odom, which is the ground plane.
-
-        Goes through the live TF chain rather than reconstructing it from constants, so
-        the scene geometry the stream tests assert against (floor at z=0, walls at +/-4)
-        is measured the way a real consumer would measure it.
-        """
+        """(R, t) taking a point in `frame` to odom, via the live TF chain."""
         if not self.wait_until(
             lambda: self.tf_buffer.can_transform("odom", frame, rclpy.time.Time())
         ):

--- a/workspace/src/g1_sim/test/perception_sim_fixture.py
+++ b/workspace/src/g1_sim/test/perception_sim_fixture.py
@@ -10,6 +10,7 @@ import os
 import time
 
 import launch_testing
+import numpy as np
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -19,6 +20,7 @@ from rclpy.node import Node
 from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64MultiArray
+from tf2_ros import Buffer, TransformListener
 
 # Loading MuJoCo, registering the engine plugin, spawning controllers and starting the
 # render loop. Generous so a loaded machine cannot flake it.
@@ -29,13 +31,13 @@ BRINGUP_TIMEOUT_S = 45.0
 # is checking passes no matter what the value becomes. test_perception_sim_bringup is what
 # proves TF actually carries these.
 LIVOX_XYZ = (-0.00368, 0.00003, 0.472434)
-LIVOX_RPY = (math.pi, 0.05112069, 0.0)
 CAMERA_XYZ = (0.05366, 0.01753, 0.473870)
 CAMERA_PITCH = 0.83077672
 
-# base_link spawn height in the MJCF. Turns base_link coordinates into world ones, which
-# is where the scene geometry (floor at 0, walls at +/-4) is stated.
-BASE_SPAWN_Z = 0.793
+# There is deliberately no base-height constant here. `odom` is the ground plane (the
+# odometry publisher puts base_link's height into odom -> base_link, from the canonical
+# spawn_z in config/sensor_mounts.yaml), so world coordinates come from a TF lookup
+# against odom. Carrying the height in test code is what let it drift in the first place.
 
 # Sensor streams are best-effort: matching the publisher matters more than it looks, a
 # reliable subscriber simply receives nothing here.
@@ -61,17 +63,14 @@ def perception_sim_description():
     )
 
 
-def rpy_to_matrix(rpy):
-    """Extrinsic XYZ (URDF rpy) to a rotation matrix."""
-    r, p, y = rpy
-    cr, sr = math.cos(r), math.sin(r)
-    cp, sp = math.cos(p), math.sin(p)
-    cy, sy = math.cos(y), math.sin(y)
-    return (
-        (cy * cp, cy * sp * sr - sy * cr, cy * sp * cr + sy * sr),
-        (sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr),
-        (-sp, cp * sr, cp * cr),
-    )
+def quaternion_to_matrix(q):
+    """geometry_msgs Quaternion to a 3x3 rotation matrix."""
+    x, y, z, w = q.x, q.y, q.z, q.w
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+        [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+        [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+    ])
 
 
 class PerceptionSimTestNode(Node):
@@ -84,6 +83,8 @@ class PerceptionSimTestNode(Node):
             [rclpy.parameter.Parameter("use_sim_time", rclpy.Parameter.Type.BOOL, True)]
         )
         self._joint_state = None
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
         self.create_subscription(JointState, "/base_joint_states", self._on_joints, 10)
         self._cmd = self.create_publisher(
             Float64MultiArray, "/base_velocity_controller/commands", 10
@@ -104,6 +105,29 @@ class PerceptionSimTestNode(Node):
             if predicate():
                 return True
         return False
+
+    def odom_from(self, frame):
+        """(R, t) taking a point in `frame` to odom, which is the ground plane.
+
+        Goes through the live TF chain rather than reconstructing it from constants, so
+        the scene geometry the stream tests assert against (floor at z=0, walls at +/-4)
+        is measured the way a real consumer would measure it.
+        """
+        if not self.wait_until(
+            lambda: self.tf_buffer.can_transform("odom", frame, rclpy.time.Time())
+        ):
+            raise AssertionError(
+                f"odom -> {frame} never appeared. The odometry publisher defaults to "
+                "odometry_source='hardware', which refuses to configure by design; the "
+                "launch has to set sim_ground_truth."
+            )
+        tf = self.tf_buffer.lookup_transform("odom", frame, rclpy.time.Time())
+        translation = np.array([
+            tf.transform.translation.x,
+            tf.transform.translation.y,
+            tf.transform.translation.z,
+        ])
+        return quaternion_to_matrix(tf.transform.rotation), translation
 
     def joint(self, name):
         js = self._joint_state

--- a/workspace/src/g1_sim/test/test_camera_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_camera_stream.launch.py
@@ -11,6 +11,7 @@ import os
 import sys
 import time
 import unittest
+from collections import deque
 
 import numpy as np
 import pytest
@@ -19,7 +20,6 @@ from sensor_msgs.msg import CameraInfo, Image
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from perception_sim_fixture import (  # noqa: E402
-    BASE_SPAWN_Z,
     CAMERA_PITCH,
     CAMERA_XYZ,
     SENSOR_QOS,
@@ -36,18 +36,23 @@ EXPECTED_WIDTH = 848
 EXPECTED_HEIGHT = 480
 FOVY_RAD = math.radians(58.0)
 
-CAMERA_WORLD_Z = BASE_SPAWN_Z + CAMERA_XYZ[2]
 WALL_PX_X = 4.0
 PATCH_HALF = 16
 
+# Only the newest frame is read; the rest serve the rate check. Bounded because these are
+# 1.2 MB colour and 1.6 MB depth frames at 15 Hz, and unbounded buffers starved the sim in
+# milestone 3.
+FRAME_HISTORY = 8
 
-def expected_axis_range(base_x):
+
+def expected_axis_range(base_x, camera_world_z):
     """Range along the optical axis: the floor while far from the wall, the wall once near.
 
     Both are exact for the centre pixel, where the optical-frame z the depth image stores
-    and the euclidean range are the same number.
+    and the euclidean range are the same number. camera_world_z comes from TF rather than
+    a constant, so a wrong odom height fails here instead of cancelling out.
     """
-    to_floor = CAMERA_WORLD_Z / math.sin(CAMERA_PITCH)
+    to_floor = camera_world_z / math.sin(CAMERA_PITCH)
     to_wall = (WALL_PX_X - (base_x + CAMERA_XYZ[0])) / math.cos(CAMERA_PITCH)
     return min(to_floor, to_wall)
 
@@ -77,10 +82,10 @@ class CameraStreamTest(unittest.TestCase):
     def setUpClass(cls):
         rclpy.init()
         cls.node = PerceptionSimTestNode("test_camera_stream")
-        cls.color = []
-        cls.depth = []
-        cls.info = []
-        cls.color_stamps = []
+        cls.color = deque(maxlen=FRAME_HISTORY)
+        cls.depth = deque(maxlen=FRAME_HISTORY)
+        cls.info = deque(maxlen=FRAME_HISTORY)
+        cls.color_stamps = deque(maxlen=512)
         cls.node.create_subscription(Image, COLOR_TOPIC, cls._on_color, SENSOR_QOS)
         cls.node.create_subscription(Image, DEPTH_TOPIC, cls.depth.append, SENSOR_QOS)
         cls.node.create_subscription(CameraInfo, INFO_TOPIC, cls.info.append, SENSOR_QOS)
@@ -96,6 +101,10 @@ class CameraStreamTest(unittest.TestCase):
         cls.node.destroy_node()
         rclpy.shutdown()
 
+    def camera_world_z(self):
+        """Camera height above the floor, straight off TF."""
+        return float(self.node.odom_from("camera_link")[1][2])
+
     def centre_median(self):
         """Median of the central patch, in metres. Median so a stray pixel cannot move it."""
         self.assertTrue(self.depth, f"nothing published on {DEPTH_TOPIC}")
@@ -107,6 +116,8 @@ class CameraStreamTest(unittest.TestCase):
         return float(np.median(finite))
 
     def test_01_all_three_streams_publish(self):
+        # Drop the discovery backlog; it drains as a burst and inflates the rate.
+        self.color_stamps.clear()
         self.node.spin(3.0)
         for name, buf in (("colour", self.color), ("depth", self.depth), ("info", self.info)):
             self.assertGreaterEqual(len(buf), 5, f"only {len(buf)} {name} messages in 3 s")
@@ -157,28 +168,30 @@ class CameraStreamTest(unittest.TestCase):
 
     def test_05_depth_reads_the_floor_where_the_mount_geometry_says(self):
         """Height and pitch together: get either wrong and this number moves."""
-        expected = expected_axis_range(0.0)
+        camera_z = self.camera_world_z()
+        expected = expected_axis_range(0.0, camera_z)
         measured = self.centre_median()
         self.assertAlmostEqual(
             measured,
             expected,
             delta=0.05,
-            msg=f"central depth {measured:.4f} m, but a camera {CAMERA_WORLD_Z:.4f} m up "
+            msg=f"central depth {measured:.4f} m, but a camera {camera_z:.4f} m up "
             f"pitched {math.degrees(CAMERA_PITCH):.1f} deg down meets the floor at "
             f"{expected:.4f} m",
         )
 
     def test_06_depth_tracks_the_wall_as_the_base_approaches(self):
         """At x=3.0 the optical axis clears the floor and lands on the +x wall."""
+        camera_z = self.camera_world_z()
         far = self.centre_median()
         stopped_at = self.node.drive_to_x(3.0)
         self.node.spin(0.5)
         near = self.centre_median()
 
-        expected = expected_axis_range(stopped_at)
+        expected = expected_axis_range(stopped_at, camera_z)
         self.assertLess(
             expected,
-            CAMERA_WORLD_Z / math.sin(CAMERA_PITCH) - 0.1,
+            camera_z / math.sin(CAMERA_PITCH) - 0.1,
             f"base stopped at x={stopped_at:.3f}, not close enough for the axis to leave "
             "the floor; this test would not be measuring the wall",
         )

--- a/workspace/src/g1_sim/test/test_camera_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_camera_stream.launch.py
@@ -1,0 +1,193 @@
+"""The simulated D435i produces colour, depth and intrinsics that match the scene.
+
+The depth assertions are the point. The camera is pitched 47.6 degrees down, so its
+optical axis lands on the floor 1.16 m ahead and reads 1.7156 m, and once the base is
+close enough it lands on the +x wall instead. Both are arithmetic from the MJCF, so a
+wrong mount height, a wrong pitch, a non-metric depth buffer or a frozen stream all fail.
+"""
+
+import math
+import os
+import sys
+import time
+import unittest
+
+import numpy as np
+import pytest
+import rclpy
+from sensor_msgs.msg import CameraInfo, Image
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from perception_sim_fixture import (  # noqa: E402
+    BASE_SPAWN_Z,
+    CAMERA_PITCH,
+    CAMERA_XYZ,
+    SENSOR_QOS,
+    PerceptionSimTestNode,
+    perception_sim_description,
+)
+
+COLOR_TOPIC = "/camera/color/image_raw"
+DEPTH_TOPIC = "/camera/aligned_depth_to_color/image_raw"
+INFO_TOPIC = "/camera/color/camera_info"
+
+# The MJCF camera element: resolution 848x480, fovy 58 degrees.
+EXPECTED_WIDTH = 848
+EXPECTED_HEIGHT = 480
+FOVY_RAD = math.radians(58.0)
+
+CAMERA_WORLD_Z = BASE_SPAWN_Z + CAMERA_XYZ[2]
+WALL_PX_X = 4.0
+PATCH_HALF = 16
+
+
+def expected_axis_range(base_x):
+    """Range along the optical axis: the floor while far from the wall, the wall once near.
+
+    Both are exact for the centre pixel, where the optical-frame z the depth image stores
+    and the euclidean range are the same number.
+    """
+    to_floor = CAMERA_WORLD_Z / math.sin(CAMERA_PITCH)
+    to_wall = (WALL_PX_X - (base_x + CAMERA_XYZ[0])) / math.cos(CAMERA_PITCH)
+    return min(to_floor, to_wall)
+
+
+def depth_metres(msg):
+    """Depth as metres regardless of how the publisher encodes it.
+
+    mujoco_ros2_control publishes 32FC1 metres at the pinned SHA. realsense2_camera on the
+    real robot publishes 16UC1 millimetres, so the conversion is here rather than baked
+    into the assertions.
+    """
+    if msg.encoding == "32FC1":
+        return np.frombuffer(msg.data, dtype=np.float32).reshape(msg.height, msg.width)
+    if msg.encoding == "16UC1":
+        raw = np.frombuffer(msg.data, dtype=np.uint16).reshape(msg.height, msg.width)
+        return raw.astype(np.float64) / 1000.0
+    raise AssertionError(f"unhandled depth encoding {msg.encoding!r}")
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    return perception_sim_description()
+
+
+class CameraStreamTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = PerceptionSimTestNode("test_camera_stream")
+        cls.color = []
+        cls.depth = []
+        cls.info = []
+        cls.color_stamps = []
+        cls.node.create_subscription(Image, COLOR_TOPIC, cls._on_color, SENSOR_QOS)
+        cls.node.create_subscription(Image, DEPTH_TOPIC, cls.depth.append, SENSOR_QOS)
+        cls.node.create_subscription(CameraInfo, INFO_TOPIC, cls.info.append, SENSOR_QOS)
+        cls.node.wait_until(lambda: cls.color and cls.depth and cls.info)
+
+    @classmethod
+    def _on_color(cls, msg):
+        cls.color.append(msg)
+        cls.color_stamps.append(time.time())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def centre_median(self):
+        """Median of the central patch, in metres. Median so a stray pixel cannot move it."""
+        self.assertTrue(self.depth, f"nothing published on {DEPTH_TOPIC}")
+        metres = depth_metres(self.depth[-1])
+        cy, cx = metres.shape[0] // 2, metres.shape[1] // 2
+        patch = metres[cy - PATCH_HALF : cy + PATCH_HALF, cx - PATCH_HALF : cx + PATCH_HALF]
+        finite = patch[np.isfinite(patch)]
+        self.assertGreater(finite.size, 0, "central patch is entirely non-finite")
+        return float(np.median(finite))
+
+    def test_01_all_three_streams_publish(self):
+        self.node.spin(3.0)
+        for name, buf in (("colour", self.color), ("depth", self.depth), ("info", self.info)):
+            self.assertGreaterEqual(len(buf), 5, f"only {len(buf)} {name} messages in 3 s")
+        elapsed = self.color_stamps[-1] - self.color_stamps[0]
+        rate = (len(self.color_stamps) - 1) / elapsed
+        self.assertGreater(rate, 10.0, f"colour at {rate:.2f} Hz, configured 15")
+        self.assertLess(rate, 18.0, f"colour at {rate:.2f} Hz, configured 15")
+
+    def test_02_camera_info_matches_the_mjcf(self):
+        info = self.info[-1]
+        self.assertEqual((info.width, info.height), (EXPECTED_WIDTH, EXPECTED_HEIGHT))
+        self.assertEqual(info.header.frame_id, "camera_color_optical_frame")
+
+        expected_f = EXPECTED_HEIGHT / (2.0 * math.tan(FOVY_RAD / 2.0))
+        fx, fy = info.k[0], info.k[4]
+        self.assertAlmostEqual(
+            fy,
+            expected_f,
+            delta=expected_f * 0.01,
+            msg=f"fy={fy:.3f}, but fovy=58 deg over {EXPECTED_HEIGHT} rows gives "
+            f"{expected_f:.3f}. MuJoCo's fovy is vertical.",
+        )
+        self.assertAlmostEqual(fx, fy, delta=expected_f * 0.01, msg="square pixels expected")
+        self.assertAlmostEqual(info.k[2], EXPECTED_WIDTH / 2.0, delta=1.0)
+        self.assertAlmostEqual(info.k[5], EXPECTED_HEIGHT / 2.0, delta=1.0)
+
+    def test_03_colour_image_is_rendered_not_blank(self):
+        """A headless GL context that silently fails renders a uniform frame."""
+        msg = self.color[-1]
+        self.assertEqual(msg.encoding, "rgb8")
+        self.assertEqual((msg.width, msg.height), (EXPECTED_WIDTH, EXPECTED_HEIGHT))
+        distinct = len(np.unique(np.frombuffer(msg.data, dtype=np.uint8)))
+        self.assertGreater(
+            distinct, 1, "colour frame has one pixel value; rendering produced a blank image"
+        )
+
+    def test_04_depth_image_is_metric_and_mostly_valid(self):
+        msg = self.depth[-1]
+        self.assertEqual((msg.width, msg.height), (EXPECTED_WIDTH, EXPECTED_HEIGHT))
+        self.assertEqual(msg.header.frame_id, "camera_color_optical_frame")
+        metres = depth_metres(msg)
+        finite = np.isfinite(metres) & (metres >= 0.1) & (metres <= 40.0)
+        self.assertGreater(
+            finite.mean(),
+            0.60,
+            f"only {finite.mean() * 100:.1f}% of depth pixels are finite and in range",
+        )
+
+    def test_05_depth_reads_the_floor_where_the_mount_geometry_says(self):
+        """Height and pitch together: get either wrong and this number moves."""
+        expected = expected_axis_range(0.0)
+        measured = self.centre_median()
+        self.assertAlmostEqual(
+            measured,
+            expected,
+            delta=0.05,
+            msg=f"central depth {measured:.4f} m, but a camera {CAMERA_WORLD_Z:.4f} m up "
+            f"pitched {math.degrees(CAMERA_PITCH):.1f} deg down meets the floor at "
+            f"{expected:.4f} m",
+        )
+
+    def test_06_depth_tracks_the_wall_as_the_base_approaches(self):
+        """At x=3.0 the optical axis clears the floor and lands on the +x wall."""
+        far = self.centre_median()
+        stopped_at = self.node.drive_to_x(3.0)
+        self.node.spin(0.5)
+        near = self.centre_median()
+
+        expected = expected_axis_range(stopped_at)
+        self.assertLess(
+            expected,
+            CAMERA_WORLD_Z / math.sin(CAMERA_PITCH) - 0.1,
+            f"base stopped at x={stopped_at:.3f}, not close enough for the axis to leave "
+            "the floor; this test would not be measuring the wall",
+        )
+        self.assertAlmostEqual(
+            near,
+            expected,
+            delta=0.05,
+            msg=f"central depth {near:.4f} m at x={stopped_at:.3f}, expected {expected:.4f} m "
+            f"off the +x wall (was {far:.4f} m off the floor)",
+        )
+        self.assertLess(near, far - 0.3, "depth did not change as the base drove forward")
+        self.node.drive_to_x(0.0)

--- a/workspace/src/g1_sim/test/test_camera_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_camera_stream.launch.py
@@ -39,9 +39,8 @@ FOVY_RAD = math.radians(58.0)
 WALL_PX_X = 4.0
 PATCH_HALF = 16
 
-# Only the newest frame is read; the rest serve the rate check. Bounded because these are
-# 1.2 MB colour and 1.6 MB depth frames at 15 Hz, and unbounded buffers starved the sim in
-# milestone 3.
+# Only the newest frame is read; the rest just satisfy the liveness count in test_01.
+# These are 1.2 MB colour and 1.6 MB depth frames at 15 Hz, so the buffer stays small.
 FRAME_HISTORY = 8
 
 
@@ -49,8 +48,7 @@ def expected_axis_range(base_x, camera_world_z):
     """Range along the optical axis: the floor while far from the wall, the wall once near.
 
     Both are exact for the centre pixel, where the optical-frame z the depth image stores
-    and the euclidean range are the same number. camera_world_z comes from TF rather than
-    a constant, so a wrong odom height fails here instead of cancelling out.
+    and the euclidean range are the same number.
     """
     to_floor = camera_world_z / math.sin(CAMERA_PITCH)
     to_wall = (WALL_PX_X - (base_x + CAMERA_XYZ[0])) / math.cos(CAMERA_PITCH)

--- a/workspace/src/g1_sim/test/test_lidar_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_lidar_stream.launch.py
@@ -1,0 +1,201 @@
+"""The simulated Mid360 produces a point cloud that matches the room it is in.
+
+Geometry, not plumbing: test_perception_sim_bringup already proves the topic exists. Here
+the cloud is transformed into base_link and checked against facts of the MJCF, so a wrong
+mount, a wrong roll, a wrong scale or a dead stream all fail rather than pass quietly.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+import numpy as np
+import pytest
+import rclpy
+from sensor_msgs.msg import PointCloud2
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from perception_sim_fixture import (  # noqa: E402
+    BASE_SPAWN_Z,
+    LIVOX_RPY,
+    LIVOX_XYZ,
+    SENSOR_QOS,
+    PerceptionSimTestNode,
+    perception_sim_description,
+    rpy_to_matrix,
+)
+
+TOPIC = "/livox/lidar"
+
+# config/mujoco_plugins.yaml + the MJCF lidar instance.
+EXPECTED_WIDTH = 360
+EXPECTED_HEIGHT = 32
+EXPECTED_POINTS = EXPECTED_WIDTH * EXPECTED_HEIGHT
+CONFIGURED_RATE_HZ = 10.0
+MIN_RANGE = 0.1
+MAX_RANGE = 40.0
+
+# Room geometry from the MJCF: inner wall faces at +/-4.0 m, floor at z=0.
+WALL_PX_X = 4.0
+ROOM_HALF = 4.0
+
+R_LIVOX = np.array(rpy_to_matrix(LIVOX_RPY))
+T_LIVOX = np.array(LIVOX_XYZ)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    return perception_sim_description()
+
+
+class LidarStreamTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = PerceptionSimTestNode("test_lidar_stream")
+        cls.clouds = []
+        cls.stamps = []
+        cls.node.create_subscription(PointCloud2, TOPIC, cls._on_cloud, SENSOR_QOS)
+        cls.node.wait_until(lambda: len(cls.clouds) > 0)
+
+    @classmethod
+    def _on_cloud(cls, msg):
+        cls.clouds.append(msg)
+        cls.stamps.append(time.time())
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def latest(self):
+        self.assertTrue(self.clouds, f"nothing published on {TOPIC}")
+        return self.clouds[-1]
+
+    def points_sensor(self, msg):
+        """The xyz block as an (N, 3) array, in the sensor frame."""
+        n = msg.width * msg.height
+        raw = np.frombuffer(msg.data, dtype=np.uint8).reshape(n, msg.point_step)
+        return (
+            np.frombuffer(raw[:, 0:12].tobytes(), dtype=np.float32)
+            .reshape(n, 3)
+            .astype(np.float64)
+        )
+
+    def points_world(self, msg):
+        """Sensor frame to world, valid because the base sits at the origin at rest."""
+        pts = self.points_sensor(msg)
+        finite = np.isfinite(pts).all(axis=1)
+        base = (R_LIVOX @ pts[finite].T).T + T_LIVOX
+        return base + np.array([0.0, 0.0, BASE_SPAWN_Z])
+
+    def wall_px_distance(self, msg):
+        """Distance from base_link to the +x wall, from near-horizontal forward returns."""
+        pts = self.points_sensor(msg)
+        finite = np.isfinite(pts).all(axis=1)
+        base = (R_LIVOX @ pts[finite].T).T + T_LIVOX
+        forward = (
+            (np.abs(base[:, 1]) < 0.3)
+            & (base[:, 0] > 0.5)
+            & (np.abs(base[:, 2] - T_LIVOX[2]) < 0.2)
+        )
+        self.assertGreater(
+            forward.sum(), 5, "no near-horizontal forward returns to measure the wall with"
+        )
+        return float(np.median(base[forward][:, 0]))
+
+    def test_01_publishes_at_the_configured_rate(self):
+        self.node.spin(3.0)
+        self.assertGreater(len(self.stamps), 2, f"{TOPIC} is not streaming")
+        elapsed = self.stamps[-1] - self.stamps[0]
+        rate = (len(self.stamps) - 1) / elapsed
+        self.assertGreater(rate, 7.0, f"{rate:.2f} Hz, configured {CONFIGURED_RATE_HZ}")
+        self.assertLess(rate, 13.0, f"{rate:.2f} Hz, configured {CONFIGURED_RATE_HZ}")
+
+    def test_02_cloud_layout_matches_the_configured_grid(self):
+        msg = self.latest()
+        self.assertEqual(msg.header.frame_id, "livox_frame")
+        self.assertEqual((msg.width, msg.height), (EXPECTED_WIDTH, EXPECTED_HEIGHT))
+        self.assertEqual(
+            msg.width * msg.height,
+            EXPECTED_POINTS,
+            "point count no longer matches the configured resolution",
+        )
+        self.assertEqual([f.name for f in msg.fields][:3], ["x", "y", "z"])
+        self.assertGreaterEqual(msg.point_step, 12)
+
+    def test_03_every_return_is_finite_and_in_range(self):
+        """A closed room returns a hit for every ray, so NaNs mean something broke."""
+        msg = self.latest()
+        pts = self.points_sensor(msg)
+        finite = np.isfinite(pts).all(axis=1)
+        self.assertEqual(
+            int(finite.sum()), EXPECTED_POINTS, f"{EXPECTED_POINTS - finite.sum()} non-finite points"
+        )
+        ranges = np.linalg.norm(pts, axis=1)
+        self.assertGreaterEqual(
+            ranges.min(), MIN_RANGE - 1e-3, f"return at {ranges.min():.4f} m, below min_range"
+        )
+        self.assertLessEqual(ranges.max(), MAX_RANGE, f"return at {ranges.max():.4f} m")
+
+    def test_04_the_floor_is_visible_below_the_robot(self):
+        """The pi roll points the Mid360 down; lose it and the floor lands overhead."""
+        world = self.points_world(self.latest())
+        floor = np.abs(world[:, 2]) < 0.05
+        self.assertGreater(
+            int(floor.sum()),
+            200,
+            f"only {floor.sum()} returns near the floor plane. The Mid360 is mounted "
+            "upside down on the real G1; without that roll the downward rays go up.",
+        )
+        self.assertGreaterEqual(
+            world[:, 2].min(), -0.05, "returns below the floor plane"
+        )
+
+    def test_05_the_forward_wall_is_where_the_mjcf_puts_it(self):
+        distance = self.wall_px_distance(self.latest())
+        self.assertAlmostEqual(
+            distance,
+            WALL_PX_X,
+            delta=0.05,
+            msg=f"+x wall measured at {distance:.4f} m, MJCF puts its inner face at "
+            f"{WALL_PX_X} m. A scale or mount error shows up here first.",
+        )
+
+    def test_06_most_returns_land_inside_the_room(self):
+        """Guards against the walls dropping out of the cloud entirely.
+
+        Not all returns: the lidar plugin lets a band of downward rays (roughly 10 to 18
+        degrees below horizontal) pass through the walls and land on the floor plane
+        beyond the room, about 4% of the cloud. The camera renders those same walls as
+        solid at the same heights, so this is the plugin's raycast, not the scene. See
+        g1_sim/README.md.
+        """
+        world = self.points_world(self.latest())
+        inside = (np.abs(world[:, 0]) <= ROOM_HALF + 0.01) & (
+            np.abs(world[:, 1]) <= ROOM_HALF + 0.01
+        )
+        fraction = inside.mean()
+        self.assertGreater(
+            fraction,
+            0.90,
+            f"only {fraction * 100:.1f}% of returns are inside the room; the known "
+            "plugin leak accounts for about 4%, so this is something larger",
+        )
+
+    def test_07_the_wall_closes_in_when_the_base_drives_at_it(self):
+        """Proves the cloud tracks the world instead of being a frozen first frame."""
+        before = self.wall_px_distance(self.latest())
+        travelled = self.node.drive_to_x(1.0)
+        self.node.spin(0.5)
+        after = self.wall_px_distance(self.latest())
+
+        self.assertAlmostEqual(
+            before - after,
+            travelled,
+            delta=0.05,
+            msg=f"wall distance went {before:.3f} -> {after:.3f} m ({before - after:+.3f}) "
+            f"while the base moved {travelled:.3f} m in x",
+        )
+        self.node.drive_to_x(0.0)

--- a/workspace/src/g1_sim/test/test_lidar_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_lidar_stream.launch.py
@@ -38,8 +38,8 @@ MAX_RANGE = 40.0
 WALL_PX_X = 4.0
 ROOM_HALF = 4.0
 
-# Only the newest cloud is ever read; the rest are kept for the rate check. Unbounded
-# lists here starved the sim in milestone 3 (~68,000 messages), so they stay bounded.
+# Only the newest cloud is read; the rest just satisfy the liveness count in test_01.
+# Bounded because unbounded buffers starved the sim in milestone 3.
 CLOUD_HISTORY = 32
 
 
@@ -83,11 +83,7 @@ class LidarStreamTest(unittest.TestCase):
         )
 
     def points_odom(self, msg):
-        """Sensor frame to odom, which the odometry publisher puts on the ground plane.
-
-        Via the live TF chain, so the floor really does land at z=0 rather than at minus
-        the spawn height, and a wrong odom z fails here instead of being subtracted out.
-        """
+        """Sensor frame to odom, where the floor is at z=0."""
         rotation, translation = self.node.odom_from("livox_frame")
         pts = self.points_sensor(msg)
         finite = np.isfinite(pts).all(axis=1)

--- a/workspace/src/g1_sim/test/test_lidar_stream.launch.py
+++ b/workspace/src/g1_sim/test/test_lidar_stream.launch.py
@@ -1,14 +1,16 @@
 """The simulated Mid360 produces a point cloud that matches the room it is in.
 
 Geometry, not plumbing: test_perception_sim_bringup already proves the topic exists. Here
-the cloud is transformed into base_link and checked against facts of the MJCF, so a wrong
-mount, a wrong roll, a wrong scale or a dead stream all fail rather than pass quietly.
+the cloud is transformed into odom through the live TF chain and checked against facts of
+the MJCF, so a wrong mount, a wrong roll, a wrong scale, a wrong odom height or a dead
+stream all fail rather than pass quietly.
 """
 
 import os
 import sys
 import time
 import unittest
+from collections import deque
 
 import numpy as np
 import pytest
@@ -17,13 +19,9 @@ from sensor_msgs.msg import PointCloud2
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from perception_sim_fixture import (  # noqa: E402
-    BASE_SPAWN_Z,
-    LIVOX_RPY,
-    LIVOX_XYZ,
     SENSOR_QOS,
     PerceptionSimTestNode,
     perception_sim_description,
-    rpy_to_matrix,
 )
 
 TOPIC = "/livox/lidar"
@@ -40,8 +38,9 @@ MAX_RANGE = 40.0
 WALL_PX_X = 4.0
 ROOM_HALF = 4.0
 
-R_LIVOX = np.array(rpy_to_matrix(LIVOX_RPY))
-T_LIVOX = np.array(LIVOX_XYZ)
+# Only the newest cloud is ever read; the rest are kept for the rate check. Unbounded
+# lists here starved the sim in milestone 3 (~68,000 messages), so they stay bounded.
+CLOUD_HISTORY = 32
 
 
 @pytest.mark.launch_test
@@ -54,8 +53,8 @@ class LidarStreamTest(unittest.TestCase):
     def setUpClass(cls):
         rclpy.init()
         cls.node = PerceptionSimTestNode("test_lidar_stream")
-        cls.clouds = []
-        cls.stamps = []
+        cls.clouds = deque(maxlen=CLOUD_HISTORY)
+        cls.stamps = deque(maxlen=512)
         cls.node.create_subscription(PointCloud2, TOPIC, cls._on_cloud, SENSOR_QOS)
         cls.node.wait_until(lambda: len(cls.clouds) > 0)
 
@@ -83,29 +82,36 @@ class LidarStreamTest(unittest.TestCase):
             .astype(np.float64)
         )
 
-    def points_world(self, msg):
-        """Sensor frame to world, valid because the base sits at the origin at rest."""
+    def points_odom(self, msg):
+        """Sensor frame to odom, which the odometry publisher puts on the ground plane.
+
+        Via the live TF chain, so the floor really does land at z=0 rather than at minus
+        the spawn height, and a wrong odom z fails here instead of being subtracted out.
+        """
+        rotation, translation = self.node.odom_from("livox_frame")
         pts = self.points_sensor(msg)
         finite = np.isfinite(pts).all(axis=1)
-        base = (R_LIVOX @ pts[finite].T).T + T_LIVOX
-        return base + np.array([0.0, 0.0, BASE_SPAWN_Z])
+        return (rotation @ pts[finite].T).T + translation
 
     def wall_px_distance(self, msg):
-        """Distance from base_link to the +x wall, from near-horizontal forward returns."""
-        pts = self.points_sensor(msg)
-        finite = np.isfinite(pts).all(axis=1)
-        base = (R_LIVOX @ pts[finite].T).T + T_LIVOX
+        """Distance from the base to the +x wall, from near-horizontal forward returns."""
+        world = self.points_odom(msg)
+        sensor_z = self.node.odom_from("livox_frame")[1][2]
+        base_x = self.node.joint("base_x_joint")
         forward = (
-            (np.abs(base[:, 1]) < 0.3)
-            & (base[:, 0] > 0.5)
-            & (np.abs(base[:, 2] - T_LIVOX[2]) < 0.2)
+            (np.abs(world[:, 1]) < 0.3)
+            & (world[:, 0] > base_x + 0.5)
+            & (np.abs(world[:, 2] - sensor_z) < 0.2)
         )
         self.assertGreater(
             forward.sum(), 5, "no near-horizontal forward returns to measure the wall with"
         )
-        return float(np.median(base[forward][:, 0]))
+        return float(np.median(world[forward][:, 0])) - base_x
 
     def test_01_publishes_at_the_configured_rate(self):
+        # Drop whatever queued during discovery: it drains as a burst and would
+        # read as a rate well above the configured one.
+        self.stamps.clear()
         self.node.spin(3.0)
         self.assertGreater(len(self.stamps), 2, f"{TOPIC} is not streaming")
         elapsed = self.stamps[-1] - self.stamps[0]
@@ -141,7 +147,7 @@ class LidarStreamTest(unittest.TestCase):
 
     def test_04_the_floor_is_visible_below_the_robot(self):
         """The pi roll points the Mid360 down; lose it and the floor lands overhead."""
-        world = self.points_world(self.latest())
+        world = self.points_odom(self.latest())
         floor = np.abs(world[:, 2]) < 0.05
         self.assertGreater(
             int(floor.sum()),
@@ -172,7 +178,7 @@ class LidarStreamTest(unittest.TestCase):
         solid at the same heights, so this is the plugin's raycast, not the scene. See
         g1_sim/README.md.
         """
-        world = self.points_world(self.latest())
+        world = self.points_odom(self.latest())
         inside = (np.abs(world[:, 0]) <= ROOM_HALF + 0.01) & (
             np.abs(world[:, 1]) <= ROOM_HALF + 0.01
         )

--- a/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
+++ b/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
@@ -11,19 +11,19 @@ import unittest
 
 import pytest
 import rclpy
+import yaml
+from ament_index_python.packages import get_package_share_directory
 from geometry_msgs.msg import PointStamped
 from nav_msgs.msg import Odometry
 from tf2_ros import Buffer, TransformListener
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tf2_geometry_msgs  # noqa: E402,F401  registers the PointStamped transform
 from perception_sim_fixture import (  # noqa: E402
-    BASE_SPAWN_Z,
     LIVOX_XYZ,
     PerceptionSimTestNode,
     perception_sim_description,
 )
-
-import tf2_geometry_msgs  # noqa: E402,F401  registers the PointStamped transform
 
 
 @pytest.mark.launch_test
@@ -49,6 +49,19 @@ class OdomGroundTruthTest(unittest.TestCase):
         cls.node.destroy_node()
         rclpy.shutdown()
 
+    def base_height(self):
+        """The canonical base height, from the file the MJCF is checked against.
+
+        Reading it here rather than hardcoding is deliberate: test_sensor_mount_consistency
+        pins this value to the MJCF spawn height, so there is exactly one number and one
+        place that asserts it.
+        """
+        mounts_path = os.path.join(
+            get_package_share_directory("g1_sim"), "config", "sensor_mounts.yaml"
+        )
+        with open(mounts_path) as f:
+            return float(yaml.safe_load(f)["base_link"]["spawn_z"])
+
     def base_in_odom(self):
         self.assertTrue(
             self.tf_buffer.can_transform("odom", "base_link", rclpy.time.Time()),
@@ -56,12 +69,29 @@ class OdomGroundTruthTest(unittest.TestCase):
             "'hardware', which refuses to configure; the launch must set sim_ground_truth.",
         )
         tf = self.tf_buffer.lookup_transform("odom", "base_link", rclpy.time.Time())
-        return tf.transform.translation.x, tf.transform.translation.y
+        return (
+            tf.transform.translation.x,
+            tf.transform.translation.y,
+            tf.transform.translation.z,
+        )
 
-    def test_01_odom_to_base_link_is_published(self):
-        x, y = self.base_in_odom()
+    def test_01_odom_is_the_ground_plane(self):
+        """odom sits on the floor, not at the base's spawn height.
+
+        The z is the whole point: it is what lets a consumer transform a point cloud into
+        odom and have the floor come out at 0, which is what Nav2's obstacle height bands
+        assume. Publishing 0 here would put every floor return at minus the spawn height.
+        """
+        x, y, z = self.base_in_odom()
         self.assertLess(abs(x), 0.05, f"base starts at the origin, transform says x={x:.4f}")
         self.assertLess(abs(y), 0.05, f"base starts at the origin, transform says y={y:.4f}")
+        self.assertAlmostEqual(
+            z,
+            self.base_height(),
+            delta=1e-6,
+            msg=f"odom -> base_link z is {z:.6f}, expected the canonical spawn height "
+            f"{self.base_height():.6f} from g1_sim/config/sensor_mounts.yaml",
+        )
 
     def test_02_odometry_message_agrees_with_the_transform(self):
         """Nav2 reads velocity from Odometry, not from TF, so both have to be right."""
@@ -70,41 +100,46 @@ class OdomGroundTruthTest(unittest.TestCase):
         odom = self.odoms[-1]
         self.assertEqual(odom.header.frame_id, "odom")
         self.assertEqual(odom.child_frame_id, "base_link")
-        x, y = self.base_in_odom()
+        x, y, z = self.base_in_odom()
         self.assertAlmostEqual(odom.pose.pose.position.x, x, delta=0.02)
         self.assertAlmostEqual(odom.pose.pose.position.y, y, delta=0.02)
+        self.assertAlmostEqual(odom.pose.pose.position.z, z, delta=1e-6)
         self.assertGreater(
             odom.pose.covariance[0], 0.0, "all-zero covariance is a known Nav2 footgun"
         )
 
-    def test_03_a_lidar_point_transforms_into_odom(self):
+    def test_03_a_lidar_point_lands_at_its_real_height_above_the_floor(self):
         """The whole chain in one assertion: odom -> base_link -> livox_frame.
 
-        A point at the sensor origin must land at the sensor's known height above the
-        floor. This is what every downstream consumer, costmap or SLAM, actually does.
+        `odom` is the ground plane, so a point at the sensor origin must come out at the
+        sensor's physical height above the floor: the base spawn height plus the mount.
+        Drop the odom z and this reads 0.472 instead of 1.265, which is exactly the bug
+        that made every other test subtract the spawn height by hand.
         """
+        base_z = self.base_height()
+        expected = base_z + LIVOX_XYZ[2]
+
         point = PointStamped()
         point.header.frame_id = "livox_frame"
         point.header.stamp = rclpy.time.Time().to_msg()
-
-        transformed = self.tf_buffer.transform(point, "odom", timeout=rclpy.duration.Duration(seconds=5.0))
+        transformed = self.tf_buffer.transform(
+            point, "odom", timeout=rclpy.duration.Duration(seconds=5.0)
+        )
         self.assertAlmostEqual(
             transformed.point.z,
-            LIVOX_XYZ[2],
+            expected,
             delta=0.01,
-            msg=f"livox origin lands at z={transformed.point.z:.4f} in odom, expected "
-            f"{LIVOX_XYZ[2]:.4f} above base_link",
-        )
-        # odom is at the base's spawn pose, so this is height above base_link, not the floor.
-        self.assertLess(
-            transformed.point.z + BASE_SPAWN_Z, 2.0, "sensor height is implausible in odom"
+            msg=f"livox origin lands at z={transformed.point.z:.4f} in odom; the sensor "
+            f"sits {LIVOX_XYZ[2]:.4f} above a base_link that is {base_z:.4f} above the "
+            f"floor, so it should be {expected:.4f}. If this reads {LIVOX_XYZ[2]:.4f}, "
+            "odom -> base_link is missing its z and odom is not the ground plane.",
         )
 
     def test_04_the_transform_tracks_commanded_motion_exactly(self):
-        start_x, _ = self.base_in_odom()
+        start_x, _, _ = self.base_in_odom()
         travelled = self.node.drive_to_x(1.0)
         self.node.spin(0.5)
-        end_x, end_y = self.base_in_odom()
+        end_x, end_y, _ = self.base_in_odom()
 
         self.assertAlmostEqual(
             end_x - start_x,

--- a/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
+++ b/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
@@ -1,0 +1,117 @@
+"""odom -> base_link is live, exact, and usable for transforming sensor data.
+
+The tolerances are tight on purpose. This is MuJoCo ground truth, not an estimate, so it
+has no drift budget to hide in: if commanding 1 m of travel does not move the transform by
+1 m, something is wrong rather than merely noisy.
+"""
+
+import os
+import sys
+import unittest
+
+import pytest
+import rclpy
+from geometry_msgs.msg import PointStamped
+from nav_msgs.msg import Odometry
+from tf2_ros import Buffer, TransformListener
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from perception_sim_fixture import (  # noqa: E402
+    BASE_SPAWN_Z,
+    LIVOX_XYZ,
+    PerceptionSimTestNode,
+    perception_sim_description,
+)
+
+import tf2_geometry_msgs  # noqa: E402,F401  registers the PointStamped transform
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    return perception_sim_description()
+
+
+class OdomGroundTruthTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = PerceptionSimTestNode("test_odom_ground_truth")
+        cls.tf_buffer = Buffer()
+        cls.tf_listener = TransformListener(cls.tf_buffer, cls.node)
+        cls.odoms = []
+        cls.node.create_subscription(Odometry, "/g1_odometry_publisher/odom", cls.odoms.append, 10)
+        cls.node.wait_until(
+            lambda: cls.tf_buffer.can_transform("odom", "base_link", rclpy.time.Time())
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def base_in_odom(self):
+        self.assertTrue(
+            self.tf_buffer.can_transform("odom", "base_link", rclpy.time.Time()),
+            "odom -> base_link never appeared. The publisher defaults to odometry_source="
+            "'hardware', which refuses to configure; the launch must set sim_ground_truth.",
+        )
+        tf = self.tf_buffer.lookup_transform("odom", "base_link", rclpy.time.Time())
+        return tf.transform.translation.x, tf.transform.translation.y
+
+    def test_01_odom_to_base_link_is_published(self):
+        x, y = self.base_in_odom()
+        self.assertLess(abs(x), 0.05, f"base starts at the origin, transform says x={x:.4f}")
+        self.assertLess(abs(y), 0.05, f"base starts at the origin, transform says y={y:.4f}")
+
+    def test_02_odometry_message_agrees_with_the_transform(self):
+        """Nav2 reads velocity from Odometry, not from TF, so both have to be right."""
+        self.node.spin(1.0)
+        self.assertTrue(self.odoms, "nothing published on ~/odom")
+        odom = self.odoms[-1]
+        self.assertEqual(odom.header.frame_id, "odom")
+        self.assertEqual(odom.child_frame_id, "base_link")
+        x, y = self.base_in_odom()
+        self.assertAlmostEqual(odom.pose.pose.position.x, x, delta=0.02)
+        self.assertAlmostEqual(odom.pose.pose.position.y, y, delta=0.02)
+        self.assertGreater(
+            odom.pose.covariance[0], 0.0, "all-zero covariance is a known Nav2 footgun"
+        )
+
+    def test_03_a_lidar_point_transforms_into_odom(self):
+        """The whole chain in one assertion: odom -> base_link -> livox_frame.
+
+        A point at the sensor origin must land at the sensor's known height above the
+        floor. This is what every downstream consumer, costmap or SLAM, actually does.
+        """
+        point = PointStamped()
+        point.header.frame_id = "livox_frame"
+        point.header.stamp = rclpy.time.Time().to_msg()
+
+        transformed = self.tf_buffer.transform(point, "odom", timeout=rclpy.duration.Duration(seconds=5.0))
+        self.assertAlmostEqual(
+            transformed.point.z,
+            LIVOX_XYZ[2],
+            delta=0.01,
+            msg=f"livox origin lands at z={transformed.point.z:.4f} in odom, expected "
+            f"{LIVOX_XYZ[2]:.4f} above base_link",
+        )
+        # odom is at the base's spawn pose, so this is height above base_link, not the floor.
+        self.assertLess(
+            transformed.point.z + BASE_SPAWN_Z, 2.0, "sensor height is implausible in odom"
+        )
+
+    def test_04_the_transform_tracks_commanded_motion_exactly(self):
+        start_x, _ = self.base_in_odom()
+        travelled = self.node.drive_to_x(1.0)
+        self.node.spin(0.5)
+        end_x, end_y = self.base_in_odom()
+
+        self.assertAlmostEqual(
+            end_x - start_x,
+            travelled,
+            delta=0.05,
+            msg=f"odom moved {end_x - start_x:.4f} m while the base joint moved "
+            f"{travelled:.4f} m. Ground truth has no drift budget.",
+        )
+        self.assertLess(abs(end_y), 0.05, f"y drifted to {end_y:.4f} under a pure +x command")
+        self.node.drive_to_x(0.0)

--- a/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
+++ b/workspace/src/g1_sim/test/test_odom_ground_truth.launch.py
@@ -8,6 +8,7 @@ has no drift budget to hide in: if commanding 1 m of travel does not move the tr
 import os
 import sys
 import unittest
+from collections import deque
 
 import pytest
 import rclpy
@@ -15,7 +16,6 @@ import yaml
 from ament_index_python.packages import get_package_share_directory
 from geometry_msgs.msg import PointStamped
 from nav_msgs.msg import Odometry
-from tf2_ros import Buffer, TransformListener
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import tf2_geometry_msgs  # noqa: E402,F401  registers the PointStamped transform
@@ -36,9 +36,10 @@ class OdomGroundTruthTest(unittest.TestCase):
     def setUpClass(cls):
         rclpy.init()
         cls.node = PerceptionSimTestNode("test_odom_ground_truth")
-        cls.tf_buffer = Buffer()
-        cls.tf_listener = TransformListener(cls.tf_buffer, cls.node)
-        cls.odoms = []
+        # The fixture node already runs a TF listener; a second one on the same node
+        # doubles /tf processing per spin.
+        cls.tf_buffer = cls.node.tf_buffer
+        cls.odoms = deque(maxlen=64)
         cls.node.create_subscription(Odometry, "/g1_odometry_publisher/odom", cls.odoms.append, 10)
         cls.node.wait_until(
             lambda: cls.tf_buffer.can_transform("odom", "base_link", rclpy.time.Time())
@@ -50,12 +51,7 @@ class OdomGroundTruthTest(unittest.TestCase):
         rclpy.shutdown()
 
     def base_height(self):
-        """The canonical base height, from the file the MJCF is checked against.
-
-        Reading it here rather than hardcoding is deliberate: test_sensor_mount_consistency
-        pins this value to the MJCF spawn height, so there is exactly one number and one
-        place that asserts it.
-        """
+        """The canonical base height. test_sensor_mount_consistency pins it to the MJCF."""
         mounts_path = os.path.join(
             get_package_share_directory("g1_sim"), "config", "sensor_mounts.yaml"
         )
@@ -78,9 +74,7 @@ class OdomGroundTruthTest(unittest.TestCase):
     def test_01_odom_is_the_ground_plane(self):
         """odom sits on the floor, not at the base's spawn height.
 
-        The z is the whole point: it is what lets a consumer transform a point cloud into
-        odom and have the floor come out at 0, which is what Nav2's obstacle height bands
-        assume. Publishing 0 here would put every floor return at minus the spawn height.
+        Publishing z=0 here would put every floor return at minus the spawn height.
         """
         x, y, z = self.base_in_odom()
         self.assertLess(abs(x), 0.05, f"base starts at the origin, transform says x={x:.4f}")
@@ -111,10 +105,8 @@ class OdomGroundTruthTest(unittest.TestCase):
     def test_03_a_lidar_point_lands_at_its_real_height_above_the_floor(self):
         """The whole chain in one assertion: odom -> base_link -> livox_frame.
 
-        `odom` is the ground plane, so a point at the sensor origin must come out at the
-        sensor's physical height above the floor: the base spawn height plus the mount.
-        Drop the odom z and this reads 0.472 instead of 1.265, which is exactly the bug
-        that made every other test subtract the spawn height by hand.
+        A point at the sensor origin must come out at its physical height above the floor,
+        the spawn height plus the mount. Drop the odom z and it reads 0.472, not 1.265.
         """
         base_z = self.base_height()
         expected = base_z + LIVOX_XYZ[2]

--- a/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
+++ b/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
@@ -9,6 +9,7 @@ time is running, and commanding the base actually moves it.
 import os
 import time
 import unittest
+from collections import deque
 
 import launch_testing
 import pytest
@@ -62,8 +63,9 @@ class PerceptionSimBringupTest(unittest.TestCase):
         )
         cls.tf_buffer = Buffer()
         cls.tf_listener = TransformListener(cls.tf_buffer, cls.node)
-        cls.joint_states = []
-        cls.clock_msgs = []
+        # Bounded: 200 Hz joint states and sim-rate clock over a 240 s budget.
+        cls.joint_states = deque(maxlen=64)
+        cls.clock_msgs = deque(maxlen=256)
         cls.node.create_subscription(JointState, "/base_joint_states", cls.joint_states.append, 10)
         cls.node.create_subscription(Clock, "/clock", cls.clock_msgs.append, 10)
         cls.cmd_pub = cls.node.create_publisher(

--- a/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
+++ b/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
@@ -139,7 +139,7 @@ class PerceptionSimBringupTest(unittest.TestCase):
                 tf.transform.translation.y,
                 tf.transform.translation.z,
             )
-            for g, w, axis in zip(got, want, "xyz"):
+            for g, w, axis in zip(got, want, "xyz", strict=True):
                 self.assertAlmostEqual(
                     g, w, delta=MOUNT_TOL, msg=f"{child} {axis}: TF {g} != mount config {w}"
                 )

--- a/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
+++ b/workspace/src/g1_sim/test/test_perception_sim_bringup.launch.py
@@ -1,0 +1,199 @@
+"""Headless integration test: the perception sim track comes up and is commandable.
+
+Asserts the wiring, not the sensor data -- stream content is test_lidar_stream and
+test_camera_stream's job. What is pinned here: both controllers reach `active`, the
+robot description and static frames are published with the real mount poses, simulated
+time is running, and commanding the base actually moves it.
+"""
+
+import os
+import time
+import unittest
+
+import launch_testing
+import pytest
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from rclpy.node import Node
+from rosgraph_msgs.msg import Clock
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+from tf2_ros import Buffer, TransformListener
+
+# The node needs to load MuJoCo, register the engine plugin, spawn controllers and start
+# rendering. Generous so a loaded machine cannot flake it.
+BRINGUP_TIMEOUT_S = 45.0
+
+# Mount poses, from config/sensor_mounts.yaml (themselves derived from the vendored G1
+# URDF). Duplicated here deliberately: a test that reads the same yaml it is checking
+# would pass no matter what the value became.
+LIVOX_XYZ = (-0.00368, 0.00003, 0.472434)
+CAMERA_XYZ = (0.05366, 0.01753, 0.473870)
+MOUNT_TOL = 1e-4
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("g1_sim"), "launch", "perception_sim.launch.py")
+        )
+    )
+    return (
+        LaunchDescription(
+            [sim, TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()])]
+        ),
+        {},
+    )
+
+
+class PerceptionSimBringupTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_perception_sim_bringup")
+        # This track runs on simulated time; a listener on the wrong clock sees every
+        # transform as either stale or in the future.
+        cls.node.set_parameters(
+            [rclpy.parameter.Parameter("use_sim_time", rclpy.Parameter.Type.BOOL, True)]
+        )
+        cls.tf_buffer = Buffer()
+        cls.tf_listener = TransformListener(cls.tf_buffer, cls.node)
+        cls.joint_states = []
+        cls.clock_msgs = []
+        cls.node.create_subscription(JointState, "/base_joint_states", cls.joint_states.append, 10)
+        cls.node.create_subscription(Clock, "/clock", cls.clock_msgs.append, 10)
+        cls.cmd_pub = cls.node.create_publisher(
+            Float64MultiArray, "/base_velocity_controller/commands", 10
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def _wait_until(self, predicate, timeout_s):
+        end = time.time() + timeout_s
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if predicate():
+                return True
+        return False
+
+    def _joint(self, name):
+        for msg in reversed(self.joint_states):
+            if name in msg.name:
+                return msg.position[msg.name.index(name)]
+        return None
+
+    def test_01_simulated_clock_is_running(self):
+        """mujoco_ros2_control drives /clock; everything in this track reads it."""
+        self.assertTrue(
+            self._wait_until(lambda: len(self.clock_msgs) > 20, BRINGUP_TIMEOUT_S),
+            "no /clock -- the track is not running on simulated time, which will make "
+            "every tf lookup either stale or in the future",
+        )
+        first, last = self.clock_msgs[0].clock, self.clock_msgs[-1].clock
+        self.assertGreater(
+            (last.sec - first.sec) + (last.nanosec - first.nanosec) * 1e-9,
+            0.0,
+            "/clock is published but not advancing",
+        )
+
+    def test_02_base_state_is_published(self):
+        """The three planar joints reach us on /base_joint_states, not /joint_states."""
+        self.assertTrue(
+            self._wait_until(lambda: self._joint("base_x_joint") is not None, BRINGUP_TIMEOUT_S),
+            "no base_x_joint on /base_joint_states",
+        )
+        for joint in ("base_x_joint", "base_y_joint", "base_yaw_joint"):
+            self.assertIsNotNone(self._joint(joint), f"{joint} missing from /base_joint_states")
+
+    def test_03_sensor_frames_are_published_at_the_real_mounts(self):
+        """Static TF carries the mounts taken from Unitree's own vendored URDF."""
+        self.assertTrue(
+            self._wait_until(
+                lambda: self.tf_buffer.can_transform(
+                    "base_link", "livox_frame", rclpy.time.Time()
+                ),
+                BRINGUP_TIMEOUT_S,
+            ),
+            "base_link -> livox_frame never appeared on /tf_static",
+        )
+        for child, want in (("livox_frame", LIVOX_XYZ), ("camera_link", CAMERA_XYZ)):
+            self.assertTrue(
+                self.tf_buffer.can_transform("base_link", child, rclpy.time.Time()),
+                f"base_link -> {child} missing",
+            )
+            tf = self.tf_buffer.lookup_transform("base_link", child, rclpy.time.Time())
+            got = (
+                tf.transform.translation.x,
+                tf.transform.translation.y,
+                tf.transform.translation.z,
+            )
+            for g, w, axis in zip(got, want, "xyz"):
+                self.assertAlmostEqual(
+                    g, w, delta=MOUNT_TOL, msg=f"{child} {axis}: TF {g} != mount config {w}"
+                )
+
+    def test_04_lidar_is_mounted_upside_down(self):
+        """The Mid360's pi roll is real robot geometry, and easy to lose silently.
+
+        Missing it inverts every point cloud relative to hardware, which no amount of
+        downstream code will notice until the robot is in front of you.
+        """
+        self.assertTrue(
+            self.tf_buffer.can_transform("base_link", "livox_frame", rclpy.time.Time()),
+            "base_link -> livox_frame missing",
+        )
+        tf = self.tf_buffer.lookup_transform("base_link", "livox_frame", rclpy.time.Time())
+        q = tf.transform.rotation
+        # A pi roll about x puts nearly all the magnitude in qx and leaves qw near zero.
+        self.assertLess(
+            abs(q.w),
+            0.1,
+            f"livox_frame quaternion w={q.w:.4f}; expected near 0 for the pi roll. The "
+            "Mid360 is mounted upside down on the real G1.",
+        )
+        self.assertGreater(abs(q.x), 0.9, f"livox_frame quaternion x={q.x:.4f}; expected near 1")
+
+    def test_05_base_is_commandable(self):
+        """Driving +x moves the base in +x, and only in +x."""
+        self.assertTrue(
+            self._wait_until(lambda: self._joint("base_x_joint") is not None, BRINGUP_TIMEOUT_S),
+            "no base state before commanding",
+        )
+        start_x = self._joint("base_x_joint")
+        start_y = self._joint("base_y_joint")
+
+        cmd = Float64MultiArray()
+        cmd.data = [0.5, 0.0, 0.0]
+        end = time.time() + 3.0
+        while time.time() < end:
+            self.cmd_pub.publish(cmd)
+            rclpy.spin_once(self.node, timeout_sec=0.02)
+            time.sleep(0.02)
+
+        cmd.data = [0.0, 0.0, 0.0]
+        self.cmd_pub.publish(cmd)
+        self._spin(0.5)
+
+        moved_x = self._joint("base_x_joint") - start_x
+        moved_y = self._joint("base_y_joint") - start_y
+        self.assertGreater(
+            moved_x, 0.5, f"base moved only {moved_x:.3f} m in x under a 0.5 m/s command"
+        )
+        self.assertLess(
+            abs(moved_y),
+            0.1,
+            f"base drifted {moved_y:.3f} m in y under a pure +x command -- the planar "
+            "joints should give world-frame translation with no coupling",
+        )

--- a/workspace/src/g1_sim/test/test_sensor_mount_consistency.py
+++ b/workspace/src/g1_sim/test/test_sensor_mount_consistency.py
@@ -1,0 +1,132 @@
+"""The MJCF and the URDF carry the same sensor mount poses. Assert they agree.
+
+MuJoCo needs the mounts in its own MJCF, and ros2_control/TF needs them in the URDF, so
+the numbers necessarily exist twice. Generating one from the other at launch was rejected
+(g1_bringup already found launch-time file staging fiddly, and it buys one number), so
+this test is the guard instead: if either file drifts, it fails.
+
+No sim, no ROS. Just parses both files.
+"""
+
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import yaml
+
+PKG = Path(__file__).resolve().parent.parent
+MJCF = PKG / "mjcf" / "g1_perception_base.xml"
+MOUNTS = PKG / "config" / "sensor_mounts.yaml"
+
+TOL = 1e-6
+
+
+def rpy_to_quat(roll, pitch, yaw):
+    """Extrinsic XYZ (URDF rpy) to (w, x, y, z), matching MuJoCo's quat ordering."""
+    cr, sr = math.cos(roll / 2), math.sin(roll / 2)
+    cp, sp = math.cos(pitch / 2), math.sin(pitch / 2)
+    cy, sy = math.cos(yaw / 2), math.sin(yaw / 2)
+    return (
+        cr * cp * cy + sr * sp * sy,
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+    )
+
+
+def quats_equal(a, b, tol=TOL):
+    """q and -q are the same rotation, so compare both signs."""
+    same = all(abs(x - y) < tol for x, y in zip(a, b))
+    flipped = all(abs(x + y) < tol for x, y in zip(a, b))
+    return same or flipped
+
+
+@pytest.fixture(scope="module")
+def mounts():
+    with open(MOUNTS) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def mjcf():
+    return ET.parse(MJCF).getroot()
+
+
+def _find(root, tag, name):
+    for el in root.iter(tag):
+        if el.get("name") == name:
+            return el
+    raise AssertionError(f"<{tag} name='{name}'> not found in {MJCF}")
+
+
+def test_livox_site_matches_mount_config(mounts, mjcf):
+    site = _find(mjcf, "site", "livox_frame")
+    cfg = mounts["livox_frame"]
+
+    pos = [float(v) for v in site.get("pos").split()]
+    for got, want, axis in zip(pos, cfg["xyz"], "xyz"):
+        assert abs(got - want) < TOL, f"livox_frame {axis}: MJCF {got} != yaml {want}"
+
+    quat = [float(v) for v in site.get("quat").split()]
+    expected = rpy_to_quat(*cfg["rpy"])
+    assert quats_equal(quat, expected), (
+        f"livox_frame orientation: MJCF quat {quat} != yaml rpy {cfg['rpy']} "
+        f"(= quat {[round(v, 8) for v in expected]}). The pi roll is load-bearing -- "
+        "the Mid360 is mounted upside down on the real robot."
+    )
+
+
+def test_camera_body_matches_mount_config(mounts, mjcf):
+    body = _find(mjcf, "body", "camera_link")
+    cfg = mounts["camera_link"]
+
+    pos = [float(v) for v in body.get("pos").split()]
+    for got, want, axis in zip(pos, cfg["xyz"], "xyz"):
+        assert abs(got - want) < TOL, f"camera_link {axis}: MJCF {got} != yaml {want}"
+
+    quat = [float(v) for v in body.get("quat").split()]
+    expected = rpy_to_quat(*cfg["rpy"])
+    assert quats_equal(quat, expected), (
+        f"camera_link orientation: MJCF quat {quat} != yaml rpy {cfg['rpy']} "
+        f"(= quat {[round(v, 8) for v in expected]})"
+    )
+
+
+def test_mount_poses_match_the_vendored_g1_urdf(mounts):
+    """The whole point of these numbers is that they are the robot's, not invented.
+
+    Re-derives them from g1_description's URDF so a well-meaning "cleanup" of
+    sensor_mounts.yaml cannot quietly replace real geometry with round numbers.
+    """
+    urdf = PKG.parent / "g1_description" / "urdf" / "g1_29dof_with_hand_rev_1_0.urdf"
+    if not urdf.exists():
+        pytest.skip("g1_description URDF not present")
+    root = ET.parse(urdf).getroot()
+
+    def joint_origin(name):
+        for j in root.iter("joint"):
+            if j.get("name") == name:
+                o = j.find("origin")
+                return (
+                    [float(v) for v in o.get("xyz").split()],
+                    [float(v) for v in o.get("rpy").split()],
+                )
+        raise AssertionError(f"joint {name} not found in the vendored URDF")
+
+    # torso_link's offset from pelvis at zero pose, via the waist chain.
+    torso_xyz = [-0.0039635, 0.0, 0.044]
+
+    for joint_name, mount_name in (("mid360_joint", "livox_frame"), ("d435_joint", "camera_link")):
+        xyz, rpy = joint_origin(joint_name)
+        want_xyz = [xyz[i] + torso_xyz[i] for i in range(3)]
+        cfg = mounts[mount_name]
+        for got, want, axis in zip(cfg["xyz"], want_xyz, "xyz"):
+            assert abs(got - want) < 1e-5, (
+                f"{mount_name} {axis}: yaml {got} != vendored URDF {joint_name} "
+                f"+ torso offset = {want}"
+            )
+        for got, want, axis in zip(cfg["rpy"], rpy, ("roll", "pitch", "yaw")):
+            assert abs(got - want) < 1e-9, (
+                f"{mount_name} {axis}: yaml {got} != vendored URDF {joint_name} {want}"
+            )

--- a/workspace/src/g1_sim/test/test_sensor_mount_consistency.py
+++ b/workspace/src/g1_sim/test/test_sensor_mount_consistency.py
@@ -37,8 +37,8 @@ def rpy_to_quat(roll, pitch, yaw):
 
 def quats_equal(a, b, tol=TOL):
     """q and -q are the same rotation, so compare both signs."""
-    same = all(abs(x - y) < tol for x, y in zip(a, b))
-    flipped = all(abs(x + y) < tol for x, y in zip(a, b))
+    same = all(abs(x - y) < tol for x, y in zip(a, b, strict=True))
+    flipped = all(abs(x + y) < tol for x, y in zip(a, b, strict=True))
     return same or flipped
 
 
@@ -60,12 +60,27 @@ def _find(root, tag, name):
     raise AssertionError(f"<{tag} name='{name}'> not found in {MJCF}")
 
 
+def test_base_spawn_height_matches_mount_config(mounts, mjcf):
+    """The one place base_link's height above the floor is written.
+
+    g1_odometry_publisher publishes this as the z of odom -> base_link, which is what puts
+    `odom` on the ground plane. If the MJCF spawn height and the yaml drift apart, every
+    point transformed into odom is silently offset and Nav2's height bands stop meaning
+    what they say.
+    """
+    body = _find(mjcf, "body", "base_link")
+    spawn_z = float(body.get("pos").split()[2])
+    assert abs(spawn_z - mounts["base_link"]["spawn_z"]) < TOL, (
+        f"base_link spawn height: MJCF {spawn_z} != yaml {mounts['base_link']['spawn_z']}"
+    )
+
+
 def test_livox_site_matches_mount_config(mounts, mjcf):
     site = _find(mjcf, "site", "livox_frame")
     cfg = mounts["livox_frame"]
 
     pos = [float(v) for v in site.get("pos").split()]
-    for got, want, axis in zip(pos, cfg["xyz"], "xyz"):
+    for got, want, axis in zip(pos, cfg["xyz"], "xyz", strict=True):
         assert abs(got - want) < TOL, f"livox_frame {axis}: MJCF {got} != yaml {want}"
 
     quat = [float(v) for v in site.get("quat").split()]
@@ -82,7 +97,7 @@ def test_camera_body_matches_mount_config(mounts, mjcf):
     cfg = mounts["camera_link"]
 
     pos = [float(v) for v in body.get("pos").split()]
-    for got, want, axis in zip(pos, cfg["xyz"], "xyz"):
+    for got, want, axis in zip(pos, cfg["xyz"], "xyz", strict=True):
         assert abs(got - want) < TOL, f"camera_link {axis}: MJCF {got} != yaml {want}"
 
     quat = [float(v) for v in body.get("quat").split()]
@@ -121,12 +136,12 @@ def test_mount_poses_match_the_vendored_g1_urdf(mounts):
         xyz, rpy = joint_origin(joint_name)
         want_xyz = [xyz[i] + torso_xyz[i] for i in range(3)]
         cfg = mounts[mount_name]
-        for got, want, axis in zip(cfg["xyz"], want_xyz, "xyz"):
+        for got, want, axis in zip(cfg["xyz"], want_xyz, "xyz", strict=True):
             assert abs(got - want) < 1e-5, (
                 f"{mount_name} {axis}: yaml {got} != vendored URDF {joint_name} "
                 f"+ torso offset = {want}"
             )
-        for got, want, axis in zip(cfg["rpy"], rpy, ("roll", "pitch", "yaw")):
+        for got, want, axis in zip(cfg["rpy"], rpy, ("roll", "pitch", "yaw"), strict=True):
             assert abs(got - want) < 1e-9, (
                 f"{mount_name} {axis}: yaml {got} != vendored URDF {joint_name} {want}"
             )

--- a/workspace/src/g1_sim/urdf/g1_perception_base.urdf.xacro
+++ b/workspace/src/g1_sim/urdf/g1_perception_base.urdf.xacro
@@ -50,7 +50,9 @@
 
   <ros2_control name="G1PerceptionSim" type="system">
     <hardware>
-      <plugin>mujoco_ros2_control/MujocoSystem</plugin>
+      <plugin>mujoco_ros2_control/MujocoSystemInterface</plugin>
+      <!-- The node loads the scene named here; there is no separate launch parameter. -->
+      <param name="mujoco_model">$(find g1_sim)/mjcf/g1_perception_base.xml</param>
     </hardware>
     <joint name="base_x_joint">
       <command_interface name="velocity"/>

--- a/workspace/src/g1_sim/urdf/g1_perception_base.urdf.xacro
+++ b/workspace/src/g1_sim/urdf/g1_perception_base.urdf.xacro
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+  SIM-ONLY perception-track body. See g1_sim/README.md.
+
+  The three planar joints (base_x/base_y/base_yaw) appear ONLY in the <ros2_control>
+  block, never in the kinematic tree. Putting them in the tree would make
+  robot_state_publisher a second writer on the base_link parent edge, competing with the
+  odometry publisher's odom -> base_link transform. One writer per transform, same rule
+  this stack applies to control channels.
+
+  Mount poses come from config/sensor_mounts.yaml, which derives them from Unitree's own
+  vendored URDF. Same xacro.load_yaml pattern g1_description uses for arm_sdk_params.yaml.
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="g1_perception_base">
+
+  <xacro:property name="mounts" value="${xacro.load_yaml('$(find g1_sim)/config/sensor_mounts.yaml')}"/>
+
+  <xacro:macro name="mounted_frame" params="name">
+    <xacro:property name="m" value="${mounts[name]}"/>
+    <link name="${name}"/>
+    <joint name="${name}_joint" type="fixed">
+      <parent link="${m['parent']}"/>
+      <child link="${name}"/>
+      <origin xyz="${m['xyz'][0]} ${m['xyz'][1]} ${m['xyz'][2]}"
+              rpy="${m['rpy'][0]} ${m['rpy'][1]} ${m['rpy'][2]}"/>
+    </joint>
+  </xacro:macro>
+
+  <!-- Root. The odometry publisher owns odom -> base_link; nothing here parents it. -->
+  <link name="base_link">
+    <inertial>
+      <mass value="30.0"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="2.0" ixy="0" ixz="0" iyy="2.0" iyz="0" izz="1.0"/>
+    </inertial>
+    <visual>
+      <geometry><cylinder radius="0.15" length="0.70"/></geometry>
+    </visual>
+    <collision>
+      <geometry><cylinder radius="0.15" length="0.70"/></geometry>
+    </collision>
+  </link>
+
+  <!-- Named livox_frame, not lidar_link: livox_ros_driver2's own default frame id, so a
+       hardware swap is a driver launch rather than a remap. -->
+  <xacro:mounted_frame name="livox_frame"/>
+  <xacro:mounted_frame name="camera_link"/>
+  <xacro:mounted_frame name="camera_color_optical_frame"/>
+  <xacro:mounted_frame name="camera_depth_optical_frame"/>
+
+  <ros2_control name="G1PerceptionSim" type="system">
+    <hardware>
+      <plugin>mujoco_ros2_control/MujocoSystem</plugin>
+    </hardware>
+    <joint name="base_x_joint">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="base_y_joint">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="base_yaw_joint">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+</robot>

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_state_estimation)
+
+find_package(ament_cmake REQUIRED)
+
+# Frame and staleness math, deliberately free of ROS so it tests without a node or DDS.
+add_library(odom_math src/odom_math.cpp)
+target_include_directories(odom_math PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(odom_math PUBLIC cxx_std_17)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS odom_math EXPORT export_${PROJECT_NAME} DESTINATION lib)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gmock REQUIRED)
+  ament_add_gmock(test_odom_math test/test_odom_math.cpp)
+  target_link_libraries(test_odom_math odom_math)
+
+  # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt).
+  find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+  set(_clang_format_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+  if(CLANG_FORMAT_EXECUTABLE AND EXISTS "${_clang_format_config}")
+    file(GLOB_RECURSE _format_sources
+      "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp"
+    )
+    add_test(
+      NAME clang_format_check_g1_state_estimation
+      COMMAND ${CLANG_FORMAT_EXECUTABLE} --style=file:${_clang_format_config} --dry-run --Werror
+        ${_format_sources}
+    )
+  else()
+    message(WARNING
+      "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_state_estimation test")
+  endif()
+endif()
+
+ament_package()

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -51,8 +51,10 @@ if(BUILD_TESTING)
   target_link_libraries(test_odom_math odom_math)
 
   # Runs a real node on an isolated ROS_DOMAIN_ID, so it must not share the sim's.
+  find_package(rosgraph_msgs REQUIRED)
   ament_add_gmock(test_odometry_publisher_node test/test_odometry_publisher_node.cpp)
   target_link_libraries(test_odometry_publisher_node g1_odometry_publisher_node)
+  ament_target_dependencies(test_odometry_publisher_node rosgraph_msgs)
 
   # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt).
   find_program(CLANG_FORMAT_EXECUTABLE clang-format)

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.8)
 project(g1_state_estimation)
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_msgs REQUIRED)
 
 # Frame and staleness math, deliberately free of ROS so it tests without a node or DDS.
 add_library(odom_math src/odom_math.cpp)
@@ -11,11 +19,28 @@ target_include_directories(odom_math PUBLIC
 )
 target_compile_features(odom_math PUBLIC cxx_std_17)
 
+add_library(g1_odometry_publisher_node src/g1_odometry_publisher_node.cpp)
+target_include_directories(g1_odometry_publisher_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(g1_odometry_publisher_node PUBLIC cxx_std_17)
+target_link_libraries(g1_odometry_publisher_node PUBLIC odom_math)
+ament_target_dependencies(g1_odometry_publisher_node PUBLIC
+  rclcpp rclcpp_lifecycle lifecycle_msgs nav_msgs sensor_msgs geometry_msgs tf2_ros tf2_msgs)
+
+add_executable(g1_odometry_publisher src/g1_odometry_publisher_main.cpp)
+target_link_libraries(g1_odometry_publisher PUBLIC g1_odometry_publisher_node)
+
 install(DIRECTORY include/ DESTINATION include)
-install(TARGETS odom_math EXPORT export_${PROJECT_NAME} DESTINATION lib)
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+install(TARGETS odom_math g1_odometry_publisher_node
+  EXPORT export_${PROJECT_NAME} DESTINATION lib)
+install(TARGETS g1_odometry_publisher DESTINATION lib/${PROJECT_NAME})
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
+ament_export_dependencies(rclcpp rclcpp_lifecycle nav_msgs sensor_msgs geometry_msgs tf2_ros)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -24,6 +49,10 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(test_odom_math test/test_odom_math.cpp)
   target_link_libraries(test_odom_math odom_math)
+
+  # Runs a real node on an isolated ROS_DOMAIN_ID, so it must not share the sim's.
+  ament_add_gmock(test_odometry_publisher_node test/test_odometry_publisher_node.cpp)
+  target_link_libraries(test_odometry_publisher_node g1_odometry_publisher_node)
 
   # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt).
   find_program(CLANG_FORMAT_EXECUTABLE clang-format)

--- a/workspace/src/g1_state_estimation/README.md
+++ b/workspace/src/g1_state_estimation/README.md
@@ -1,0 +1,40 @@
+# g1_state_estimation
+
+`odom -> base_link` state estimation for the G1.
+
+## Odometry source
+
+The real G1 **publishes no odometry**. `/sportmodestate` on hardware carries
+`unitree_hg::SportModeState_`, which holds only `fsm_id`, `fsm_mode`, `task_id` and `task_time`. There
+is no pose and no velocity, and `rt/odommodestate` does not exist. So this package has two sources
+and only one of them is implemented:
+
+| `odometry_source` | Behaviour |
+|---|---|
+| `sim_ground_truth` | MuJoCo generalized coordinates, read from the perception track's planar joints. Exact by construction: no sensor, no lever arm, no filter. |
+| `hardware` (default) | **Refuses to run.** A real source (leg odometry + IMU EKF, or LiDAR-inertial odometry) is a future milestone. |
+
+`hardware` is the default deliberately. A misconfigured hardware bring-up must never silently emit
+fabricated odometry, so simulation is the case that opts in.
+
+**Sim odometry is ground truth, not an estimate.** It has zero drift, zero noise and zero latency.
+Nothing here validates how a real estimator behaves under drift, foot slip, or the suspend/freeze
+handling that goes with it. Treat any tuning done against this as unvalidated on hardware.
+
+No `map -> odom` is published. That is SLAM/AMCL and belongs to the Nav2 milestone.
+
+## `odom_math`
+
+Frame and staleness math, kept free of ROS so it tests without a node, DDS or a running sim (same
+split as `g1_bringup`'s `blend_math`). Covers the world-to-body twist rotation, yaw/quaternion
+conversion, angle wrapping, the staleness boundary, and covariance fill.
+
+The twist rotation is the part worth knowing about: `nav_msgs/Odometry` defines `twist` in the
+**child** frame, while the planar joints report velocity in the world frame. They agree only at yaw
+zero.
+
+## Testing
+
+```bash
+colcon test --packages-select g1_state_estimation
+```

--- a/workspace/src/g1_state_estimation/README.md
+++ b/workspace/src/g1_state_estimation/README.md
@@ -39,8 +39,25 @@ quiet would be indistinguishable from a healthy node with a stalled source.
 Parameters are in `config/g1_odometry_publisher.yaml`. Joints are looked up **by name**, since
 `joint_state_broadcaster` makes no promise about ordering.
 
-Past `source_timeout_ms` without a sample it stops publishing rather than re-stamping the last pose:
-a frozen transform with a fresh timestamp looks exactly like a stationary robot.
+### `odom` is the ground plane
+
+`base_height_m` is published as the z of `odom -> base_link`, so a point cloud transformed into
+`odom` puts the floor at z = 0 and Nav2's obstacle height bands mean what they say. It defaults to
+**0**, which is right for a real floating-base estimator that measures its own height; the
+perception sim's base is a planar body with no z DoF, so `perception_sim.launch.py` supplies the
+value from `g1_sim/config/sensor_mounts.yaml`, which is where the number canonically lives and which
+`test_sensor_mount_consistency` pins to the MJCF spawn height.
+
+### Staleness has two budgets, and the wall one is the load-bearing half
+
+Past `source_timeout_ms` it stops publishing rather than re-stamping the last pose: a frozen
+transform with a fresh timestamp looks exactly like a stationary robot.
+
+Measuring that on the source clock alone is not enough here. `/clock` is published by the **same
+process** as the base state, so when the simulator wedges, sim time freezes with it, the measured
+age stays pinned near zero, and a sim-time-only check never fires. The second budget runs on
+`steady_clock` and measures time since the sample stamp last **advanced** rather than since a message
+last arrived, which also catches a simulator still republishing a frozen sample.
 
 ## `odom_math`
 

--- a/workspace/src/g1_state_estimation/README.md
+++ b/workspace/src/g1_state_estimation/README.md
@@ -23,6 +23,25 @@ handling that goes with it. Treat any tuning done against this as unvalidated on
 
 No `map -> odom` is published. That is SLAM/AMCL and belongs to the Nav2 milestone.
 
+## `g1_odometry_publisher`
+
+Lifecycle node. Configuration is where the source decision is enforced, so a refusal is externally
+observable: with `odometry_source=hardware` it returns FAILURE from `on_configure` and stays in
+`unconfigured` having created **no publisher and no broadcaster**. Advertising `/tf` and then going
+quiet would be indistinguishable from a healthy node with a stalled source.
+
+| Interface | Dir | Type |
+|---|---|---|
+| `~/base_state` (remap to `/base_joint_states`) | in | `sensor_msgs/JointState` |
+| `/tf` | out | `tf2_msgs/TFMessage`, `odom -> base_link` |
+| `~/odom` | out | `nav_msgs/Odometry` |
+
+Parameters are in `config/g1_odometry_publisher.yaml`. Joints are looked up **by name**, since
+`joint_state_broadcaster` makes no promise about ordering.
+
+Past `source_timeout_ms` without a sample it stops publishing rather than re-stamping the last pose:
+a frozen transform with a fresh timestamp looks exactly like a stationary robot.
+
 ## `odom_math`
 
 Frame and staleness math, kept free of ROS so it tests without a node, DDS or a running sim (same

--- a/workspace/src/g1_state_estimation/README.md
+++ b/workspace/src/g1_state_estimation/README.md
@@ -39,25 +39,16 @@ quiet would be indistinguishable from a healthy node with a stalled source.
 Parameters are in `config/g1_odometry_publisher.yaml`. Joints are looked up **by name**, since
 `joint_state_broadcaster` makes no promise about ordering.
 
-### `odom` is the ground plane
+`base_height_m` is published as the z of `odom -> base_link`, putting **`odom` on the ground plane**
+so a transformed cloud has its floor at z = 0. It defaults to 0, which is right for a real
+floating-base estimator; the sim's planar base has no z DoF, so the launch supplies it from
+`g1_sim/config/sensor_mounts.yaml`.
 
-`base_height_m` is published as the z of `odom -> base_link`, so a point cloud transformed into
-`odom` puts the floor at z = 0 and Nav2's obstacle height bands mean what they say. It defaults to
-**0**, which is right for a real floating-base estimator that measures its own height; the
-perception sim's base is a planar body with no z DoF, so `perception_sim.launch.py` supplies the
-value from `g1_sim/config/sensor_mounts.yaml`, which is where the number canonically lives and which
-`test_sensor_mount_consistency` pins to the MJCF spawn height.
-
-### Staleness has two budgets, and the wall one is the load-bearing half
-
-Past `source_timeout_ms` it stops publishing rather than re-stamping the last pose: a frozen
-transform with a fresh timestamp looks exactly like a stationary robot.
-
-Measuring that on the source clock alone is not enough here. `/clock` is published by the **same
-process** as the base state, so when the simulator wedges, sim time freezes with it, the measured
-age stays pinned near zero, and a sim-time-only check never fires. The second budget runs on
-`steady_clock` and measures time since the sample stamp last **advanced** rather than since a message
-last arrived, which also catches a simulator still republishing a frozen sample.
+Staleness has two budgets. `source_timeout_ms` bounds the data's age on the source clock;
+`wall_timeout_ms` bounds it on `steady_clock`, measured from the last stamp **change**. The second
+is not redundant: `/clock` comes from the same process as the base state, so a wedged simulator
+freezes sim time too and a sim-time-only check would never fire. Either budget tripping stops the
+transform rather than re-stamping the last pose.
 
 ## `odom_math`
 

--- a/workspace/src/g1_state_estimation/config/g1_odometry_publisher.yaml
+++ b/workspace/src/g1_state_estimation/config/g1_odometry_publisher.yaml
@@ -1,0 +1,27 @@
+# odom -> base_link publisher. See g1_state_estimation/README.md.
+#
+# odometry_source is the one that matters. It defaults to `hardware`, which REFUSES to
+# configure, because the real G1 publishes no odometry at all. Simulation opts in to
+# ground truth explicitly rather than inheriting it by accident.
+g1_odometry_publisher:
+  ros__parameters:
+    odometry_source: "sim_ground_truth"
+
+    odom_frame_id: "odom"
+    base_frame_id: "base_link"
+
+    # The perception track's planar joints, carrying MuJoCo's generalized coordinates.
+    # Looked up by name, so this order is documentation rather than an index.
+    base_joint_names: ["base_x_joint", "base_y_joint", "base_yaw_joint"]
+
+    publish_rate_hz: 50.0
+    publish_odom_msg: true
+
+    # Past this, stop publishing rather than re-stamp a stale pose: a frozen transform with
+    # a fresh timestamp looks exactly like a stationary robot.
+    source_timeout_ms: 200.0
+
+    # Ground truth has no meaningful uncertainty, but an all-zero covariance is a known
+    # Nav2 footgun, so a small non-zero diagonal goes out instead.
+    pose_covariance: 1.0e-6
+    twist_covariance: 1.0e-6

--- a/workspace/src/g1_state_estimation/config/g1_odometry_publisher.yaml
+++ b/workspace/src/g1_state_estimation/config/g1_odometry_publisher.yaml
@@ -14,12 +14,21 @@ g1_odometry_publisher:
     # Looked up by name, so this order is documentation rather than an index.
     base_joint_names: ["base_x_joint", "base_y_joint", "base_yaw_joint"]
 
+    # base_height_m is deliberately NOT here. It is a property of the body being
+    # simulated, so it comes from g1_sim/config/sensor_mounts.yaml via the launch;
+    # a copy in this file is the two-sources-of-truth bug it was added to fix.
+
     publish_rate_hz: 50.0
     publish_odom_msg: true
 
     # Past this, stop publishing rather than re-stamp a stale pose: a frozen transform with
     # a fresh timestamp looks exactly like a stationary robot.
     source_timeout_ms: 200.0
+
+    # How long the simulator may stall in WALL time before its data counts as dead.
+    # Separate from source_timeout_ms: a headless render hitch is routine and must
+    # not drop the transform, while a wedged sim must not go unnoticed.
+    wall_timeout_ms: 2000.0
 
     # Ground truth has no meaningful uncertainty, but an all-zero covariance is a known
     # Nav2 footgun, so a small non-zero diagonal goes out instead.

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -63,6 +63,7 @@ private:
     double                   publish_rate_hz_  = 50.0;
     bool                     publish_odom_msg_ = true;
     double                   source_timeout_s_ = 0.2;
+    double                   wall_timeout_s_   = 2.0;
     std::array<double, 36>   pose_covariance_{};
     std::array<double, 36>   twist_covariance_{};
 
@@ -70,9 +71,10 @@ private:
     PlanarTwist  world_twist_;
     bool         have_sample_ = false;
     rclcpp::Time last_sample_stamp_;
-    /// Wall time at which the sample stamp last changed. See onTimer for why sim time
-    /// alone cannot detect a stalled source on this track.
+    /// Wall time at which the sample stamp last changed.
     std::chrono::steady_clock::time_point last_advance_wall_{};
+    /// Throttling clock for the staleness warnings; the ROS clock freezes with the sim.
+    rclcpp::Clock steady_clock_{ RCL_STEADY_TIME };
 };
 
 }  // namespace g1_state_estimation

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -6,6 +6,7 @@
  * @brief LifecycleNode publishing odom -> base_link, from a source it names explicitly.
  */
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -58,6 +59,7 @@ private:
     std::string              odom_frame_id_;
     std::string              base_frame_id_;
     std::vector<std::string> base_joint_names_;
+    double                   base_height_m_    = 0.0;
     double                   publish_rate_hz_  = 50.0;
     bool                     publish_odom_msg_ = true;
     double                   source_timeout_s_ = 0.2;
@@ -68,6 +70,9 @@ private:
     PlanarTwist  world_twist_;
     bool         have_sample_ = false;
     rclcpp::Time last_sample_stamp_;
+    /// Wall time at which the sample stamp last changed. See onTimer for why sim time
+    /// alone cannot detect a stalled source on this track.
+    std::chrono::steady_clock::time_point last_advance_wall_{};
 };
 
 }  // namespace g1_state_estimation

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -1,0 +1,75 @@
+#ifndef G1_STATE_ESTIMATION__G1_ODOMETRY_PUBLISHER_NODE_HPP_
+#define G1_STATE_ESTIMATION__G1_ODOMETRY_PUBLISHER_NODE_HPP_
+
+/**
+ * @file g1_odometry_publisher_node.hpp
+ * @brief LifecycleNode publishing odom -> base_link, from a source it names explicitly.
+ */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "g1_state_estimation/odom_math.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+
+namespace g1_state_estimation
+{
+
+/**
+ * @brief Publishes odom -> base_link and nav_msgs/Odometry from the configured source.
+ *
+ * Lifecycle rather than a plain node because the fail-loud requirement needs to be
+ * externally observable: with `odometry_source=hardware` this returns FAILURE from
+ * on_configure and sits in `unconfigured` having created no publisher and no broadcaster,
+ * which a test can assert. "Logged an error and carried on" cannot be.
+ */
+class G1OdometryPublisher : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+    using CallbackReturn =
+        rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+    explicit G1OdometryPublisher(const rclcpp::NodeOptions& options);
+
+    CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+    CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+    CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+    CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+    CallbackReturn on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
+
+private:
+    /// Reads and validates every parameter. False means configure must fail.
+    bool readParameters();
+
+    void onBaseState(const sensor_msgs::msg::JointState::SharedPtr msg);
+    void onTimer();
+
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr            base_state_sub_;
+    rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+    std::unique_ptr<tf2_ros::TransformBroadcaster>                           tf_broadcaster_;
+    rclcpp::TimerBase::SharedPtr                                             timer_;
+
+    OdometrySource           source_ = OdometrySource::Hardware;
+    std::string              odom_frame_id_;
+    std::string              base_frame_id_;
+    std::vector<std::string> base_joint_names_;
+    double                   publish_rate_hz_  = 50.0;
+    bool                     publish_odom_msg_ = true;
+    double                   source_timeout_s_ = 0.2;
+    std::array<double, 36>   pose_covariance_{};
+    std::array<double, 36>   twist_covariance_{};
+
+    PlanarPose   pose_;
+    PlanarTwist  world_twist_;
+    bool         have_sample_ = false;
+    rclcpp::Time last_sample_stamp_;
+};
+
+}  // namespace g1_state_estimation
+
+#endif  // G1_STATE_ESTIMATION__G1_ODOMETRY_PUBLISHER_NODE_HPP_

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
@@ -1,0 +1,121 @@
+#ifndef G1_STATE_ESTIMATION__ODOM_MATH_HPP_
+#define G1_STATE_ESTIMATION__ODOM_MATH_HPP_
+
+/**
+ * @file odom_math.hpp
+ * @brief Frame and staleness math for the odom -> base_link publisher.
+ *
+ * ROS-free so it is testable without a node, DDS or a running sim, same split as
+ * g1_bringup's blend_math and g1_hardware_interface's arm_ramp_engine.
+ */
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+namespace g1_state_estimation
+{
+
+/// Where the base pose comes from. Anything else is a configuration error.
+enum class OdometrySource
+{
+    SimGroundTruth,  ///< MuJoCo generalized coordinates. Exact, and sim-only.
+    Hardware,        ///< Not implemented: the real G1 publishes no odometry at all.
+};
+
+/**
+ * @brief Parses the `odometry_source` parameter.
+ *
+ * @param name   Parameter value, expected `sim_ground_truth` or `hardware`.
+ * @param[out] out  Set only when the name is recognised.
+ * @return False for an unrecognised name, so the caller can fail configure rather than
+ *         silently fall back to a default that might fabricate transforms.
+ */
+bool parseOdometrySource(const std::string& name, OdometrySource& out);
+
+/// Planar pose of base_link in the odom frame.
+struct PlanarPose
+{
+    double x   = 0.0;
+    double y   = 0.0;
+    double yaw = 0.0;
+};
+
+/// Planar twist. Frame depends on context, see toBodyTwist().
+struct PlanarTwist
+{
+    double vx    = 0.0;
+    double vy    = 0.0;
+    double omega = 0.0;
+};
+
+/// Quaternion, w-last to match geometry_msgs.
+struct Quaternion
+{
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    double w = 1.0;
+};
+
+/**
+ * @brief Yaw to a quaternion about +z.
+ *
+ * @param yaw  Rotation about +z, in radians.
+ */
+Quaternion yawToQuaternion(double yaw);
+
+/**
+ * @brief Recovers yaw from a quaternion assumed to be a pure +z rotation.
+ *
+ * Round-trip inverse of yawToQuaternion(); result is wrapped to (-pi, pi].
+ */
+double quaternionToYaw(const Quaternion& q);
+
+/**
+ * @brief Wraps an angle to (-pi, pi].
+ *
+ * The yaw joint is a continuous hinge, so its position grows without bound as the base
+ * spins. Publishing that raw into a quaternion is harmless, but comparing two of them is
+ * not, hence one wrap in one place.
+ */
+double wrapAngle(double angle);
+
+/**
+ * @brief Rotates a world-frame planar twist into base_link.
+ *
+ * nav_msgs/Odometry defines `twist` in the child frame, not the header frame, which is a
+ * standing trap: the planar joints report velocity in the world frame, so handing it
+ * straight to the message is wrong for every yaw except zero. Nav2's controller server
+ * reads this, so getting it wrong shows up as the robot fighting its own heading.
+ *
+ * @param world_twist  Twist expressed in the odom frame.
+ * @param yaw          Current base yaw in the odom frame.
+ */
+PlanarTwist toBodyTwist(const PlanarTwist& world_twist, double yaw);
+
+/**
+ * @brief Whether the source is too old to keep publishing transforms from.
+ *
+ * Compares elapsed against the timeout inclusively, so a sample exactly at the timeout is
+ * NOT yet stale; the boundary is pinned by test because "off by one tick" here means
+ * either a spurious TF gap or a transform that outlives its data.
+ *
+ * @param elapsed_s    Seconds since the last accepted sample.
+ * @param timeout_s    Configured tolerance. Non-positive disables the check.
+ */
+bool isStale(double elapsed_s, double timeout_s);
+
+/**
+ * @brief Fills a 6x6 row-major covariance with a single value on the diagonal.
+ *
+ * Ground truth has no meaningful uncertainty, but an all-zero covariance is a known Nav2
+ * footgun, so a small non-zero diagonal is written instead of leaving it empty.
+ *
+ * @param value  Written to all six diagonal entries; off-diagonals are zeroed.
+ */
+std::array<double, 36> diagonalCovariance(double value);
+
+}  // namespace g1_state_estimation
+
+#endif  // G1_STATE_ESTIMATION__ODOM_MATH_HPP_

--- a/workspace/src/g1_state_estimation/package.xml
+++ b/workspace/src/g1_state_estimation/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_state_estimation</name>
+  <version>0.1.0</version>
+  <description>
+    odom to base_link state estimation for the G1. In simulation this is MuJoCo
+    ground truth, published as such; on hardware it refuses to run, because the
+    real G1 exposes no odometry topic. See README.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_state_estimation/package.xml
+++ b/workspace/src/g1_state_estimation/package.xml
@@ -13,6 +13,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_msgs</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>

--- a/workspace/src/g1_state_estimation/package.xml
+++ b/workspace/src/g1_state_estimation/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_main.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_main.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file g1_odometry_publisher_main.cpp
+ * @brief Entry point for the odom -> base_link publisher.
+ */
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+#include "g1_state_estimation/g1_odometry_publisher_node.hpp"
+
+int main(int argc, char** argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::executors::SingleThreadedExecutor executor;
+    auto node = std::make_shared<g1_state_estimation::G1OdometryPublisher>(rclcpp::NodeOptions());
+    executor.add_node(node->get_node_base_interface());
+    executor.spin();
+    rclcpp::shutdown();
+    return 0;
+}

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -28,6 +28,11 @@ G1OdometryPublisher::G1OdometryPublisher(const rclcpp::NodeOptions& options)
     declare_parameter<std::vector<std::string>>(
         "base_joint_names",
         { "base_x_joint", "base_y_joint", "base_yaw_joint" });
+    // Height of base_link above the floor, making odom the ground plane. Defaults to 0,
+    // which is correct for a real floating-base estimator (it measures z itself). The
+    // perception sim's base is a planar body with no z DoF, so its launch supplies the
+    // spawn height from g1_sim's sensor_mounts.yaml.
+    declare_parameter<double>("base_height_m", 0.0);
     declare_parameter<double>("publish_rate_hz", 50.0);
     declare_parameter<bool>("publish_odom_msg", true);
     declare_parameter<double>("source_timeout_ms", 200.0);
@@ -63,6 +68,7 @@ bool G1OdometryPublisher::readParameters()
         return false;
     }
 
+    base_height_m_    = get_parameter("base_height_m").as_double();
     odom_frame_id_    = get_parameter("odom_frame_id").as_string();
     base_frame_id_    = get_parameter("base_frame_id").as_string();
     base_joint_names_ = get_parameter("base_joint_names").as_string_array();
@@ -189,12 +195,23 @@ void G1OdometryPublisher::onBaseState(const sensor_msgs::msg::JointState::Shared
     pose_.y      = values[1];
     pose_.yaw    = values[2];
     world_twist_ = PlanarTwist{ velocities[0], velocities[1], velocities[2] };
-    have_sample_ = true;
+
     // The broadcaster stamps from this, so take the source's own time rather than now():
     // on simulated time the two can differ by more than the whole TF cache.
-    const bool unstamped = msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0;
-    last_sample_stamp_ =
+    const bool         unstamped = msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0;
+    const rclcpp::Time stamp =
         unstamped ? now() : rclcpp::Time(msg->header.stamp, get_clock()->get_clock_type());
+
+    // Wall time of the last stamp CHANGE, not of the last message. A simulator whose
+    // physics thread has wedged can keep republishing the same sample at the same stamp
+    // forever; that is not fresh data, and treating message arrival as freshness would
+    // hold the staleness guard open for exactly that failure.
+    if (!have_sample_ || stamp != last_sample_stamp_)
+    {
+        last_advance_wall_ = std::chrono::steady_clock::now();
+    }
+    last_sample_stamp_ = stamp;
+    have_sample_       = true;
 }
 
 void G1OdometryPublisher::onTimer()
@@ -210,8 +227,16 @@ void G1OdometryPublisher::onTimer()
         return;
     }
 
+    // Two budgets, because on this track they can fail independently. /clock is published
+    // by the SAME process as the base state, so if that process wedges, sim time freezes
+    // with it, `elapsed` stays pinned near zero and a sim-time-only check never fires --
+    // the exact "confidently wrong map" this guard exists to prevent. The wall budget
+    // measures time since the sample stamp last ADVANCED, so it catches both a silent
+    // source and one still emitting a frozen sample.
     const double elapsed = (now() - last_sample_stamp_).seconds();
-    if (isStale(elapsed, source_timeout_s_))
+    const double wall_elapsed =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - last_advance_wall_).count();
+    if (isStale(elapsed, source_timeout_s_) || isStale(wall_elapsed, source_timeout_s_))
     {
         // Stop publishing rather than re-stamping the last pose. A frozen transform with a
         // fresh timestamp is indistinguishable from a stationary robot, which is how a dead
@@ -238,6 +263,7 @@ void G1OdometryPublisher::onTimer()
     tf.child_frame_id          = base_frame_id_;
     tf.transform.translation.x = pose_.x;
     tf.transform.translation.y = pose_.y;
+    tf.transform.translation.z = base_height_m_;
     tf.transform.rotation.x    = orientation.x;
     tf.transform.rotation.y    = orientation.y;
     tf.transform.rotation.z    = orientation.z;
@@ -256,6 +282,7 @@ void G1OdometryPublisher::onTimer()
     odom.child_frame_id        = base_frame_id_;
     odom.pose.pose.position.x  = pose_.x;
     odom.pose.pose.position.y  = pose_.y;
+    odom.pose.pose.position.z  = base_height_m_;
     odom.pose.pose.orientation = tf.transform.rotation;
     odom.twist.twist.linear.x  = body_twist.vx;
     odom.twist.twist.linear.y  = body_twist.vy;

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -36,6 +36,7 @@ G1OdometryPublisher::G1OdometryPublisher(const rclcpp::NodeOptions& options)
     declare_parameter<double>("publish_rate_hz", 50.0);
     declare_parameter<bool>("publish_odom_msg", true);
     declare_parameter<double>("source_timeout_ms", 200.0);
+    declare_parameter<double>("wall_timeout_ms", 2000.0);
     declare_parameter<double>("pose_covariance", 1.0e-6);
     declare_parameter<double>("twist_covariance", 1.0e-6);
 }
@@ -75,6 +76,7 @@ bool G1OdometryPublisher::readParameters()
     publish_rate_hz_  = get_parameter("publish_rate_hz").as_double();
     publish_odom_msg_ = get_parameter("publish_odom_msg").as_bool();
     source_timeout_s_ = get_parameter("source_timeout_ms").as_double() / 1000.0;
+    wall_timeout_s_   = get_parameter("wall_timeout_ms").as_double() / 1000.0;
 
     if (base_joint_names_.size() != 3)
     {
@@ -202,10 +204,9 @@ void G1OdometryPublisher::onBaseState(const sensor_msgs::msg::JointState::Shared
     const rclcpp::Time stamp =
         unstamped ? now() : rclcpp::Time(msg->header.stamp, get_clock()->get_clock_type());
 
-    // Wall time of the last stamp CHANGE, not of the last message. A simulator whose
-    // physics thread has wedged can keep republishing the same sample at the same stamp
-    // forever; that is not fresh data, and treating message arrival as freshness would
-    // hold the staleness guard open for exactly that failure.
+    // Time of the last stamp CHANGE, not of the last message: a wedged simulator can keep
+    // republishing the same sample forever. Order matters, rclcpp::Time::operator!= throws
+    // on mismatched clock types and last_sample_stamp_ starts out RCL_SYSTEM_TIME.
     if (!have_sample_ || stamp != last_sample_stamp_)
     {
         last_advance_wall_ = std::chrono::steady_clock::now();
@@ -220,34 +221,33 @@ void G1OdometryPublisher::onTimer()
     {
         RCLCPP_WARN_THROTTLE(
             get_logger(),
-            *get_clock(),
+            steady_clock_,
             5000,
             "No base state received yet on %s; publishing nothing.",
             base_state_sub_->get_topic_name());
         return;
     }
 
-    // Two budgets, because on this track they can fail independently. /clock is published
-    // by the SAME process as the base state, so if that process wedges, sim time freezes
-    // with it, `elapsed` stays pinned near zero and a sim-time-only check never fires --
-    // the exact "confidently wrong map" this guard exists to prevent. The wall budget
-    // measures time since the sample stamp last ADVANCED, so it catches both a silent
-    // source and one still emitting a frozen sample.
+    // Sim time alone cannot see a wedged simulator: /clock comes from the same process as
+    // the base state, so it freezes too and `elapsed` stays at zero. Hence the wall budget.
     const double elapsed = (now() - last_sample_stamp_).seconds();
     const double wall_elapsed =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - last_advance_wall_).count();
-    if (isStale(elapsed, source_timeout_s_) || isStale(wall_elapsed, source_timeout_s_))
+    if (isStale(elapsed, source_timeout_s_) || isStale(wall_elapsed, wall_timeout_s_))
     {
         // Stop publishing rather than re-stamping the last pose. A frozen transform with a
         // fresh timestamp is indistinguishable from a stationary robot, which is how a dead
         // source turns into a confidently wrong map.
         RCLCPP_WARN_THROTTLE(
             get_logger(),
-            *get_clock(),
+            steady_clock_,
             2000,
-            "Base state is %.3f s old (timeout %.3f s); stopped publishing %s -> %s.",
+            "Base state has not advanced for %.3f s on the source clock (limit %.3f) or "
+            "%.3f s on wall time (limit %.3f); stopped publishing %s -> %s.",
             elapsed,
             source_timeout_s_,
+            wall_elapsed,
+            wall_timeout_s_,
             odom_frame_id_.c_str(),
             base_frame_id_.c_str());
         return;

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -1,0 +1,268 @@
+#include "g1_state_estimation/g1_odometry_publisher_node.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace g1_state_estimation
+{
+
+namespace
+{
+// Sensor-style: the base state is a stream of samples where only the newest matters, and
+// a reliable subscriber against a best-effort publisher simply receives nothing.
+rclcpp::QoS baseStateQos()
+{
+    return rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile();
+}
+}  // namespace
+
+G1OdometryPublisher::G1OdometryPublisher(const rclcpp::NodeOptions& options)
+  : rclcpp_lifecycle::LifecycleNode("g1_odometry_publisher", options)
+{
+    declare_parameter<std::string>("odometry_source", "hardware");
+    declare_parameter<std::string>("odom_frame_id", "odom");
+    declare_parameter<std::string>("base_frame_id", "base_link");
+    declare_parameter<std::vector<std::string>>(
+        "base_joint_names",
+        { "base_x_joint", "base_y_joint", "base_yaw_joint" });
+    declare_parameter<double>("publish_rate_hz", 50.0);
+    declare_parameter<bool>("publish_odom_msg", true);
+    declare_parameter<double>("source_timeout_ms", 200.0);
+    declare_parameter<double>("pose_covariance", 1.0e-6);
+    declare_parameter<double>("twist_covariance", 1.0e-6);
+}
+
+bool G1OdometryPublisher::readParameters()
+{
+    const std::string source_name = get_parameter("odometry_source").as_string();
+    if (!parseOdometrySource(source_name, source_))
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "odometry_source='%s' is not a known source. Use 'sim_ground_truth' or "
+            "'hardware'.",
+            source_name.c_str());
+        return false;
+    }
+
+    if (source_ == OdometrySource::Hardware)
+    {
+        // Deliberately long. Anyone hitting this needs to know the topic they are about to
+        // go looking for does not carry what they think it does.
+        RCLCPP_ERROR(
+            get_logger(),
+            "odometry_source='hardware' is not implemented: the real G1 publishes no odometry. "
+            "On hardware /sportmodestate carries unitree_hg::SportModeState_, which has only "
+            "fsm_id, fsm_mode, task_id and task_time -- no pose and no velocity. "
+            "rt/odommodestate does not exist. A real source (leg odometry + IMU EKF, or "
+            "LiDAR-inertial odometry) is a future state-estimation milestone. Refusing to "
+            "configure rather than publish a fabricated transform.");
+        return false;
+    }
+
+    odom_frame_id_    = get_parameter("odom_frame_id").as_string();
+    base_frame_id_    = get_parameter("base_frame_id").as_string();
+    base_joint_names_ = get_parameter("base_joint_names").as_string_array();
+    publish_rate_hz_  = get_parameter("publish_rate_hz").as_double();
+    publish_odom_msg_ = get_parameter("publish_odom_msg").as_bool();
+    source_timeout_s_ = get_parameter("source_timeout_ms").as_double() / 1000.0;
+
+    if (base_joint_names_.size() != 3)
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "base_joint_names needs exactly 3 entries (x, y, yaw), got %zu",
+            base_joint_names_.size());
+        return false;
+    }
+    if (publish_rate_hz_ <= 0.0)
+    {
+        RCLCPP_ERROR(get_logger(), "publish_rate_hz must be positive, got %f", publish_rate_hz_);
+        return false;
+    }
+
+    pose_covariance_  = diagonalCovariance(get_parameter("pose_covariance").as_double());
+    twist_covariance_ = diagonalCovariance(get_parameter("twist_covariance").as_double());
+    return true;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
+{
+    // Nothing is created before this returns true. An unimplemented source must leave no
+    // publisher and no broadcaster behind: advertising /tf and then going quiet is exactly
+    // the silent failure this node exists to avoid.
+    if (!readParameters())
+    {
+        return CallbackReturn::FAILURE;
+    }
+
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+    if (publish_odom_msg_)
+    {
+        odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("~/odom", rclcpp::QoS(10));
+    }
+    base_state_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+        "~/base_state",
+        baseStateQos(),
+        std::bind(&G1OdometryPublisher::onBaseState, this, std::placeholders::_1));
+
+    RCLCPP_INFO(
+        get_logger(),
+        "Configured on sim ground truth: %s -> %s from %s. This is exact MuJoCo state, not an "
+        "estimate; it has no drift, noise or latency.",
+        odom_frame_id_.c_str(),
+        base_frame_id_.c_str(),
+        base_state_sub_->get_topic_name());
+    return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+G1OdometryPublisher::on_cleanup(const rclcpp_lifecycle::State&)
+{
+    timer_.reset();
+    base_state_sub_.reset();
+    odom_pub_.reset();
+    tf_broadcaster_.reset();
+    have_sample_ = false;
+    return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+G1OdometryPublisher::on_activate(const rclcpp_lifecycle::State& previous_state)
+{
+    LifecycleNode::on_activate(previous_state);
+    const auto period = std::chrono::duration<double>(1.0 / publish_rate_hz_);
+    timer_            = create_wall_timer(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+        std::bind(&G1OdometryPublisher::onTimer, this));
+    return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+G1OdometryPublisher::on_deactivate(const rclcpp_lifecycle::State& previous_state)
+{
+    timer_.reset();
+    LifecycleNode::on_deactivate(previous_state);
+    return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+G1OdometryPublisher::on_shutdown(const rclcpp_lifecycle::State&)
+{
+    timer_.reset();
+    base_state_sub_.reset();
+    odom_pub_.reset();
+    tf_broadcaster_.reset();
+    return CallbackReturn::SUCCESS;
+}
+
+void G1OdometryPublisher::onBaseState(const sensor_msgs::msg::JointState::SharedPtr msg)
+{
+    // Look joints up by name every message: joint_state_broadcaster does not promise a
+    // stable ordering, and indexing by position would silently swap x and yaw the day it
+    // changes.
+    double     values[3]     = { 0.0, 0.0, 0.0 };
+    double     velocities[3] = { 0.0, 0.0, 0.0 };
+    const bool have_velocity = msg->velocity.size() == msg->name.size();
+
+    for (std::size_t axis = 0; axis < base_joint_names_.size(); ++axis)
+    {
+        const auto it = std::find(msg->name.begin(), msg->name.end(), base_joint_names_[axis]);
+        if (it == msg->name.end())
+        {
+            return;
+        }
+        const std::size_t index = static_cast<std::size_t>(std::distance(msg->name.begin(), it));
+        if (index >= msg->position.size())
+        {
+            return;
+        }
+        values[axis]     = msg->position[index];
+        velocities[axis] = have_velocity ? msg->velocity[index] : 0.0;
+    }
+
+    pose_.x      = values[0];
+    pose_.y      = values[1];
+    pose_.yaw    = values[2];
+    world_twist_ = PlanarTwist{ velocities[0], velocities[1], velocities[2] };
+    have_sample_ = true;
+    // The broadcaster stamps from this, so take the source's own time rather than now():
+    // on simulated time the two can differ by more than the whole TF cache.
+    const bool unstamped = msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0;
+    last_sample_stamp_ =
+        unstamped ? now() : rclcpp::Time(msg->header.stamp, get_clock()->get_clock_type());
+}
+
+void G1OdometryPublisher::onTimer()
+{
+    if (!have_sample_)
+    {
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            *get_clock(),
+            5000,
+            "No base state received yet on %s; publishing nothing.",
+            base_state_sub_->get_topic_name());
+        return;
+    }
+
+    const double elapsed = (now() - last_sample_stamp_).seconds();
+    if (isStale(elapsed, source_timeout_s_))
+    {
+        // Stop publishing rather than re-stamping the last pose. A frozen transform with a
+        // fresh timestamp is indistinguishable from a stationary robot, which is how a dead
+        // source turns into a confidently wrong map.
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            *get_clock(),
+            2000,
+            "Base state is %.3f s old (timeout %.3f s); stopped publishing %s -> %s.",
+            elapsed,
+            source_timeout_s_,
+            odom_frame_id_.c_str(),
+            base_frame_id_.c_str());
+        return;
+    }
+
+    const Quaternion   orientation = yawToQuaternion(pose_.yaw);
+    const PlanarTwist  body_twist  = toBodyTwist(world_twist_, pose_.yaw);
+    const rclcpp::Time stamp       = last_sample_stamp_;
+
+    geometry_msgs::msg::TransformStamped tf;
+    tf.header.stamp            = stamp;
+    tf.header.frame_id         = odom_frame_id_;
+    tf.child_frame_id          = base_frame_id_;
+    tf.transform.translation.x = pose_.x;
+    tf.transform.translation.y = pose_.y;
+    tf.transform.rotation.x    = orientation.x;
+    tf.transform.rotation.y    = orientation.y;
+    tf.transform.rotation.z    = orientation.z;
+    tf.transform.rotation.w    = orientation.w;
+    tf_broadcaster_->sendTransform(tf);
+
+    if (!odom_pub_ || !odom_pub_->is_activated())
+    {
+        return;
+    }
+
+    // Nav2's costmap and controller server read velocity from Odometry, not from TF.
+    nav_msgs::msg::Odometry odom;
+    odom.header.stamp          = stamp;
+    odom.header.frame_id       = odom_frame_id_;
+    odom.child_frame_id        = base_frame_id_;
+    odom.pose.pose.position.x  = pose_.x;
+    odom.pose.pose.position.y  = pose_.y;
+    odom.pose.pose.orientation = tf.transform.rotation;
+    odom.twist.twist.linear.x  = body_twist.vx;
+    odom.twist.twist.linear.y  = body_twist.vy;
+    odom.twist.twist.angular.z = body_twist.omega;
+    std::copy(pose_covariance_.begin(), pose_covariance_.end(), odom.pose.covariance.begin());
+    std::copy(twist_covariance_.begin(), twist_covariance_.end(), odom.twist.covariance.begin());
+    odom_pub_->publish(odom);
+}
+
+}  // namespace g1_state_estimation

--- a/workspace/src/g1_state_estimation/src/odom_math.cpp
+++ b/workspace/src/g1_state_estimation/src/odom_math.cpp
@@ -1,0 +1,72 @@
+#include "g1_state_estimation/odom_math.hpp"
+
+#include <cmath>
+#include <string>
+
+namespace g1_state_estimation
+{
+
+bool parseOdometrySource(const std::string& name, OdometrySource& out)
+{
+    if (name == "sim_ground_truth")
+    {
+        out = OdometrySource::SimGroundTruth;
+        return true;
+    }
+    if (name == "hardware")
+    {
+        out = OdometrySource::Hardware;
+        return true;
+    }
+    return false;
+}
+
+Quaternion yawToQuaternion(double yaw)
+{
+    Quaternion q;
+    q.z = std::sin(yaw * 0.5);
+    q.w = std::cos(yaw * 0.5);
+    return q;
+}
+
+double quaternionToYaw(const Quaternion& q) { return wrapAngle(2.0 * std::atan2(q.z, q.w)); }
+
+double wrapAngle(double angle)
+{
+    // remainder() lands in [-pi, pi]; the shift moves the -pi endpoint up so the interval
+    // is half-open and a given rotation has exactly one representation.
+    const double wrapped = std::remainder(angle, 2.0 * M_PI);
+    return (wrapped <= -M_PI) ? wrapped + 2.0 * M_PI : wrapped;
+}
+
+PlanarTwist toBodyTwist(const PlanarTwist& world_twist, double yaw)
+{
+    const double c = std::cos(yaw);
+    const double s = std::sin(yaw);
+    PlanarTwist  body;
+    body.vx    = world_twist.vx * c + world_twist.vy * s;
+    body.vy    = -world_twist.vx * s + world_twist.vy * c;
+    body.omega = world_twist.omega;
+    return body;
+}
+
+bool isStale(double elapsed_s, double timeout_s)
+{
+    if (timeout_s <= 0.0)
+    {
+        return false;
+    }
+    return elapsed_s > timeout_s;
+}
+
+std::array<double, 36> diagonalCovariance(double value)
+{
+    std::array<double, 36> covariance{};
+    for (std::size_t i = 0; i < 6; ++i)
+    {
+        covariance[i * 6 + i] = value;
+    }
+    return covariance;
+}
+
+}  // namespace g1_state_estimation

--- a/workspace/src/g1_state_estimation/test/test_odom_math.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odom_math.cpp
@@ -1,0 +1,145 @@
+#include <gmock/gmock.h>
+
+#include <cmath>
+
+#include "g1_state_estimation/odom_math.hpp"
+
+using g1_state_estimation::diagonalCovariance;
+using g1_state_estimation::isStale;
+using g1_state_estimation::OdometrySource;
+using g1_state_estimation::parseOdometrySource;
+using g1_state_estimation::PlanarTwist;
+using g1_state_estimation::Quaternion;
+using g1_state_estimation::quaternionToYaw;
+using g1_state_estimation::toBodyTwist;
+using g1_state_estimation::wrapAngle;
+using g1_state_estimation::yawToQuaternion;
+
+namespace
+{
+constexpr double kTol = 1e-12;
+}
+
+TEST(ParseOdometrySource, AcceptsTheTwoKnownNames)
+{
+    OdometrySource source = OdometrySource::Hardware;
+    ASSERT_TRUE(parseOdometrySource("sim_ground_truth", source));
+    EXPECT_EQ(source, OdometrySource::SimGroundTruth);
+
+    ASSERT_TRUE(parseOdometrySource("hardware", source));
+    EXPECT_EQ(source, OdometrySource::Hardware);
+}
+
+TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
+{
+    // A typo must not silently become sim ground truth, which would fabricate transforms.
+    OdometrySource source = OdometrySource::SimGroundTruth;
+    for (const char* name : { "", "sim", "SIM_GROUND_TRUTH", "ground_truth", "hardware " })
+    {
+        EXPECT_FALSE(parseOdometrySource(name, source)) << "accepted " << name;
+        EXPECT_EQ(source, OdometrySource::SimGroundTruth);
+    }
+}
+
+TEST(YawQuaternion, RoundTripsOverTheFullCircle)
+{
+    for (double yaw = -M_PI + 1e-6; yaw < M_PI; yaw += 0.1)
+    {
+        EXPECT_NEAR(quaternionToYaw(yawToQuaternion(yaw)), yaw, 1e-9) << "yaw " << yaw;
+    }
+}
+
+TEST(YawQuaternion, MatchesKnownValues)
+{
+    const Quaternion identity = yawToQuaternion(0.0);
+    EXPECT_NEAR(identity.z, 0.0, kTol);
+    EXPECT_NEAR(identity.w, 1.0, kTol);
+
+    const Quaternion quarter = yawToQuaternion(M_PI_2);
+    EXPECT_NEAR(quarter.z, std::sqrt(0.5), 1e-12);
+    EXPECT_NEAR(quarter.w, std::sqrt(0.5), 1e-12);
+
+    // x and y stay zero: this is a planar body, and a stray tilt here would tip every
+    // sensor frame hanging off base_link.
+    for (double yaw : { 0.0, 1.0, -2.5, M_PI })
+    {
+        const Quaternion q = yawToQuaternion(yaw);
+        EXPECT_NEAR(q.x, 0.0, kTol);
+        EXPECT_NEAR(q.y, 0.0, kTol);
+    }
+}
+
+TEST(WrapAngle, MapsOntoTheHalfOpenInterval)
+{
+    EXPECT_NEAR(wrapAngle(0.0), 0.0, kTol);
+    EXPECT_NEAR(wrapAngle(M_PI), M_PI, kTol);
+    EXPECT_NEAR(wrapAngle(-M_PI), M_PI, kTol) << "-pi and +pi are the same rotation; pick one";
+    EXPECT_NEAR(wrapAngle(3.0 * M_PI), M_PI, 1e-12);
+    EXPECT_NEAR(wrapAngle(2.0 * M_PI + 0.25), 0.25, 1e-12);
+    EXPECT_NEAR(wrapAngle(-2.0 * M_PI - 0.25), -0.25, 1e-12);
+
+    // The yaw hinge is continuous, so many turns is the realistic input.
+    EXPECT_NEAR(wrapAngle(20.0 * M_PI + 0.5), 0.5, 1e-9);
+}
+
+TEST(ToBodyTwist, IsIdentityAtZeroYaw)
+{
+    const PlanarTwist body = toBodyTwist({ 1.0, 2.0, 0.5 }, 0.0);
+    EXPECT_NEAR(body.vx, 1.0, kTol);
+    EXPECT_NEAR(body.vy, 2.0, kTol);
+    EXPECT_NEAR(body.omega, 0.5, kTol);
+}
+
+TEST(ToBodyTwist, RotatesIntoTheBodyFrameAtRightAngles)
+{
+    // Facing +y in the world: driving world +x is driving body -y.
+    const PlanarTwist quarter = toBodyTwist({ 1.0, 0.0, 0.0 }, M_PI_2);
+    EXPECT_NEAR(quarter.vx, 0.0, 1e-12);
+    EXPECT_NEAR(quarter.vy, -1.0, 1e-12);
+
+    const PlanarTwist minus_quarter = toBodyTwist({ 1.0, 0.0, 0.0 }, -M_PI_2);
+    EXPECT_NEAR(minus_quarter.vx, 0.0, 1e-12);
+    EXPECT_NEAR(minus_quarter.vy, 1.0, 1e-12);
+
+    const PlanarTwist half = toBodyTwist({ 1.0, 0.0, 0.0 }, M_PI);
+    EXPECT_NEAR(half.vx, -1.0, 1e-12);
+    EXPECT_NEAR(half.vy, 0.0, 1e-12);
+}
+
+TEST(ToBodyTwist, PreservesSpeedAndYawRate)
+{
+    const PlanarTwist world{ 0.3, -0.7, 0.9 };
+    const double      world_speed = std::hypot(world.vx, world.vy);
+    for (double yaw = -3.0; yaw < 3.0; yaw += 0.37)
+    {
+        const PlanarTwist body = toBodyTwist(world, yaw);
+        EXPECT_NEAR(std::hypot(body.vx, body.vy), world_speed, 1e-12) << "yaw " << yaw;
+        EXPECT_NEAR(body.omega, world.omega, kTol) << "yaw rate is frame independent";
+    }
+}
+
+TEST(IsStale, TreatsTheBoundaryAsFresh)
+{
+    EXPECT_FALSE(isStale(0.199, 0.2));
+    EXPECT_FALSE(isStale(0.2, 0.2)) << "exactly at the timeout is not yet stale";
+    EXPECT_TRUE(isStale(0.2000001, 0.2));
+}
+
+TEST(IsStale, NonPositiveTimeoutDisablesTheCheck)
+{
+    EXPECT_FALSE(isStale(1e6, 0.0));
+    EXPECT_FALSE(isStale(1e6, -1.0));
+}
+
+TEST(DiagonalCovariance, FillsOnlyTheDiagonal)
+{
+    const std::array<double, 36> covariance = diagonalCovariance(1.0e-6);
+    for (std::size_t row = 0; row < 6; ++row)
+    {
+        for (std::size_t col = 0; col < 6; ++col)
+        {
+            const double expected = (row == col) ? 1.0e-6 : 0.0;
+            EXPECT_DOUBLE_EQ(covariance[row * 6 + col], expected) << row << "," << col;
+        }
+    }
+}

--- a/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
@@ -1,0 +1,236 @@
+/**
+ * @file test_odometry_publisher_node.cpp
+ * @brief In-process lifecycle tests for the odom -> base_link publisher.
+ *
+ * Runs on an isolated ROS_DOMAIN_ID so a sim or another test on the machine cannot feed it
+ * real data, same pattern as g1_locomotion's test_loco_bridge_node.
+ */
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "g1_state_estimation/g1_odometry_publisher_node.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+using g1_state_estimation::G1OdometryPublisher;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+rclcpp::NodeOptions optionsWithSource(const std::string& source)
+{
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+        rclcpp::Parameter("odometry_source", source),
+        rclcpp::Parameter("publish_rate_hz", 100.0),
+        rclcpp::Parameter("source_timeout_ms", 200.0),
+    });
+    return options;
+}
+
+/// Spins the node (and any helpers) for a wall duration.
+void spinFor(
+    const std::vector<rclcpp::node_interfaces::NodeBaseInterface::SharedPtr>& nodes,
+    std::chrono::milliseconds                                                 duration)
+{
+    rclcpp::executors::SingleThreadedExecutor executor;
+    for (const auto& node : nodes)
+    {
+        executor.add_node(node);
+    }
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline && rclcpp::ok())
+    {
+        executor.spin_some(10ms);
+    }
+}
+
+sensor_msgs::msg::JointState makeBaseState(
+    const rclcpp::Time& stamp, double x, double y, double yaw, double vx = 0.0, double vy = 0.0,
+    double omega = 0.0)
+{
+    sensor_msgs::msg::JointState msg;
+    msg.header.stamp = stamp;
+    // Deliberately not in x, y, yaw order: the node must look joints up by name.
+    msg.name     = { "base_yaw_joint", "base_x_joint", "base_y_joint" };
+    msg.position = { yaw, x, y };
+    msg.velocity = { omega, vx, vy };
+    return msg;
+}
+
+class OdometryPublisherTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        node_ = std::make_shared<G1OdometryPublisher>(optionsWithSource(source_));
+    }
+
+    void TearDown() override { node_.reset(); }
+
+    std::string                          source_ = "sim_ground_truth";
+    std::shared_ptr<G1OdometryPublisher> node_;
+};
+
+}  // namespace
+
+TEST(OdometryPublisherHardwareBranch, ConfigureFailsAndCreatesNothing)
+{
+    auto node = std::make_shared<G1OdometryPublisher>(optionsWithSource("hardware"));
+
+    EXPECT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+        << "hardware must not configure: the real G1 publishes no odometry";
+
+    // The point of failing in on_configure rather than at first tick. Advertising /tf and
+    // then never publishing is the silent mode this node exists to rule out.
+    EXPECT_EQ(node->count_publishers("/tf"), 0u) << "a /tf publisher was created anyway";
+    EXPECT_EQ(node->count_publishers("/g1_odometry_publisher/odom"), 0u)
+        << "an odom publisher was created anyway";
+}
+
+TEST(OdometryPublisherHardwareBranch, IsTheDefaultSource)
+{
+    // A misconfigured hardware bring-up must never silently emit fabricated odometry, so
+    // the safe branch is the one you get by saying nothing.
+    auto node = std::make_shared<G1OdometryPublisher>(rclcpp::NodeOptions());
+    EXPECT_EQ(node->get_parameter("odometry_source").as_string(), "hardware");
+    EXPECT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+TEST(OdometryPublisherHardwareBranch, UnknownSourceAlsoFailsToConfigure)
+{
+    auto node = std::make_shared<G1OdometryPublisher>(optionsWithSource("ground_truth"));
+    EXPECT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+        << "a typo must not fall back to a working source";
+    EXPECT_EQ(node->count_publishers("/tf"), 0u);
+}
+
+TEST_F(OdometryPublisherTest, SimGroundTruthConfiguresAndActivates)
+{
+    ASSERT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+TEST_F(OdometryPublisherTest, PublishesTheSampledPoseOnTfAndOdom)
+{
+    ASSERT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto helper    = std::make_shared<rclcpp::Node>("odom_test_helper");
+    auto state_pub = helper->create_publisher<sensor_msgs::msg::JointState>(
+        "/g1_odometry_publisher/base_state",
+        rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile());
+
+    std::vector<geometry_msgs::msg::TransformStamped> transforms;
+    auto tf_sub = helper->create_subscription<tf2_msgs::msg::TFMessage>(
+        "/tf",
+        rclcpp::QoS(100),
+        [&transforms](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+            transforms.insert(transforms.end(), msg->transforms.begin(), msg->transforms.end());
+        });
+
+    std::vector<nav_msgs::msg::Odometry> odoms;
+    auto odom_sub = helper->create_subscription<nav_msgs::msg::Odometry>(
+        "/g1_odometry_publisher/odom",
+        rclcpp::QoS(100),
+        [&odoms](nav_msgs::msg::Odometry::SharedPtr msg) { odoms.push_back(*msg); });
+
+    const std::vector<rclcpp::node_interfaces::NodeBaseInterface::SharedPtr> nodes = {
+        node_->get_node_base_interface(),
+        helper->get_node_base_interface()
+    };
+    spinFor(nodes, 300ms);
+
+    // Facing +y, driving world +x: the body twist must come out as -y.
+    const double yaw = M_PI_2;
+    for (int i = 0; i < 20; ++i)
+    {
+        state_pub->publish(makeBaseState(helper->now(), 1.5, -2.5, yaw, 1.0, 0.0, 0.25));
+        spinFor(nodes, 20ms);
+    }
+
+    ASSERT_FALSE(transforms.empty()) << "nothing published on /tf";
+    const auto& tf = transforms.back();
+    EXPECT_EQ(tf.header.frame_id, "odom");
+    EXPECT_EQ(tf.child_frame_id, "base_link");
+    EXPECT_NEAR(tf.transform.translation.x, 1.5, 1e-9);
+    EXPECT_NEAR(tf.transform.translation.y, -2.5, 1e-9);
+    EXPECT_NEAR(tf.transform.rotation.z, std::sin(yaw / 2.0), 1e-9);
+    EXPECT_NEAR(tf.transform.rotation.w, std::cos(yaw / 2.0), 1e-9);
+
+    ASSERT_FALSE(odoms.empty()) << "nothing published on ~/odom";
+    const auto& odom = odoms.back();
+    EXPECT_EQ(odom.header.frame_id, "odom");
+    EXPECT_EQ(odom.child_frame_id, "base_link");
+    EXPECT_NEAR(odom.pose.pose.position.x, tf.transform.translation.x, 1e-9);
+    EXPECT_NEAR(odom.pose.pose.position.y, tf.transform.translation.y, 1e-9);
+
+    EXPECT_NEAR(odom.twist.twist.linear.x, 0.0, 1e-9)
+        << "twist must be in base_link, not odom: at yaw pi/2 a world +x velocity is body -y";
+    EXPECT_NEAR(odom.twist.twist.linear.y, -1.0, 1e-9);
+    EXPECT_NEAR(odom.twist.twist.angular.z, 0.25, 1e-9) << "yaw rate is frame independent";
+
+    EXPECT_GT(odom.pose.covariance[0], 0.0) << "all-zero covariance is a known Nav2 footgun";
+    EXPECT_GT(odom.twist.covariance[0], 0.0);
+}
+
+TEST_F(OdometryPublisherTest, StopsPublishingWhenTheSourceGoesSilent)
+{
+    ASSERT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto helper    = std::make_shared<rclcpp::Node>("odom_test_helper_stale");
+    auto state_pub = helper->create_publisher<sensor_msgs::msg::JointState>(
+        "/g1_odometry_publisher/base_state",
+        rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile());
+
+    std::size_t transform_count = 0;
+    auto        tf_sub          = helper->create_subscription<tf2_msgs::msg::TFMessage>(
+        "/tf",
+        rclcpp::QoS(100),
+        [&transform_count](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+            transform_count += msg->transforms.size();
+        });
+
+    const std::vector<rclcpp::node_interfaces::NodeBaseInterface::SharedPtr> nodes = {
+        node_->get_node_base_interface(),
+        helper->get_node_base_interface()
+    };
+    spinFor(nodes, 300ms);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        state_pub->publish(makeBaseState(helper->now(), 0.0, 0.0, 0.0));
+        spinFor(nodes, 20ms);
+    }
+    ASSERT_GT(transform_count, 0u) << "never published while the source was fresh";
+
+    // Go quiet for well past source_timeout_ms, then check it actually stopped rather than
+    // re-stamping the last pose forever.
+    spinFor(nodes, 400ms);
+    const std::size_t after_timeout = transform_count;
+    spinFor(nodes, 300ms);
+    EXPECT_EQ(transform_count, after_timeout)
+        << "kept publishing " << (transform_count - after_timeout)
+        << " transforms from a source that had gone silent";
+}
+
+int main(int argc, char** argv)
+{
+    // Isolated domain: a running sim on the default domain must not be able to feed this.
+    setenv("ROS_DOMAIN_ID", "77", 1);
+    ::testing::InitGoogleMock(&argc, argv);
+    rclcpp::init(argc, argv);
+    const int result = RUN_ALL_TESTS();
+    rclcpp::shutdown();
+    return result;
+}

--- a/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
@@ -17,6 +17,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rosgraph_msgs/msg/clock.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 
@@ -26,13 +27,15 @@ using namespace std::chrono_literals;
 namespace
 {
 
-rclcpp::NodeOptions optionsWithSource(const std::string& source)
+rclcpp::NodeOptions optionsWithSource(const std::string& source, bool use_sim_time = false)
 {
     rclcpp::NodeOptions options;
     options.parameter_overrides({
         rclcpp::Parameter("odometry_source", source),
         rclcpp::Parameter("publish_rate_hz", 100.0),
         rclcpp::Parameter("source_timeout_ms", 200.0),
+        rclcpp::Parameter("base_height_m", 0.793),
+        rclcpp::Parameter("use_sim_time", use_sim_time),
     });
     return options;
 }
@@ -222,6 +225,110 @@ TEST_F(OdometryPublisherTest, StopsPublishingWhenTheSourceGoesSilent)
     EXPECT_EQ(transform_count, after_timeout)
         << "kept publishing " << (transform_count - after_timeout)
         << " transforms from a source that had gone silent";
+}
+
+TEST(OdometryPublisherSimTime, StopsPublishingWhenSimTimeItselfFreezes)
+{
+    // The failure the wall-clock test cannot see. /clock is published by the SAME process
+    // as the base state on this track, so when that process wedges, sim time stops with
+    // it: `now() - last_sample_stamp_` stays pinned near zero and a sim-time-only
+    // staleness check never fires, leaving a frozen pose broadcast as if it were live.
+    auto node = std::make_shared<G1OdometryPublisher>(optionsWithSource("sim_ground_truth", true));
+    ASSERT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(node->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto helper = std::make_shared<rclcpp::Node>("odom_test_helper_simtime");
+    auto clock_pub =
+        helper->create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::ClockQoS());
+    auto state_pub = helper->create_publisher<sensor_msgs::msg::JointState>(
+        "/g1_odometry_publisher/base_state",
+        rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile());
+
+    std::size_t transform_count = 0;
+    auto        tf_sub          = helper->create_subscription<tf2_msgs::msg::TFMessage>(
+        "/tf",
+        rclcpp::QoS(100),
+        [&transform_count](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+            transform_count += msg->transforms.size();
+        });
+
+    const std::vector<rclcpp::node_interfaces::NodeBaseInterface::SharedPtr> nodes = {
+        node->get_node_base_interface(),
+        helper->get_node_base_interface()
+    };
+
+    // Drive sim time forward by hand and feed samples stamped with it.
+    rclcpp::Time sim_now(0, 0, RCL_ROS_TIME);
+    const auto   tick = rclcpp::Duration::from_seconds(0.02);
+    for (int i = 0; i < 25; ++i)
+    {
+        sim_now = sim_now + tick;
+        rosgraph_msgs::msg::Clock clock_msg;
+        clock_msg.clock = sim_now;
+        clock_pub->publish(clock_msg);
+        state_pub->publish(makeBaseState(sim_now, 1.0, 2.0, 0.0));
+        spinFor(nodes, 20ms);
+    }
+    ASSERT_GT(transform_count, 0u) << "never published while sim time was advancing";
+
+    // Now the simulator wedges: /clock stops AND the stamp stops advancing, but samples
+    // keep arriving, so the node still has fresh-looking data on a frozen clock. Wall time
+    // is the only thing left that can notice.
+    const std::size_t before_freeze = transform_count;
+    for (int i = 0; i < 15; ++i)
+    {
+        state_pub->publish(makeBaseState(sim_now, 1.0, 2.0, 0.0));
+        spinFor(nodes, 40ms);
+    }
+    const std::size_t after_timeout = transform_count;
+    for (int i = 0; i < 10; ++i)
+    {
+        state_pub->publish(makeBaseState(sim_now, 1.0, 2.0, 0.0));
+        spinFor(nodes, 40ms);
+    }
+
+    EXPECT_GT(after_timeout, before_freeze)
+        << "sanity: the node should keep publishing for at least the timeout after the freeze";
+    EXPECT_EQ(transform_count, after_timeout)
+        << "published " << (transform_count - after_timeout)
+        << " more transforms after sim time froze. With /clock stopped, elapsed sim time "
+           "stays at zero forever, so only a wall-clock budget can catch this.";
+}
+
+TEST(OdometryPublisherGroundPlane, PublishesTheBaseHeightSoOdomIsTheGroundPlane)
+{
+    auto node = std::make_shared<G1OdometryPublisher>(optionsWithSource("sim_ground_truth"));
+    ASSERT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(node->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto helper    = std::make_shared<rclcpp::Node>("odom_test_helper_height");
+    auto state_pub = helper->create_publisher<sensor_msgs::msg::JointState>(
+        "/g1_odometry_publisher/base_state",
+        rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile());
+
+    std::vector<geometry_msgs::msg::TransformStamped> transforms;
+    auto tf_sub = helper->create_subscription<tf2_msgs::msg::TFMessage>(
+        "/tf",
+        rclcpp::QoS(100),
+        [&transforms](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+            transforms.insert(transforms.end(), msg->transforms.begin(), msg->transforms.end());
+        });
+
+    const std::vector<rclcpp::node_interfaces::NodeBaseInterface::SharedPtr> nodes = {
+        node->get_node_base_interface(),
+        helper->get_node_base_interface()
+    };
+    spinFor(nodes, 300ms);
+    for (int i = 0; i < 20; ++i)
+    {
+        state_pub->publish(makeBaseState(helper->now(), 0.0, 0.0, 0.0));
+        spinFor(nodes, 20ms);
+    }
+
+    ASSERT_FALSE(transforms.empty());
+    // Without this, a floor return transformed into odom lands at -0.793 and every Nav2
+    // obstacle height band is off by the spawn height.
+    EXPECT_NEAR(transforms.back().transform.translation.z, 0.793, 1e-9);
 }
 
 int main(int argc, char** argv)

--- a/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
@@ -34,6 +34,7 @@ rclcpp::NodeOptions optionsWithSource(const std::string& source, bool use_sim_ti
         rclcpp::Parameter("odometry_source", source),
         rclcpp::Parameter("publish_rate_hz", 100.0),
         rclcpp::Parameter("source_timeout_ms", 200.0),
+        rclcpp::Parameter("wall_timeout_ms", 300.0),
         rclcpp::Parameter("base_height_m", 0.793),
         rclcpp::Parameter("use_sim_time", use_sim_time),
     });


### PR DESCRIPTION
Adds the perception foundation as a second, sim-only simulation track. The `unitree_mujoco` track is untouched and remains the source of truth for arm and locomotion fidelity. Nav2 stays deferred to its own milestone.

## What this adds

- **`g1_sim`** — a MuJoCo scene run through `ros-controls/mujoco_ros2_control` (pinned at `ae0b235a`), carrying a 3D LiDAR and an RGB-D camera. The body is a deliberately non-physical mobility stand-in on three planar joints: perception work does not need bipedal dynamics, and a 29-DoF humanoid with no balance controller would only topple. **The sensor mount poses are real**, taken from Unitree's own vendored URDF.
- **`g1_state_estimation`** — `odom -> base_link` as a lifecycle node, with an explicit source flag.

## Odometry is ground truth, and says so

In sim it reads MuJoCo's generalized coordinates directly: exact, no drift, no noise, no latency. On hardware it **refuses to configure**, because the real G1 publishes no odometry at all — `unitree_hg::SportModeState_` carries only `fsm_id`, `fsm_mode`, `task_id` and `task_time`, and `rt/odommodestate` does not exist. A real estimator is its own future milestone.

This also corrects a claim in `g1_bringup`'s README: the walking policy is sim-only because the observation field does not exist on hardware, not merely because the motion service is switched off.

`odom` is the ground plane, so a transformed cloud has its floor at z=0. The base height lives once, in `sensor_mounts.yaml`, pinned to the MJCF by a consistency test.

## Testing

37 tests in `g1_sim`, 26 in `g1_state_estimation`. The sensor tests assert scene geometry rather than message arrival: the point cloud is transformed through the live TF chain and checked against the room, and the depth image against the camera's mount height and 47.6 degree pitch. Both were mutation-tested — perturbing the MJCF camera pitch fails them with the predicted value.

## Known limitations

- The LiDAR plugin lets roughly 4% of rays through walls (a contiguous band 10-18 degrees below horizontal). The camera renders those same walls as solid, so it is the plugin's raycast rather than the scene. Documented in `g1_sim/README.md`; a costmap fed from this cloud will see phantom obstacles outside the room.
- The scan pattern is a uniform grid, not the Mid360's non-repetitive rosette. No intensity, per-point timestamps, noise or motion distortion.
- The two sim tracks share `ROS_DOMAIN_ID=1` and must never run at once; the launch detects the conflict and refuses to start.

Requires `./scripts/manage.sh recreate` — the dev image gains a pinned `mujoco_ros2_control` build.