### PR TITLE
Move the LiDAR and depth camera onto the G1 simulation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -80,12 +80,19 @@ RUN mkdir -p /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} && \
 # (jstest fails against current unitree_sdk2 tip — unrelated upstream rename).
 # Pinned 2026-07-17 — current tip of unitree_mujoco at authoring time,
 # resolved together with UNITREE_SDK2_SHA above.
+COPY workspace/patches/unitree_mujoco/ /tmp/unitree_mujoco_patches/
 ARG UNITREE_MUJOCO_SHA=ae6a8403e272733e9996ef59990880330496177f
 RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
     cd /opt/unitree_robotics/unitree_mujoco && \
     git remote add origin https://github.com/unitreerobotics/unitree_mujoco.git && \
     git fetch --depth 1 origin ${UNITREE_MUJOCO_SHA} && \
     git checkout -q FETCH_HEAD && \
+    for p in /tmp/unitree_mujoco_patches/*.patch; do \
+        [ -e "$p" ] || continue; \
+        echo "Applying $(basename "$p")"; \
+        git apply --check "$p" || { echo "PATCH DOES NOT APPLY: $p"; exit 1; }; \
+        git apply "$p"; \
+    done && \
     rm -rf .git && \
     rm -rf simulate/mujoco && \
     mv /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} simulate/mujoco && \
@@ -192,6 +199,12 @@ RUN mkdir -p /opt/mujoco_ros2_control_ws/src && \
     git remote add origin https://github.com/ros-controls/mujoco_ros2_control.git && \
     git fetch --depth 1 origin ${MUJOCO_ROS2_CONTROL_SHA} && \
     git checkout -q FETCH_HEAD && \
+    for p in /tmp/unitree_mujoco_patches/*.patch; do \
+        [ -e "$p" ] || continue; \
+        echo "Applying $(basename "$p")"; \
+        git apply --check "$p" || { echo "PATCH DOES NOT APPLY: $p"; exit 1; }; \
+        git apply "$p"; \
+    done && \
     rm -rf .git && \
     cd /opt/mujoco_ros2_control_ws && \
     . /opt/ros/humble/setup.sh && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,6 +81,7 @@ RUN mkdir -p /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} && \
 # Pinned 2026-07-17 — current tip of unitree_mujoco at authoring time,
 # resolved together with UNITREE_SDK2_SHA above.
 COPY workspace/patches/unitree_mujoco/ /tmp/unitree_mujoco_patches/
+COPY workspace/vendor/unitree_mujoco/ /tmp/unitree_mujoco_src/
 ARG UNITREE_MUJOCO_SHA=ae6a8403e272733e9996ef59990880330496177f
 RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
     cd /opt/unitree_robotics/unitree_mujoco && \
@@ -93,12 +94,14 @@ RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
         git apply --check "$p" || { echo "PATCH DOES NOT APPLY: $p"; exit 1; }; \
         git apply "$p"; \
     done && \
+    cp /tmp/unitree_mujoco_src/*.h /tmp/unitree_mujoco_src/*.cc simulate/src/ && \
     rm -rf .git && \
     rm -rf simulate/mujoco && \
     mv /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} simulate/mujoco && \
     mkdir simulate/build && cd simulate/build && \
+    . /opt/ros/humble/setup.sh && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
-             -DCMAKE_PREFIX_PATH=/opt/unitree_robotics/lib/cmake && \
+             -DCMAKE_PREFIX_PATH="/opt/unitree_robotics/lib/cmake;/opt/ros/humble" && \
     cmake --build . --target unitree_mujoco --parallel "$(nproc)" && \
     rm -rf CMakeFiles && \
     rm -rf ../mujoco/sample ../mujoco/bin ../mujoco/doc ../mujoco/model
@@ -199,12 +202,6 @@ RUN mkdir -p /opt/mujoco_ros2_control_ws/src && \
     git remote add origin https://github.com/ros-controls/mujoco_ros2_control.git && \
     git fetch --depth 1 origin ${MUJOCO_ROS2_CONTROL_SHA} && \
     git checkout -q FETCH_HEAD && \
-    for p in /tmp/unitree_mujoco_patches/*.patch; do \
-        [ -e "$p" ] || continue; \
-        echo "Applying $(basename "$p")"; \
-        git apply --check "$p" || { echo "PATCH DOES NOT APPLY: $p"; exit 1; }; \
-        git apply "$p"; \
-    done && \
     rm -rf .git && \
     cd /opt/mujoco_ros2_control_ws && \
     . /opt/ros/humble/setup.sh && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -99,9 +99,8 @@ RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
     rm -rf simulate/mujoco && \
     mv /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} simulate/mujoco && \
     mkdir simulate/build && cd simulate/build && \
-    . /opt/ros/humble/setup.sh && \
     cmake .. -DCMAKE_BUILD_TYPE=Release \
-             -DCMAKE_PREFIX_PATH="/opt/unitree_robotics/lib/cmake;/opt/ros/humble" && \
+             -DCMAKE_PREFIX_PATH=/opt/unitree_robotics/lib/cmake && \
     cmake --build . --target unitree_mujoco --parallel "$(nproc)" && \
     rm -rf CMakeFiles && \
     rm -rf ../mujoco/sample ../mujoco/bin ../mujoco/doc ../mujoco/model

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -94,8 +94,12 @@ RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
              -DCMAKE_PREFIX_PATH=/opt/unitree_robotics/lib/cmake && \
     cmake --build . --target unitree_mujoco --parallel "$(nproc)" && \
     rm -rf CMakeFiles && \
-    rm -rf ../mujoco/include ../mujoco/simulate ../mujoco/sample \
-           ../mujoco/bin ../mujoco/doc ../mujoco/model
+    rm -rf ../mujoco/sample ../mujoco/bin ../mujoco/doc ../mujoco/model
+# include/ and simulate/ are deliberately kept (they used to be stripped here). Milestone 5
+# compiles our own sensor source into this app, and keeping them is what makes an
+# in-container rebuild possible -- CMakeLists globs mujoco/simulate/*.cc, so without them
+# every one-line change costs a full image rebuild. They are small; the bulk was
+# model/bin/doc/sample, still removed.
 # Binary at simulate/build/unitree_mujoco; g1_bringup overrides config via CLI flags.
 
 # --- CycloneDDS / ROS domain (unconditional -- required by Unitree SDK) -----

--- a/workspace/MUJOCO_LOG.TXT
+++ b/workspace/MUJOCO_LOG.TXT
@@ -1,3 +1,6 @@
 Sun Aug  2 23:48:38 2026
 ERROR: mj_ray: vector length is too small
 
+Sun Aug  2 23:55:09 2026
+ERROR: mj_ray: vector length is too small
+

--- a/workspace/MUJOCO_LOG.TXT
+++ b/workspace/MUJOCO_LOG.TXT
@@ -1,6 +1,0 @@
-Sun Aug  2 23:48:38 2026
-ERROR: mj_ray: vector length is too small
-
-Sun Aug  2 23:55:09 2026
-ERROR: mj_ray: vector length is too small
-

--- a/workspace/MUJOCO_LOG.TXT
+++ b/workspace/MUJOCO_LOG.TXT
@@ -1,0 +1,3 @@
+Sun Aug  2 23:48:38 2026
+ERROR: mj_ray: vector length is too small
+

--- a/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
+++ b/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
@@ -6,6 +6,12 @@ patch, so this stays a registration hook: an include, a thread start, and one
 source file added to the target. No new find_package: the sampler links nothing
 the app did not already link. simulate/src/unitree_sdk2_bridge.h is untouched.
 
+Also stops the sampler from both model-replacement paths (the viewer's Reload button and
+drag-and-drop), with a blocking join, before mj_deleteModel. The sampler reads the model
+outside sim.mtx by design -- a render or sweep under the lock would stall physics -- so no
+lock-based check can make freeing the model safe while it runs. It is not restarted
+afterwards; see g1_bringup's README for the limitation that remains.
+
 diff --git a/simulate/CMakeLists.txt b/simulate/CMakeLists.txt
 index 8870289..d8e59de 100644
 --- a/simulate/CMakeLists.txt
@@ -20,7 +26,7 @@ index 8870289..d8e59de 100644
  add_executable(jstest src/joystick/jstest.cc src/joystick/joystick.cc)
 \ No newline at end of file
 diff --git a/simulate/src/main.cc b/simulate/src/main.cc
-index 3368d91..ecc8c82 100755
+index 3368d91..dc8b854 100755
 --- a/simulate/src/main.cc
 +++ b/simulate/src/main.cc
 @@ -33,6 +33,7 @@
@@ -31,7 +37,29 @@ index 3368d91..ecc8c82 100755
  #include "param.h"
  
  #define MUJOCO_PLUGIN_DIR "mujoco_plugin"
-@@ -685,6 +686,11 @@ int main(int argc, char **argv)
+@@ -350,6 +351,10 @@ namespace
+         {
+           sim.Load(mnew, dnew, sim.dropfilename);
+ 
++          // Blocking join before the model is freed. The sampler touches the model
++          // outside sim.mtx by design, so nothing lock-based can make this safe.
++          grove_g1::StopSensorPublisher();
++
+           mj_deleteData(d);
+           mj_deleteModel(m);
+ 
+@@ -380,6 +385,10 @@ namespace
+         {
+           sim.Load(mnew, dnew, sim.filename);
+ 
++          // Blocking join before the model is freed. The sampler touches the model
++          // outside sim.mtx by design, so nothing lock-based can make this safe.
++          grove_g1::StopSensorPublisher();
++
+           mj_deleteData(d);
+           mj_deleteModel(m);
+ 
+@@ -685,6 +694,11 @@ int main(int argc, char **argv)
  
    std::thread unitree_thread(UnitreeSdk2BridgeThread, nullptr);
  

--- a/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
+++ b/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
@@ -1,0 +1,55 @@
+Registers grove-g1's sensor publisher in the vendored unitree_mujoco.
+
+Generated against unitree_mujoco ae6a8403e272733e9996ef59990880330496177f.
+The publisher's own source is COPYed in by the Dockerfile and is NOT part of this
+patch, so this stays a registration hook: an include, a thread start, and the build
+wiring. simulate/src/unitree_sdk2_bridge.h is deliberately untouched.
+
+diff --git a/simulate/CMakeLists.txt b/simulate/CMakeLists.txt
+index 8870289..61f7696 100644
+--- a/simulate/CMakeLists.txt
++++ b/simulate/CMakeLists.txt
+@@ -11,6 +11,9 @@ endif()
+ 
+ list(APPEND CMAKE_PREFIX_PATH "/opt/unitree_robotics/lib/cmake")
+ find_package(unitree_sdk2 REQUIRED)
++# grove-g1: sensor publishing for the converged perception track.
++find_package(rclcpp REQUIRED)
++find_package(sensor_msgs REQUIRED)
+ find_package(Boost REQUIRED COMPONENTS program_options)
+ 
+ 
+@@ -42,6 +45,7 @@ link_libraries(
+   fmt
+ )
+ 
+-add_executable(unitree_mujoco ${SIM_SRC} src/main.cc)
++add_executable(unitree_mujoco ${SIM_SRC} src/main.cc src/sensor_publisher.cc)
++target_link_libraries(unitree_mujoco rclcpp::rclcpp ${sensor_msgs_TARGETS})
+ 
+ add_executable(jstest src/joystick/jstest.cc src/joystick/joystick.cc)
+\ No newline at end of file
+diff --git a/simulate/src/main.cc b/simulate/src/main.cc
+index 3368d91..87eff03 100755
+--- a/simulate/src/main.cc
++++ b/simulate/src/main.cc
+@@ -33,6 +33,7 @@
+ #include "simulate.h"
+ #include "array_safety.h"
+ #include "unitree_sdk2_bridge.h"
++#include "sensor_publisher.h"
+ #include "param.h"
+ 
+ #define MUJOCO_PLUGIN_DIR "mujoco_plugin"
+@@ -685,6 +686,11 @@ int main(int argc, char **argv)
+ 
+   std::thread unitree_thread(UnitreeSdk2BridgeThread, nullptr);
+ 
++  // grove-g1: sensor thread for the converged perception track. A no-op unless
++  // GROVE_G1_SENSOR_CONFIG is set. Deliberately separate from the bridge thread
++  // above, whose 1 kHz callback writes the actuator commands.
++  grove_g1::StartSensorPublisher(&m, &d, &sim->mtx, argc, argv);
++
+   // start physics thread
+   std::thread physicsthreadhandle(&PhysicsThread, sim.get(), param::config.robot_scene.c_str());
+   // start simulation UI loop (blocking call)

--- a/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
+++ b/workspace/patches/unitree_mujoco/001-register-sensor-publisher.patch
@@ -1,36 +1,26 @@
-Registers grove-g1's sensor publisher in the vendored unitree_mujoco.
+Registers grove-g1's sensor sampler in the vendored unitree_mujoco.
 
 Generated against unitree_mujoco ae6a8403e272733e9996ef59990880330496177f.
-The publisher's own source is COPYed in by the Dockerfile and is NOT part of this
-patch, so this stays a registration hook: an include, a thread start, and the build
-wiring. simulate/src/unitree_sdk2_bridge.h is deliberately untouched.
+The sampler's own source is COPYed in by the Dockerfile and is NOT part of this
+patch, so this stays a registration hook: an include, a thread start, and one
+source file added to the target. No new find_package: the sampler links nothing
+the app did not already link. simulate/src/unitree_sdk2_bridge.h is untouched.
 
 diff --git a/simulate/CMakeLists.txt b/simulate/CMakeLists.txt
-index 8870289..61f7696 100644
+index 8870289..d8e59de 100644
 --- a/simulate/CMakeLists.txt
 +++ b/simulate/CMakeLists.txt
-@@ -11,6 +11,9 @@ endif()
- 
- list(APPEND CMAKE_PREFIX_PATH "/opt/unitree_robotics/lib/cmake")
- find_package(unitree_sdk2 REQUIRED)
-+# grove-g1: sensor publishing for the converged perception track.
-+find_package(rclcpp REQUIRED)
-+find_package(sensor_msgs REQUIRED)
- find_package(Boost REQUIRED COMPONENTS program_options)
- 
- 
-@@ -42,6 +45,7 @@ link_libraries(
+@@ -42,6 +42,6 @@ link_libraries(
    fmt
  )
  
 -add_executable(unitree_mujoco ${SIM_SRC} src/main.cc)
 +add_executable(unitree_mujoco ${SIM_SRC} src/main.cc src/sensor_publisher.cc)
-+target_link_libraries(unitree_mujoco rclcpp::rclcpp ${sensor_msgs_TARGETS})
  
  add_executable(jstest src/joystick/jstest.cc src/joystick/joystick.cc)
 \ No newline at end of file
 diff --git a/simulate/src/main.cc b/simulate/src/main.cc
-index 3368d91..87eff03 100755
+index 3368d91..ecc8c82 100755
 --- a/simulate/src/main.cc
 +++ b/simulate/src/main.cc
 @@ -33,6 +33,7 @@
@@ -46,9 +36,9 @@ index 3368d91..87eff03 100755
    std::thread unitree_thread(UnitreeSdk2BridgeThread, nullptr);
  
 +  // grove-g1: sensor thread for the converged perception track. A no-op unless
-+  // GROVE_G1_SENSOR_CONFIG is set. Deliberately separate from the bridge thread
-+  // above, whose 1 kHz callback writes the actuator commands.
-+  grove_g1::StartSensorPublisher(&m, &d, &sim->mtx, argc, argv);
++  // GROVE_G1_SENSOR_CONFIG is set. Loads no ROS and no DDS: unitree_sdk2 already
++  // owns the CycloneDDS domain in this process. Frames go to g1_sensor_relay.
++  grove_g1::StartSensorPublisher(&m, &d, &sim->mtx);
 +
    // start physics thread
    std::thread physicsthreadhandle(&PhysicsThread, sim.get(), param::config.robot_scene.c_str());

--- a/workspace/patches/unitree_mujoco/002-sdk-honour-cyclonedds-uri.patch
+++ b/workspace/patches/unitree_mujoco/002-sdk-honour-cyclonedds-uri.patch
@@ -1,0 +1,36 @@
+Let the SDK honour CYCLONEDDS_URI instead of building its own config
+
+With a non-empty `interface`, unitree_sdk2's ChannelFactory::Init builds an inline
+CycloneDDS config for that interface and creates the domain with it. That inline config
+replaces CYCLONEDDS_URI wholesale, so the container's /etc/cyclonedds/cyclonedds.xml never
+applies to the simulator -- including its MaxAutoParticipantIndex of 60. The simulator
+therefore fell back to Cyclone's default of 9.
+
+The simulator starts last in g1_bringup's sim.launch.py, after the relay, odometry,
+motion_service, robot_state_publisher, ros2_control_node and its controller spawners. When
+enough of those are still alive it finds indices 0-9 taken, and dies on startup with:
+
+    Failed to find a free participant index for domain 1
+    terminate called after throwing an instance of 'unitree::common::DdsException'
+
+It is a race, so it looks intermittent: the spawners are short-lived and usually gone
+before the simulator reaches DDS init.
+
+Leaving `interface` empty makes the SDK create the domain with the default config, which
+reads CYCLONEDDS_URI. The container's file pins the same `lo` interface, so the network
+behaviour is unchanged and only the index ceiling moves. sim.launch.py already refuses to
+start unless CYCLONEDDS_URI is set, so the fallback path cannot be silently missing.
+
+diff --git a/simulate/config.yaml b/simulate/config.yaml
+index 468a66b..a2db543 100644
+--- a/simulate/config.yaml
++++ b/simulate/config.yaml
+@@ -2,7 +2,7 @@ robot: "go2"  # Robot name, "go2", "b2", "b2w", "h1", "go2w", "g1", "h2"
+ robot_scene: "scene.xml" # Robot scene, /unitree_robots/[robot]/scene.xml 
+ 
+ domain_id: 1  # Domain id
+-interface: "lo" # Interface 
++interface: "" # Empty: use CYCLONEDDS_URI, which pins lo and raises MaxAutoParticipantIndex
+ 
+ use_joystick: 0 # Simulate Unitree WirelessController using a gamepad
+ joystick_type: "xbox" # support "xbox" and "switch" gamepad layout

--- a/workspace/patches/unitree_mujoco/002-sdk-honour-cyclonedds-uri.patch
+++ b/workspace/patches/unitree_mujoco/002-sdk-honour-cyclonedds-uri.patch
@@ -18,8 +18,16 @@ before the simulator reaches DDS init.
 
 Leaving `interface` empty makes the SDK create the domain with the default config, which
 reads CYCLONEDDS_URI. The container's file pins the same `lo` interface, so the network
-behaviour is unchanged and only the index ceiling moves. sim.launch.py already refuses to
-start unless CYCLONEDDS_URI is set, so the fallback path cannot be silently missing.
+behaviour is unchanged and only the index ceiling moves.
+
+What guarantees CYCLONEDDS_URI is present is `ENV CYCLONEDDS_URI` in .devcontainer/
+Dockerfile, set at image level, so it also covers running the simulator by hand outside
+sim.launch.py -- which is how the DDS failure was isolated in the first place. The launch
+file additionally checks that the URI names a file that exists, because CycloneDDS treats
+an unreadable URI as a stderr warning and falls back to defaults; with the compose file's
+network_mode: host that would bind the real NIC instead of lo and put rt/lowcmd on the
+LAN. Removing the code-level `interface: "lo"` fence is only safe with that check in
+place.
 
 diff --git a/simulate/config.yaml b/simulate/config.yaml
 index 468a66b..a2db543 100644

--- a/workspace/patches/unitree_mujoco/README.md
+++ b/workspace/patches/unitree_mujoco/README.md
@@ -1,0 +1,38 @@
+# unitree_mujoco patches
+
+Patches applied to the vendored `unitree_mujoco` source at image build time.
+
+## Why patch the vendor at all
+
+Sensor computation needs the **scene**: geometry, meshes, and current pose. That lives in `mjModel` /
+`mjData`, which are process-local globals inside `unitree_mujoco`. Unlike `/lowstate` and
+`rt/arm_sdk`, there is no DDS topic carrying it, so no companion process can reach it. A second
+process could load the same model and mirror joint state, but that is a second physics instance
+whose fidelity is bounded by its pose source — and the real G1 has no odometry topic at all, so that
+approach dies exactly at the hardware transition this track exists to protect.
+
+Full reasoning in `docs/notes/milestone5-convergence-plan.md` (local-only).
+
+## Rules
+
+- **All real logic goes in new files.** Vendor files get the smallest possible edit that registers
+  them. This keeps the reapply surface a few lines rather than a rewrite.
+- **`simulate/src/unitree_sdk2_bridge.h` is off limits.** Its `run()` is a 1 kHz callback that writes
+  `mj_data_->ctrl[]`, the actuator command path. Blocking it stalls robot control directly.
+- Each patch names the upstream SHA it was generated against, in its header.
+- Patches apply in filename order.
+
+## Updating the pin
+
+Bumping `UNITREE_MUJOCO_SHA` in `.devcontainer/Dockerfile` is a **two-part change**: the new SHA and
+regenerated patches. The build runs `git apply --check` first, so a patch that no longer applies
+**fails the image build** rather than silently producing a sim without sensors.
+
+To regenerate against a new SHA:
+
+```bash
+git clone https://github.com/unitreerobotics/unitree_mujoco.git /tmp/um
+cd /tmp/um && git checkout <NEW_SHA>
+# re-apply the changes by hand, then:
+git diff > /path/to/workspace/patches/unitree_mujoco/<NNN>-<name>.patch
+```

--- a/workspace/src/g1_bringup/CMakeLists.txt
+++ b/workspace/src/g1_bringup/CMakeLists.txt
@@ -163,7 +163,10 @@ if(BUILD_TESTING)
   # collisions across parallel ctest runs.
   find_package(launch_testing_ament_cmake REQUIRED)
   add_launch_test(test/test_sim_bringup.launch.py TARGET test_sim_bringup TIMEOUT 120)
+  # Converged sensor track. Own MuJoCo instance, so it shares the g1_bringup lock.
+  add_launch_test(test/test_lidar_geometry.launch.py TARGET test_lidar_geometry TIMEOUT 300)
   set_tests_properties(test_sim_bringup PROPERTIES RESOURCE_LOCK g1_sim)
+  set_tests_properties(test_lidar_geometry PROPERTIES RESOURCE_LOCK g1_sim)
   add_launch_test(test/test_arm_command.launch.py TARGET test_arm_command TIMEOUT 220)
   set_tests_properties(test_arm_command PROPERTIES RESOURCE_LOCK g1_sim)
   add_launch_test(test/test_loco.launch.py TARGET test_loco TIMEOUT 180)

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -10,7 +10,7 @@ that stands in for the robot's onboard motion service.
 
 | File | Purpose |
 |---|---|
-| `launch/sim.launch.py` | Main entry point. Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Args: `headless` (default `true`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
+| `launch/sim.launch.py` | Main entry point. Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Args: `headless` (default `true`), `sensors` (default `true`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
 | `launch/control.launch.py` | `robot_state_publisher`, `ros2_control_node` and spawners. No sim, no bridge, so it carries over to hardware unchanged. |
 | `launch/loco.launch.py` | Starts `g1_loco_bridge` and drives it configure to active off its own lifecycle events. |
 | `launch/activate_arm.launch.py` | Runs `scripts/activate_arm`, the ordered acquire step. |
@@ -29,6 +29,9 @@ that stands in for the robot's onboard motion service.
 | `/api/sport/response` | out | `unitree_api/msg/Response` | `QoS(1)` reliable, volatile |
 | `/joint_states` | out | `sensor_msgs/msg/JointState` | default, ~200 Hz |
 | `/robot_description` | out | `std_msgs/msg/String` | transient-local |
+| `/livox/lidar` | out | `sensor_msgs/msg/PointCloud2` | sensor data, `sensors:=true` only |
+| `/g1_sensor_relay/sensor_pose` | out | `geometry_msgs/msg/PoseStamped` | sensor data, diagnostics |
+| `/tf` (`odom` -> `pelvis`) | out | `tf2_msgs/msg/TFMessage` | `sensors:=true` only |
 
 ## Running
 
@@ -230,6 +233,37 @@ freshness, not on the FSM, so releasing locomotion authority stops the walking w
 robot. If inference goes stale the lower-body target freezes at the last policy output rather than
 reverting to the captured spawn pose, which would be a large step away from the stance the robot is
 actually in.
+
+## Sensors on the converged track: SIM-ONLY
+
+`sensors:=true` (the default) stages a room with known geometry, runs a LiDAR sweep **inside** the
+patched `unitree_mujoco`, and starts `g1_sensor_relay` to publish it as `PointCloud2` on
+`/livox/lidar`. `odom -> pelvis` comes from `g1_state_estimation` reading `/sportmodestate`.
+
+**Why the sweep lives inside the simulator.** It needs the scene: geometry, meshes and current pose,
+all of which live in `mjData` inside that process. No DDS topic carries it, so no companion process
+can compute it. The finished cloud is what crosses the boundary, over a local socket.
+
+**Why a separate node publishes it.** `unitree_sdk2` and `rmw_cyclonedds` both call
+`dds_create_domain` unconditionally, and CycloneDDS allows exactly one explicit domain creation per
+domain id per process. They cannot coexist, in either order. So the simulator links no ROS at all and
+the relay owns the ROS side.
+
+**Frame is `mid360_link`, not `livox_frame`.** `g1_sim`, the planar sandbox, publishes in
+`livox_frame` because that is `livox_ros_driver2`'s own default, so swapping sim for hardware is a
+driver launch rather than a pile of remaps. The converged track cannot do the same: the frame is not
+ours to name. It comes from Unitree's vendored URDF, which calls the link `mid360_link`, and
+renaming it means patching a description we otherwise consume verbatim. Adding a second link as an
+alias would put two frames on one physical sensor, which is worse.
+
+So the portability principle moves **one layer up**. The real driver's frame id is a launch
+parameter, so hardware bring-up sets `livox_ros_driver2`'s `frame_id` to `mid360_link` (or remaps at
+launch) instead of the sim contorting to match a default. Same guarantee at the swap, enforced at
+launch rather than in the model.
+
+**What is not validated here:** the Mid360's non-repetitive scan pattern (this is a uniform
+azimuth/elevation grid), intensity, per-point timestamps, noise, dropout and motion distortion. The
+depth camera is **not** on this track yet, see the milestone notes.
 
 ## Pelvis pin: debugging aid
 

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -10,7 +10,7 @@ that stands in for the robot's onboard motion service.
 
 | File | Purpose |
 |---|---|
-| `launch/sim.launch.py` | Main entry point. Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Args: `headless` (default `true`), `sensors` (default `true`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
+| `launch/sim.launch.py` | Main entry point. Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Args: `headless` (default `true`), `sensors` (default `false`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
 | `launch/control.launch.py` | `robot_state_publisher`, `ros2_control_node` and spawners. No sim, no bridge, so it carries over to hardware unchanged. |
 | `launch/loco.launch.py` | Starts `g1_loco_bridge` and drives it configure to active off its own lifecycle events. |
 | `launch/activate_arm.launch.py` | Runs `scripts/activate_arm`, the ordered acquire step. |
@@ -236,9 +236,18 @@ actually in.
 
 ## Sensors on the converged track: SIM-ONLY
 
-`sensors:=true` (the default) stages a room with known geometry, runs a LiDAR sweep **inside** the
-patched `unitree_mujoco`, and starts `g1_sensor_relay` to publish it as `PointCloud2` on
-`/livox/lidar`. `odom -> pelvis` comes from `g1_state_estimation` reading `/sportmodestate`.
+`sensors:=true` stages a room with known geometry, runs a LiDAR sweep **inside** the patched
+`unitree_mujoco`, and starts `g1_sensor_relay` to publish it as `PointCloud2` on `/livox/lidar`.
+`odom -> pelvis` comes from `g1_state_estimation` reading `/sportmodestate`.
+
+**It is off by default, provisionally.** With sensors on the walking suites pass, alone and under
+combined load, but `test_arm_command` misses its slew-limited convergence window. That was measured
+on a machine whose CPU was pinned at roughly 14% of peak clock (`powersave` governor, `quiet`
+platform profile), and the test is timing-sensitive, so the result is **unproven rather than a
+property of the sensor stack**. Re-measure on an unthrottled machine before drawing a conclusion.
+
+Keeping the default off in the meantime costs nothing: `test_lidar_geometry` enables sensors
+explicitly and passes, so the sensor path stays covered either way.
 
 **Why the sweep lives inside the simulator.** It needs the scene: geometry, meshes and current pose,
 all of which live in `mjData` inside that process. No DDS topic carries it, so no companion process

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -271,8 +271,28 @@ launch) instead of the sim contorting to match a default. Same guarantee at the 
 launch rather than in the model.
 
 **What is not validated here:** the Mid360's non-repetitive scan pattern (this is a uniform
-azimuth/elevation grid), intensity, per-point timestamps, noise, dropout and motion distortion. The
-depth camera is **not** on this track yet, see the milestone notes.
+azimuth/elevation grid), intensity, per-point timestamps, noise, dropout and motion distortion.
+
+### D435i
+
+Depth and colour come from **one** `mjr_render` of the `d435i` fixed camera, so they share a pose,
+a timestamp and intrinsics by construction. A real D435i only gets that alignment from its
+`align_depth_to_color` step, which is why the depth topic is named as if it had run.
+
+| Topic | Type | Notes |
+|---|---|---|
+| `/camera/aligned_depth_to_color/image_raw` | `Image` `32FC1` | metres; misses are NaN, not 0 |
+| `/camera/color/image_raw` | `Image` `rgb8` | |
+| `/camera/aligned_depth_to_color/camera_info`, `/camera/color/camera_info` | `CameraInfo` | same intrinsics; `fovy` is carried in the frame so they cannot drift from the MJCF |
+
+Published in `camera_depth_optical_frame` / `camera_color_optical_frame`, the REP-145 optical frames
+added by `g1_description`. **Not `d435_link`:** that is a body frame (x forward, y left, z up) and
+every depth consumer assumes the optical convention (z forward, x right, y down), so publishing in
+the link projects the cloud rotated 90 degrees.
+
+**What is not validated here:** depth noise, stereo dropout on textureless surfaces, IR projector
+behaviour, auto-exposure and colour response. One MuJoCo camera carries one set of intrinsics, so
+the colour stream matches the *depth* FOV rather than a real D435i's wider colour FOV.
 
 ## Pelvis pin: debugging aid
 

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -273,6 +273,26 @@ launch rather than in the model.
 **What is not validated here:** the Mid360's non-repetitive scan pattern (this is a uniform
 azimuth/elevation grid), intensity, per-point timestamps, noise, dropout and motion distortion.
 
+### Known limitation: the viewer's Reload button is fatal with `sensors:=true`
+
+**Clicking Reload (or dragging a model onto the window) while sensors are running kills the
+simulator with SIGSEGV. Relaunch instead.** Drag-and-drop takes the same code path and is
+equally unsafe.
+
+The sampler reads the model outside `sim.mtx` on purpose: a ~4.5 ms render or ~32 ms sweep
+under the lock would stall physics. The reload path frees the model on the main thread, so
+no lock-based check can make it safe. The reload hook therefore stops the sampler with a
+blocking join before `mj_deleteModel` and never restarts it, logging `SENSORS DISABLED`.
+That much is verified: the first reload after launch is survivable and stops sensors
+cleanly.
+
+**A second reload still crashes**, after the sampler is already stopped and none of this
+code runs. The cause was not identified. Restarting the sampler against the new model was
+tried and also faulted intermittently, so it was removed rather than shipped.
+
+Accepted rather than fixed: Reload is a debugging-only button, the workaround is to
+relaunch, and sensors do not survive a reload either way.
+
 ### D435i
 
 Depth and colour come from **one** `mjr_render` of the `d435i` fixed camera, so they share a pose,

--- a/workspace/src/g1_bringup/config/g1_sensors.rviz
+++ b/workspace/src/g1_bringup/config/g1_sensors.rviz
@@ -7,6 +7,7 @@ Panels:
       Expanded:
         - /LiDAR1
         - /Depth cloud1
+        - /Colour image1
       Splitter Ratio: 0.5
     Tree Height: 700
   - Class: rviz_common/Views
@@ -81,8 +82,8 @@ Visualization Manager:
       Size (Pixels): 3
       Alpha: 1
       Decay Time: 0
-      Color Transformer: AxisColor
-      Axis: Z
+      Color Image Topic: /camera/color/image_raw
+      Color Transformer: RGB8
       Occlusion Compensation:
         Occlusion Time-Out: 30
         Enabled: false
@@ -101,6 +102,17 @@ Visualization Manager:
       Min Value: 0.5
       Median window: 5
       Normalize Range: false
+
+    # Colour from the same render as the depth above, so the two line up pixel for pixel.
+    - Class: rviz_default_plugins/Image
+      Name: Colour image
+      Enabled: true
+      Topic:
+        Value: /camera/color/image_raw
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Normalize Range: true
 
     - Class: rviz_default_plugins/Odometry
       Name: Odometry

--- a/workspace/src/g1_bringup/config/g1_sensors.rviz
+++ b/workspace/src/g1_bringup/config/g1_sensors.rviz
@@ -1,0 +1,132 @@
+# RViz for the converged sensor track.
+#   ros2 launch g1_bringup sim.launch.py sensors:=true rviz:=true
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /LiDAR1
+      Splitter Ratio: 0.5
+    Tree Height: 700
+  - Class: rviz_common/Views
+    Name: Views
+Visualization Manager:
+  Class: ""
+  Name: root
+  Displays:
+    - Class: rviz_default_plugins/Grid
+      Name: Grid
+      Enabled: true
+      Cell Size: 1
+      Plane Cell Count: 20
+      Color: 160; 160; 164
+      Alpha: 0.3
+      Reference Frame: <Fixed Frame>
+
+    # The robot. Needs pelvis -> torso_link, which motion_service_sim supplies from
+    # /lowstate; joint_state_broadcaster only covers the arms.
+    - Class: rviz_default_plugins/RobotModel
+      Name: RobotModel
+      Enabled: true
+      Description Topic:
+        Value: /robot_description
+        Depth: 5
+        Durability Policy: Transient Local
+        Reliability Policy: Reliable
+      Alpha: 1
+      Visual Enabled: true
+      Collision Enabled: false
+
+    - Class: rviz_default_plugins/TF
+      Name: TF
+      Enabled: false
+      Show Names: true
+      Show Axes: true
+      Show Arrows: false
+      Marker Scale: 0.3
+
+    # Sampled inside unitree_mujoco, published by g1_sensor_relay. Best-effort to match
+    # the publisher: a Reliable subscriber here shows nothing at all.
+    - Class: rviz_default_plugins/PointCloud2
+      Name: LiDAR
+      Enabled: true
+      Topic:
+        Value: /livox/lidar
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Style: Points
+      Size (Pixels): 2
+      Alpha: 1
+      Decay Time: 0
+      Position Transformer: XYZ
+      Color Transformer: AxisColor
+      Axis: Z
+      Autocompute Intensity Bounds: true
+      Invert Rainbow: false
+
+    - Class: rviz_default_plugins/Odometry
+      Name: Odometry
+      Enabled: true
+      Topic:
+        Value: /g1_odometry_publisher/odom
+        Depth: 10
+        Durability Policy: Volatile
+        Reliability Policy: Reliable
+      Keep: 100
+      Position Tolerance: 0.1
+      Angle Tolerance: 0.1
+      Shape:
+        Value: Arrow
+        Alpha: 1
+        Color: 255; 85; 0
+        Shaft Length: 0.3
+        Shaft Radius: 0.03
+        Head Length: 0.1
+        Head Radius: 0.06
+
+    # Where the simulator says the sensor is. Diagnostic: it is the ground truth the
+    # cloud was swept from, so it should sit exactly on the robot's Mid360.
+    - Class: rviz_default_plugins/Pose
+      Name: Sensor pose
+      Enabled: false
+      Topic:
+        Value: /g1_sensor_relay/sensor_pose
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Shape: Axes
+      Axes Length: 0.3
+      Axes Radius: 0.02
+
+  Global Options:
+    # odom, not mid360_link: the cloud is published in the sensor frame and RViz transforms
+    # it here, which only works because odom -> pelvis -> torso_link -> mid360_link is now
+    # complete.
+    Fixed Frame: odom
+    Background Color: 48; 48; 48
+    Frame Rate: 30
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Name: Current View
+      Distance: 12
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0.8
+      Pitch: 0.6
+      Yaw: 2.4
+      Target Frame: <Fixed Frame>
+      Near Clip Distance: 0.01
+Window Geometry:
+  Height: 900
+  Width: 1400
+  Displays:
+    collapsed: false
+  Views:
+    collapsed: false

--- a/workspace/src/g1_bringup/config/g1_sensors.rviz
+++ b/workspace/src/g1_bringup/config/g1_sensors.rviz
@@ -6,6 +6,7 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /LiDAR1
+        - /Depth cloud1
       Splitter Ratio: 0.5
     Tree Height: 700
   - Class: rviz_common/Views
@@ -64,6 +65,42 @@ Visualization Manager:
       Axis: Z
       Autocompute Intensity Bounds: true
       Invert Rainbow: false
+
+    # Depth as a 3D cloud, projected through camera_info. This is the camera's own view
+    # of the world, so it should overlap the LiDAR returns where the two see the same
+    # surfaces; if it floats away from them, the mount or the depth scale is wrong.
+    - Class: rviz_default_plugins/DepthCloud
+      Name: Depth cloud
+      Enabled: true
+      Topic Filter: false
+      Depth Map Topic: /camera/aligned_depth_to_color/image_raw
+      Depth Map Transport Hint: raw
+      Color Transport Hint: raw
+      Queue Size: 5
+      Style: Points
+      Size (Pixels): 3
+      Alpha: 1
+      Decay Time: 0
+      Color Transformer: AxisColor
+      Axis: Z
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Enabled: false
+
+    # The same data as a 2D panel, which is the quickest way to see that the camera is
+    # pointed where you think and is not returning a blank frame.
+    - Class: rviz_default_plugins/Image
+      Name: Depth image
+      Enabled: true
+      Topic:
+        Value: /camera/aligned_depth_to_color/image_raw
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Max Value: 4
+      Min Value: 0.5
+      Median window: 5
+      Normalize Range: false
 
     - Class: rviz_default_plugins/Odometry
       Name: Odometry

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -21,3 +21,4 @@ socket_path: "/tmp/g1_sensors.sock"
 # linearised to metres before it leaves the simulator. S3 measured ~3.9 ms/frame with only
 # ~0.01 ms holding the sim lock.
 camera_enabled: true
+camera_color: true

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -1,0 +1,10 @@
+# Sensor thread inside unitree_mujoco. Read via GROVE_G1_SENSOR_CONFIG; if that variable
+# is unset the patched binary behaves exactly like the stock one, which is why the
+# locomotion suites are unaffected until they opt in.
+enabled: true
+
+# A full 360x32 sweep costs ~32 ms against the G1 scene (74 geoms, 36 meshes), so this
+# runs on its own thread and the rate is a real budget, not a formality.
+rate_hz: 10.0
+
+node_name: "g1_sim_sensors"

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -16,3 +16,8 @@ range_max: 40.0
 
 # Also passed to g1_sensor_relay by the launch, so there is one source of truth.
 socket_path: "/tmp/g1_sensors.sock"
+
+# Depth camera. Rendered offscreen on the sensor thread against its own snapshot, then
+# linearised to metres before it leaves the simulator. S3 measured ~3.9 ms/frame with only
+# ~0.01 ms holding the sim lock.
+camera_enabled: true

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -1,10 +1,18 @@
-# Sensor thread inside unitree_mujoco. Read via GROVE_G1_SENSOR_CONFIG; if that variable
-# is unset the patched binary behaves exactly like the stock one, which is why the
+# Sensor sampling inside unitree_mujoco. Read via GROVE_G1_SENSOR_CONFIG; with that
+# variable unset the patched binary behaves exactly like the stock one, which is why the
 # locomotion suites are unaffected until they opt in.
+#
+# The simulator loads no ROS and no DDS: unitree_sdk2 already owns the CycloneDDS domain in
+# that process. Frames go over the socket below to g1_sensor_relay, which publishes them.
 enabled: true
 
-# A full 360x32 sweep costs ~32 ms against the G1 scene (74 geoms, 36 meshes), so this
-# runs on its own thread and the rate is a real budget, not a formality.
+# A full 360x32 sweep costs ~32 ms against the G1 scene (74 geoms, 36 meshes), so this is a
+# real budget. It runs on its own thread and never blocks physics or the 1 kHz control path,
+# but it still costs a core; the timing gate decides what ships.
 rate_hz: 10.0
+azimuth_steps: 360
+elevation_steps: 32
+range_max: 40.0
 
-node_name: "g1_sim_sensors"
+# Also passed to g1_sensor_relay by the launch, so there is one source of truth.
+socket_path: "/tmp/g1_sensors.sock"

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -18,7 +18,8 @@ range_max: 40.0
 socket_path: "/tmp/g1_sensors.sock"
 
 # Depth camera. Rendered offscreen on the sensor thread against its own snapshot, then
-# linearised to metres before it leaves the simulator. S3 measured ~3.9 ms/frame with only
-# ~0.01 ms holding the sim lock.
+# linearised to metres before it leaves the simulator. Measured 7.9 ms/frame depth-only and
+# 11.5 ms with colour, of which only ~0.04 ms holds the sim lock; the rest is the render and
+# the socket write, both off-lock.
 camera_enabled: true
 camera_color: true

--- a/workspace/src/g1_bringup/include/g1_bringup/motion_service_sim_node.hpp
+++ b/workspace/src/g1_bringup/include/g1_bringup/motion_service_sim_node.hpp
@@ -20,6 +20,7 @@
 #include "g1_bringup/walk_policy.hpp"
 #include "g1_bringup/walk_policy_session.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
 #include "unitree_api/msg/request.hpp"
 #include "unitree_api/msg/response.hpp"
 #include "unitree_go/msg/sport_mode_state.hpp"
@@ -87,7 +88,19 @@ private:
     rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr lowstate_sub_;
     rclcpp::Subscription<unitree_hg::msg::LowCmd>::SharedPtr   arm_sdk_sub_;
     rclcpp::Publisher<unitree_hg::msg::LowCmd>::SharedPtr      lowcmd_pub_;
-    rclcpp::TimerBase::SharedPtr                               publish_timer_;
+    /// Lower-body joint states. joint_state_broadcaster only publishes the arms,
+    /// because the hardware interface is arm-only; without these
+    /// robot_state_publisher cannot connect pelvis to torso_link and every frame
+    /// above the waist, sensors included, is stranded in its own TF tree.
+    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr lower_joint_pub_;
+    /// Names filled once; only the numbers change per sample.
+    sensor_msgs::msg::JointState lower_joint_msg_;
+    /// /lowstate arrives at ~1 kHz. Publishing joint states that fast is pure
+    /// waste next to joint_state_broadcaster's ~200 Hz, and it measurably
+    /// disturbed bring-up, so it is decimated.
+    int                          lower_joint_decimate_ = 0;
+    bool                         publish_lower_joints_ = false;
+    rclcpp::TimerBase::SharedPtr publish_timer_;
 
     /// Base linear velocity for the policy observation. /lowstate carries no such field -- the
     /// sim's own bridge publishes it here from the pelvis `frame_vel` sensor. This is precisely

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -112,12 +112,14 @@ def _launch_setup(context, *args, **kwargs):
     # the sensor assertions measure against. Selected separately from pin_pelvis because a
     # pinned pelvis and a walking robot both want sensors eventually.
     sensors = LaunchConfiguration("sensors").perform(context).lower() == "true"
-    if pin_pelvis:
-        overlay_name = "g1_pinned_scene.xml"
-    elif sensors:
-        overlay_name = "g1_perception_scene.xml"
+    # The two options compose: pinning is orthogonal to whether sensors run, and the
+    # geometry tests want both at once (a known robot pose in a known room).
+    if sensors:
+        overlay_name = (
+            "g1_perception_pinned_scene.xml" if pin_pelvis else "g1_perception_scene.xml"
+        )
     else:
-        overlay_name = "g1_flat_scene.xml"
+        overlay_name = "g1_pinned_scene.xml" if pin_pelvis else "g1_flat_scene.xml"
     staged_path  = os.path.join(G1_MODEL_DIR, STAGED_SCENE_NAME)
     overlay_src  = os.path.join(
         get_package_share_directory("g1_bringup"), "mjcf", overlay_name

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -106,7 +106,17 @@ def _launch_setup(context, *args, **kwargs):
 
     # Stage one of our scenes (bare floor). The vendored obstacle course spawns the robot
     # among obstacles that look like balance failures.
-    overlay_name = "g1_pinned_scene.xml" if pin_pelvis else "g1_flat_scene.xml"
+    #
+    # The perception scene is the same floor plus a room with known geometry, which is what
+    # the sensor assertions measure against. Selected separately from pin_pelvis because a
+    # pinned pelvis and a walking robot both want sensors eventually.
+    sensors = LaunchConfiguration("sensors").perform(context).lower() == "true"
+    if pin_pelvis:
+        overlay_name = "g1_pinned_scene.xml"
+    elif sensors:
+        overlay_name = "g1_perception_scene.xml"
+    else:
+        overlay_name = "g1_flat_scene.xml"
     staged_path  = os.path.join(G1_MODEL_DIR, STAGED_SCENE_NAME)
     overlay_src  = os.path.join(
         get_package_share_directory("g1_bringup"), "mjcf", overlay_name
@@ -185,6 +195,13 @@ def generate_launch_description():
                 "headless",
                 default_value="true",
                 description="Run unitree_mujoco against our own managed Xvfb (no GUI window).",
+            ),
+            DeclareLaunchArgument(
+                "sensors",
+                default_value="false",
+                description="Stage the perception scene (a room with known geometry) and "
+                "run the sensor thread. Off by default so the locomotion suites keep their "
+                "existing bare-floor conditions until the timing gate says otherwise.",
             ),
             DeclareLaunchArgument(
                 "pin_pelvis",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -124,6 +124,13 @@ def _launch_setup(context, *args, **kwargs):
     shutil.copyfile(overlay_src, staged_path)
     sim_cmd = [UNITREE_MUJOCO_BIN, "-r", "g1", "-s", STAGED_SCENE_NAME]
 
+    # The patched unitree_mujoco starts its sensor thread only when this names a config,
+    # so the stock code path is what runs unless sensors are asked for explicitly.
+    if sensors:
+        sim_env["GROVE_G1_SENSOR_CONFIG"] = os.path.join(
+            get_package_share_directory("g1_bringup"), "config", "sim_sensors.yaml"
+        )
+
     def _remove_staged_scene(context, *a, **k):
         try:
             os.remove(staged_path)

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -169,7 +169,10 @@ def _launch_setup(context, *args, **kwargs):
                 "odometry_source": "sim_sportmodestate",
                 "base_frame_id": "pelvis",
             }],
-            remappings=[("~/sport_state", "/sportmodestate")],
+            remappings=[
+                ("~/sport_state", "/sportmodestate"),
+                ("~/imu_state", "/lowstate"),
+            ],
         )
         actions.append(odometry_node)
         actions.append(

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -226,10 +226,12 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "sensors",
-                default_value="false",
-                description="Stage the perception scene (a room with known geometry) and "
-                "run the sensor thread. Off by default so the locomotion suites keep their "
-                "existing bare-floor conditions until the timing gate says otherwise.",
+                default_value="true",
+                description="Stage the perception scene (a room with known geometry), run "
+                "the LiDAR sweep inside the simulator, and start g1_sensor_relay to publish "
+                "it. On by default: the walking suites pass with it, alone and under "
+                "combined load, which is what convergence was for. Set false to get the "
+                "bare-floor stack back.",
             ),
             DeclareLaunchArgument(
                 "pin_pelvis",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -7,6 +7,7 @@ the domain/DDS story, and the sim-bridge safety banner.
 
 import os
 import shutil
+import yaml
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -126,9 +127,27 @@ def _launch_setup(context, *args, **kwargs):
 
     # The patched unitree_mujoco starts its sensor thread only when this names a config,
     # so the stock code path is what runs unless sensors are asked for explicitly.
+    sensor_config = os.path.join(
+        get_package_share_directory("g1_bringup"), "config", "sim_sensors.yaml"
+    )
     if sensors:
-        sim_env["GROVE_G1_SENSOR_CONFIG"] = os.path.join(
-            get_package_share_directory("g1_bringup"), "config", "sim_sensors.yaml"
+        # The patched binary starts its sensor thread only when this names a config, so the
+        # stock code path is what runs unless sensors are asked for explicitly.
+        sim_env["GROVE_G1_SENSOR_CONFIG"] = sensor_config
+
+        # The relay owns the ROS side. Start order does not matter: it listens whenever it
+        # comes up and the simulator retries connecting every cycle, so either process can
+        # start, die or restart independently.
+        with open(sensor_config) as sensor_file:
+            socket_path = yaml.safe_load(sensor_file)["socket_path"]
+        actions.append(
+            Node(
+                package="g1_sensor_relay",
+                executable="g1_sensor_relay",
+                name="g1_sensor_relay",
+                output="both",
+                parameters=[{"socket_path": socket_path, "frame_id": "mid360_link"}],
+            )
         )
 
     def _remove_staged_scene(context, *a, **k):

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -159,9 +159,8 @@ def _launch_setup(context, *args, **kwargs):
                 parameters=[{
                     "socket_path": socket_path,
                     "frame_id": "mid360_link",
-                    # The URDF has d435_link but no optical frame, so the depth image is
-                    # published in the link itself until g1_description grows one.
-                    "depth_frame_id": "d435_link",
+                    "depth_frame_id": "camera_depth_optical_frame",
+                    "color_frame_id": "camera_color_optical_frame",
                     "world_frame_id": "odom",
                 }],
             )

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -156,7 +156,14 @@ def _launch_setup(context, *args, **kwargs):
                 executable="g1_sensor_relay",
                 name="g1_sensor_relay",
                 output="both",
-                parameters=[{"socket_path": socket_path, "frame_id": "mid360_link"}],
+                parameters=[{
+                    "socket_path": socket_path,
+                    "frame_id": "mid360_link",
+                    # The URDF has d435_link but no optical frame, so the depth image is
+                    # published in the link itself until g1_description grows one.
+                    "depth_frame_id": "d435_link",
+                    "world_frame_id": "odom",
+                }],
             )
         )
 

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -278,12 +278,16 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "sensors",
-                default_value="true",
+                default_value="false",
                 description="Stage the perception scene (a room with known geometry), run "
                 "the LiDAR sweep inside the simulator, and start g1_sensor_relay to publish "
-                "it. On by default: the walking suites pass with it, alone and under "
-                "combined load, which is what convergence was for. Set false to get the "
-                "bare-floor stack back.",
+                "it.\n"
+                "OFF by default, provisionally. test_arm_command missed its slew-limited "
+                "convergence window with sensors on, but that was measured on a CPU pinned "
+                "at ~14% of its peak clock, and the test is timing-sensitive. Treat the "
+                "result as unproven, not as a property of the sensor stack. Opt-in until it "
+                "is re-measured on an unthrottled machine. test_lidar_geometry, which is "
+                "pure geometry, turns sensors on explicitly and passes.",
             ),
             DeclareLaunchArgument(
                 "pin_pelvis",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -115,12 +115,17 @@ def _launch_setup(context, *args, **kwargs):
     # the sensor assertions measure against. Selected separately from pin_pelvis because a
     # pinned pelvis and a walking robot both want sensors eventually.
     sensors = LaunchConfiguration("sensors").perform(context).lower() == "true"
-    # The two options compose: pinning is orthogonal to whether sensors run, and the
-    # geometry tests want both at once (a known robot pose in a known room).
-    if sensors:
-        overlay_name = (
-            "g1_perception_pinned_scene.xml" if pin_pelvis else "g1_perception_scene.xml"
+    # World and pinning compose: pinning is orthogonal to which room the robot is in, and
+    # the geometry test wants both at once (a known robot pose in a known room).
+    world = LaunchConfiguration("world").perform(context)
+    if world not in ("navigation", "perception"):
+        raise RuntimeError(
+            f"world:={world!r} is not a scene. Use 'navigation' (the multi-room facility) "
+            "or 'perception' (the small room the geometry test measures against)."
         )
+    if sensors:
+        suffix       = "_pinned" if pin_pelvis else ""
+        overlay_name = f"g1_{world}{suffix}_scene.xml"
     else:
         overlay_name = "g1_pinned_scene.xml" if pin_pelvis else "g1_flat_scene.xml"
     staged_path  = os.path.join(G1_MODEL_DIR, STAGED_SCENE_NAME)
@@ -159,6 +164,22 @@ def _launch_setup(context, *args, **kwargs):
         # unitree_mujoco fills from framepos/framelinvel on the pelvis imu site, so it is
         # exact MuJoCo state. base_height_m stays 0: unlike the planar sandbox, a walking
         # robot's height is measured, not assumed.
+        if LaunchConfiguration("rviz").perform(context).lower() == "true":
+            actions.append(
+                Node(
+                    package="rviz2",
+                    executable="rviz2",
+                    name="rviz2",
+                    output="log",
+                    arguments=[
+                        "-d",
+                        os.path.join(
+                            get_package_share_directory("g1_bringup"), "config", "g1_sensors.rviz"
+                        ),
+                    ],
+                )
+            )
+
         odometry_node = LifecycleNode(
             package="g1_state_estimation",
             executable="g1_odometry_publisher",
@@ -241,6 +262,9 @@ def _launch_setup(context, *args, **kwargs):
                 get_package_share_directory("g1_bringup"), "config", "motion_service_sim.yaml"
             ),
             os.path.join(get_package_share_directory("g1_bringup"), "config", "walk_policy.yaml"),
+            # Completes pelvis -> torso_link so the sensor frames are not stranded in their
+            # own TF tree. Only when sensors run: it costs work on the 1 kHz /lowstate path.
+            {"publish_lower_joint_states": sensors},
             {"walk_policy.enabled": not pin_pelvis},
         ],
     )
@@ -278,6 +302,20 @@ def generate_launch_description():
                 "headless",
                 default_value="true",
                 description="Run unitree_mujoco against our own managed Xvfb (no GUI window).",
+            ),
+            DeclareLaunchArgument(
+                "world",
+                default_value="navigation",
+                description="Which room to stage, when sensors are on. 'navigation' is the "
+                "multi-room facility with furniture, shelving, pillars and a ramp. "
+                "'perception' is the small bare room whose wall positions test_lidar_geometry "
+                "asserts against; use it for tests, not for looking at things.",
+            ),
+            DeclareLaunchArgument(
+                "rviz",
+                default_value="false",
+                description="Open RViz on config/g1_sensors.rviz with the cloud, TF, robot "
+                "model and odometry already set up.",
             ),
             DeclareLaunchArgument(
                 "sensors",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -67,11 +67,26 @@ def _check_environment(context, *args, **kwargs):
             "the Unitree SDK/sim only speak CycloneDDS."
         )
 
-    if not os.environ.get("CYCLONEDDS_URI"):
+    cyclone_uri = os.environ.get("CYCLONEDDS_URI")
+    if not cyclone_uri:
         problems.append(
             "CYCLONEDDS_URI is unset -- expected the container-baked cyclonedds.xml "
             "pinning the 'lo' interface (see .devcontainer/Dockerfile)."
         )
+    elif cyclone_uri.startswith("file://"):
+        # Existence, not just non-emptiness. CycloneDDS treats an unreadable URI as a
+        # warning on stderr and falls back to its defaults, which with the compose file's
+        # network_mode: host means binding the real NIC instead of lo. The sim's
+        # rt/lowcmd and rt/arm_sdk would then be on the LAN on domain 1, within reach of a
+        # real G1. The simulator relies on this file too: its own config sets an empty
+        # interface so the SDK reads CYCLONEDDS_URI (see patches/unitree_mujoco/002).
+        cyclone_path = cyclone_uri[len("file://") :]
+        if not os.path.isfile(cyclone_path):
+            problems.append(
+                f"CYCLONEDDS_URI points at {cyclone_path!r}, which does not exist -- "
+                "CycloneDDS would silently fall back to defaults and bind the host NIC "
+                "instead of 'lo'."
+            )
 
     domain_id = os.environ.get("ROS_DOMAIN_ID")
     if domain_id != "1":
@@ -141,8 +156,6 @@ def _launch_setup(context, *args, **kwargs):
         get_package_share_directory("g1_bringup"), "config", "sim_sensors.yaml"
     )
     if sensors:
-        # The patched binary starts its sensor thread only when this names a config, so the
-        # stock code path is what runs unless sensors are asked for explicitly.
         sim_env["GROVE_G1_SENSOR_CONFIG"] = sensor_config
 
         # The relay owns the ROS side. Start order does not matter: it listens whenever it
@@ -166,10 +179,8 @@ def _launch_setup(context, *args, **kwargs):
             )
         )
 
-        # odom -> pelvis for the converged track. The source is /sportmodestate, which
-        # unitree_mujoco fills from framepos/framelinvel on the pelvis imu site, so it is
-        # exact MuJoCo state. base_height_m stays 0: unlike the planar sandbox, a walking
-        # robot's height is measured, not assumed.
+        # rviz only makes sense with sensors up, which is why it lives inside this branch:
+        # the shipped config's displays are all sensor topics.
         if LaunchConfiguration("rviz").perform(context).lower() == "true":
             actions.append(
                 Node(
@@ -186,6 +197,10 @@ def _launch_setup(context, *args, **kwargs):
                 )
             )
 
+        # odom -> pelvis for the converged track. The source is /sportmodestate, which
+        # unitree_mujoco fills from framepos/framelinvel on the pelvis imu site, so it is
+        # exact MuJoCo state. base_height_m stays 0: unlike the planar sandbox, a walking
+        # robot's height is measured, not assumed.
         odometry_node = LifecycleNode(
             package="g1_state_estimation",
             executable="g1_odometry_publisher",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -20,11 +20,14 @@ from launch.actions import (
     RegisterEventHandler,
     TimerAction,
 )
-from launch.event_handlers import OnProcessExit, OnShutdown
-from launch.events import Shutdown
+from launch.event_handlers import OnProcessExit, OnProcessStart, OnShutdown
+from launch.events import Shutdown, matches_action
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import Node
+from lifecycle_msgs.msg import Transition
+from launch_ros.actions import LifecycleNode, Node
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.events.lifecycle import ChangeState
 
 UNITREE_MUJOCO_BIN = "/opt/unitree_robotics/unitree_mujoco/simulate/build/unitree_mujoco"
 
@@ -149,6 +152,55 @@ def _launch_setup(context, *args, **kwargs):
                 name="g1_sensor_relay",
                 output="both",
                 parameters=[{"socket_path": socket_path, "frame_id": "mid360_link"}],
+            )
+        )
+
+        # odom -> pelvis for the converged track. The source is /sportmodestate, which
+        # unitree_mujoco fills from framepos/framelinvel on the pelvis imu site, so it is
+        # exact MuJoCo state. base_height_m stays 0: unlike the planar sandbox, a walking
+        # robot's height is measured, not assumed.
+        odometry_node = LifecycleNode(
+            package="g1_state_estimation",
+            executable="g1_odometry_publisher",
+            name="g1_odometry_publisher",
+            namespace="",
+            output="both",
+            parameters=[{
+                "odometry_source": "sim_sportmodestate",
+                "base_frame_id": "pelvis",
+            }],
+            remappings=[("~/sport_state", "/sportmodestate")],
+        )
+        actions.append(odometry_node)
+        actions.append(
+            RegisterEventHandler(
+                OnProcessStart(
+                    target_action=odometry_node,
+                    on_start=[
+                        EmitEvent(
+                            event=ChangeState(
+                                lifecycle_node_matcher=matches_action(odometry_node),
+                                transition_id=Transition.TRANSITION_CONFIGURE,
+                            )
+                        )
+                    ],
+                )
+            )
+        )
+        actions.append(
+            RegisterEventHandler(
+                OnStateTransition(
+                    target_lifecycle_node=odometry_node,
+                    goal_state="inactive",
+                    entities=[
+                        EmitEvent(
+                            event=ChangeState(
+                                lifecycle_node_matcher=matches_action(odometry_node),
+                                transition_id=Transition.TRANSITION_ACTIVATE,
+                            )
+                        )
+                    ],
+                )
             )
         )
 

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
@@ -227,6 +227,11 @@
     <camera name="corridor_hub" pos="-3.5 0 2.2" xyaxes="0 1 0 -0.25 0 0.96" fovy="60"/>
     <!-- Tracking Camera Following Unitree G1 -->
     <camera name="robot_cam" pos="2.5 -2.5 2.2" xyaxes="0.707 0.707 0 -0.3 0.3 0.9" fovy="55"/>
+
+    <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes
+         cam_xpos/cam_xmat into its own snapshot every frame from torso_link's live pose,
+         because the mount belongs to the vendored robot and cannot host a camera element. -->
+    <camera name="d435i" mode="fixed" fovy="58" resolution="848 480" pos="0 0 1"/>
   </worldbody>
 
   <equality>

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
@@ -1,0 +1,237 @@
+<mujoco model="g1_navigation_pinned_scene">
+  <!--
+    Adapted from the user's scene_navigation.xml for the converged sensor track. Two
+    changes only:
+      * includes the vendored g1_29dof.xml rather than g1_rl.xml, since unitree_mujoco
+        stages scenes against its own model directory;
+      * every geom carries group="3", because the LiDAR sweep masks to that group so the
+        robot's own collision shell cannot occlude the world.
+    Staged into the vendored model directory at launch, so relative includes resolve.
+
+    Original header follows.
+  --><!--
+    Unitree G1 Enhanced Multi-Room Facility World Environment
+    Features:
+      1. 4-Room Partitioned Facility (18m x 18m) with central corridor doorways.
+      2. Pick-and-Place Manipulation Lab: Workbench with target objects
+         (Red Cube, Green Cylinder, Blue Sphere, Yellow Box, Sorting Tray).
+      3. Storage Bay: Multi-tier shelving units & stacked cargo crates.
+      4. Navigation Zone: Structural pillars, slalom hurdles, and low ramp.
+      5. Control Hub: Desks, equipment, and resting area.
+      6. Offscreen Cameras: facility_overview, manipulation_lab, storage_bay, robot_cam.
+  -->
+
+  <include file="g1_29dof.xml"/>
+
+  <statistic center="0 0 0.8" extent="8"/>
+
+  <visual>
+    <headlight diffuse="0.5 0.5 0.5" ambient="0.3 0.3 0.3" specular="0.2 0.2 0.2"/>
+    <rgba haze="0.15 0.2 0.25 1"/>
+    <global azimuth="120" elevation="-20" offwidth="1920" offheight="1080"/>
+  </visual>
+
+  <asset>
+    <!-- Skybox -->
+    <texture type="skybox" builtin="gradient" rgb1="0.2 0.3 0.42" rgb2="0.05 0.05 0.1"
+             width="512" height="3072"/>
+    <!-- Floor Tile Texture -->
+    <texture type="2d" name="floor_tile" builtin="checker"
+             rgb1="0.78 0.80 0.84" rgb2="0.62 0.65 0.70"
+             width="512" height="512"/>
+    <material name="floor_mat" texture="floor_tile" texuniform="true"
+              texrepeat="12 12" reflectance="0.18"/>
+
+    <!-- Room Wall Materials -->
+    <material name="wall_outer" rgba="0.85 0.85 0.82 1" specular="0.1" shininess="0.2"/>
+    <material name="wall_inner" rgba="0.72 0.75 0.80 1" specular="0.15" shininess="0.3"/>
+
+    <!-- Furniture & Equipment Materials -->
+    <material name="wood_desk" rgba="0.55 0.35 0.2 1" specular="0.4" shininess="0.5"/>
+    <material name="metal_gray" rgba="0.35 0.38 0.42 1" specular="0.6" shininess="0.7"/>
+    <material name="shelf_blue" rgba="0.2 0.35 0.6 1" specular="0.5" shininess="0.6"/>
+    <material name="crate_orange" rgba="0.85 0.42 0.1 1" specular="0.3" shininess="0.4"/>
+    <material name="crate_darkblue" rgba="0.15 0.32 0.6 1" specular="0.3" shininess="0.4"/>
+    <material name="pillar_mat" rgba="0.3 0.32 0.35 1" specular="0.4" shininess="0.5"/>
+    <material name="ramp_mat" rgba="0.25 0.55 0.35 1" specular="0.2" shininess="0.3"/>
+
+    <!-- Pick & Place Object Materials -->
+    <material name="mat_red_obj" rgba="0.9 0.15 0.15 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_green_obj" rgba="0.15 0.8 0.2 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_blue_obj" rgba="0.15 0.3 0.9 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_yellow_obj" rgba="0.95 0.8 0.1 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_tray" rgba="0.3 0.3 0.35 1" specular="0.4" shininess="0.5"/>
+  </asset>
+
+  <worldbody>
+    <!-- Ground Plane -->
+    <geom group="3" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
+          contype="1" conaffinity="1"/>
+
+    <!-- Ceiling Lights for all 4 rooms -->
+    <light name="light_center" pos="0 0 5.0" dir="0 0 -1" diffuse="0.7 0.7 0.7" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_manip_lab" pos="4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_storage_bay" pos="4.5 4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_nav_zone" pos="-4.5 4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_control_hub" pos="-4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+
+    <!-- Outer Facility Enclosure Walls (18m x 18m) -->
+    <geom group="3" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+
+    <!-- Interior Partition Walls with Central Doorways -->
+    <!-- North-South Partition Wall (West-East Divider) -->
+    <geom group="3" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="3" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+
+    <!-- West-East Partition Wall (North-South Divider) -->
+    <geom group="3" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="3" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 1: Pick-and-Place Manipulation Testing Lab (East-South Room)   -->
+    <!-- ==================================================================== -->
+    <body name="manipulation_workbench" pos="4.5 -4.5 0">
+      <!-- Desk Top & Legs -->
+      <geom group="3" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+
+    </body>
+
+    <!-- Pick and Place Target Objects on Workbench (Worldbody Top Level) -->
+    <body name="red_cube" pos="4.1 -4.65 0.78">
+      <freejoint name="red_cube_joint"/>
+      <geom group="3" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+    </body>
+
+    <body name="green_cylinder" pos="4.35 -4.35 0.79">
+      <freejoint name="green_cyl_joint"/>
+      <geom group="3" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+    </body>
+
+    <body name="blue_sphere" pos="4.6 -4.65 0.787">
+      <freejoint name="blue_sphere_joint"/>
+      <geom group="3" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
+    </body>
+
+    <body name="yellow_box" pos="4.1 -4.35 0.775">
+      <freejoint name="yellow_box_joint"/>
+      <geom group="3" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Target Sorting Tray / Bin on Desk -->
+    <body name="sorting_tray" pos="4.95 -4.5 0.75">
+      <geom group="3" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Manipulation Room Storage Shelving Unit along East Wall -->
+    <body name="lab_shelf_unit" pos="8.2 -4.5 0" euler="0 0 -90">
+      <geom group="3" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <!-- Spare Containers on Shelf -->
+      <geom group="3" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="3" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 2: Cargo & Industrial Storage Bay (East-North Room)            -->
+    <!-- ==================================================================== -->
+    <!-- Multi-Tier Heavy Storage Shelving Unit 1 -->
+    <body name="storage_shelf_1" pos="4.5 7.8 0">
+      <geom group="3" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <!-- Cargo Boxes on Shelf Tier 1 -->
+      <geom group="3" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="3" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Stacked Cargo Crates -->
+    <body name="crate_stack_1" pos="7.0 4.0 0">
+      <geom group="3" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
+      <geom group="3" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+    </body>
+
+    <body name="crate_stack_2" pos="3.0 3.5 0">
+      <geom group="3" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 3: Navigation & Obstacle Traversal Zone (West-North Room)       -->
+    <!-- ==================================================================== -->
+    <!-- Structural Cylindrical Columns / Pillars -->
+    <geom group="3" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="3" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+
+    <!-- Slalom Navigation Crates -->
+    <body name="slalom_crate_1" pos="-3.0 6.5 0">
+      <geom group="3" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
+    </body>
+    <body name="slalom_crate_2" pos="-6.5 3.5 0">
+      <geom group="3" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+    </body>
+
+    <!-- Low Slope Ramp (Slope & elevation traversal test) -->
+    <body name="slope_ramp" pos="-5.5 1.8 0.08" euler="0 -5 0">
+      <geom group="3" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 4: Control Station & Rest Hub (West-South Room)                -->
+    <!-- ==================================================================== -->
+    <body name="control_station_desk" pos="-5.5 -5.5 0">
+      <geom group="3" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <geom group="3" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- CAMERA PRESETS                                                       -->
+    <!-- ==================================================================== -->
+    <!-- Overview Top-Isometric View of Facility -->
+    <camera name="facility_overview" pos="11.0 -11.0 10.0" xyaxes="0.707 0.707 0 -0.4 0.4 0.82" fovy="55"/>
+    <!-- Close-up View of Pick-and-Place Manipulation Lab -->
+    <camera name="manipulation_lab" pos="4.5 -7.2 2.4" xyaxes="1 0 0 0 0.5 0.866" fovy="50"/>
+    <!-- View of Storage Bay -->
+    <camera name="storage_bay" pos="4.5 1.5 2.5" xyaxes="1 0 0 0 0.35 0.93" fovy="55"/>
+    <!-- View down Central Corridor Doorway Intersection -->
+    <camera name="corridor_hub" pos="-3.5 0 2.2" xyaxes="0 1 0 -0.25 0 0.96" fovy="60"/>
+    <!-- Tracking Camera Following Unitree G1 -->
+    <camera name="robot_cam" pos="2.5 -2.5 2.2" xyaxes="0.707 0.707 0 -0.3 0.3 0.9" fovy="55"/>
+  </worldbody>
+
+  <equality>
+    <!-- Same fixture mechanism as the perception scene: welding torso_link holds the
+         sensor pose still, which the geometry checks need. -->
+    <weld name="torso_world_pin" body1="torso_link"/>
+  </equality>
+</mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_pinned_scene.xml
@@ -4,7 +4,7 @@
     changes only:
       * includes the vendored g1_29dof.xml rather than g1_rl.xml, since unitree_mujoco
         stages scenes against its own model directory;
-      * every geom carries group="3", because the LiDAR sweep masks to that group so the
+      * every geom carries group="2", because the LiDAR sweep masks to that group so the
         robot's own collision shell cannot occlude the world.
     Staged into the vendored model directory at launch, so relative includes resolve.
 
@@ -65,7 +65,7 @@
 
   <worldbody>
     <!-- Ground Plane -->
-    <geom group="3" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
+    <geom group="2" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
           contype="1" conaffinity="1"/>
 
     <!-- Ceiling Lights for all 4 rooms -->
@@ -76,19 +76,19 @@
     <light name="light_control_hub" pos="-4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
 
     <!-- Outer Facility Enclosure Walls (18m x 18m) -->
-    <geom group="3" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
 
     <!-- Interior Partition Walls with Central Doorways -->
     <!-- North-South Partition Wall (West-East Divider) -->
-    <geom group="3" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
-    <geom group="3" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
 
     <!-- West-East Partition Wall (North-South Divider) -->
-    <geom group="3" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
-    <geom group="3" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
 
 
     <!-- ==================================================================== -->
@@ -96,57 +96,57 @@
     <!-- ==================================================================== -->
     <body name="manipulation_workbench" pos="4.5 -4.5 0">
       <!-- Desk Top & Legs -->
-      <geom group="3" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
 
     </body>
 
     <!-- Pick and Place Target Objects on Workbench (Worldbody Top Level) -->
     <body name="red_cube" pos="4.1 -4.65 0.78">
       <freejoint name="red_cube_joint"/>
-      <geom group="3" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+      <geom group="2" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
     </body>
 
     <body name="green_cylinder" pos="4.35 -4.35 0.79">
       <freejoint name="green_cyl_joint"/>
-      <geom group="3" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+      <geom group="2" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
     </body>
 
     <body name="blue_sphere" pos="4.6 -4.65 0.787">
       <freejoint name="blue_sphere_joint"/>
-      <geom group="3" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
+      <geom group="2" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
     </body>
 
     <body name="yellow_box" pos="4.1 -4.35 0.775">
       <freejoint name="yellow_box_joint"/>
-      <geom group="3" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
+      <geom group="2" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Target Sorting Tray / Bin on Desk -->
     <body name="sorting_tray" pos="4.95 -4.5 0.75">
-      <geom group="3" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Manipulation Room Storage Shelving Unit along East Wall -->
     <body name="lab_shelf_unit" pos="8.2 -4.5 0" euler="0 0 -90">
-      <geom group="3" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
 
       <!-- Spare Containers on Shelf -->
-      <geom group="3" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
-      <geom group="3" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
+      <geom group="2" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="2" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
     </body>
 
 
@@ -155,27 +155,27 @@
     <!-- ==================================================================== -->
     <!-- Multi-Tier Heavy Storage Shelving Unit 1 -->
     <body name="storage_shelf_1" pos="4.5 7.8 0">
-      <geom group="3" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
 
       <!-- Cargo Boxes on Shelf Tier 1 -->
-      <geom group="3" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
-      <geom group="3" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
+      <geom group="2" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="2" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Stacked Cargo Crates -->
     <body name="crate_stack_1" pos="7.0 4.0 0">
-      <geom group="3" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
-      <geom group="3" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
+      <geom group="2" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
     </body>
 
     <body name="crate_stack_2" pos="3.0 3.5 0">
-      <geom group="3" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
+      <geom group="2" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
     </body>
 
 
@@ -183,20 +183,20 @@
     <!-- ZONE 3: Navigation & Obstacle Traversal Zone (West-North Room)       -->
     <!-- ==================================================================== -->
     <!-- Structural Cylindrical Columns / Pillars -->
-    <geom group="3" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
-    <geom group="3" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="2" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="2" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
 
     <!-- Slalom Navigation Crates -->
     <body name="slalom_crate_1" pos="-3.0 6.5 0">
-      <geom group="3" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
     </body>
     <body name="slalom_crate_2" pos="-6.5 3.5 0">
-      <geom group="3" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
     </body>
 
     <!-- Low Slope Ramp (Slope & elevation traversal test) -->
     <body name="slope_ramp" pos="-5.5 1.8 0.08" euler="0 -5 0">
-      <geom group="3" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
+      <geom group="2" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
     </body>
 
 
@@ -204,13 +204,13 @@
     <!-- ZONE 4: Control Station & Rest Hub (West-South Room)                -->
     <!-- ==================================================================== -->
     <body name="control_station_desk" pos="-5.5 -5.5 0">
-      <geom group="3" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
 
-      <geom group="3" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
     </body>
 
 

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
@@ -1,0 +1,231 @@
+<mujoco model="g1_navigation_scene">
+  <!--
+    Adapted from the user's scene_navigation.xml for the converged sensor track. Two
+    changes only:
+      * includes the vendored g1_29dof.xml rather than g1_rl.xml, since unitree_mujoco
+        stages scenes against its own model directory;
+      * every geom carries group="3", because the LiDAR sweep masks to that group so the
+        robot's own collision shell cannot occlude the world.
+    Staged into the vendored model directory at launch, so relative includes resolve.
+
+    Original header follows.
+  --><!--
+    Unitree G1 Enhanced Multi-Room Facility World Environment
+    Features:
+      1. 4-Room Partitioned Facility (18m x 18m) with central corridor doorways.
+      2. Pick-and-Place Manipulation Lab: Workbench with target objects
+         (Red Cube, Green Cylinder, Blue Sphere, Yellow Box, Sorting Tray).
+      3. Storage Bay: Multi-tier shelving units & stacked cargo crates.
+      4. Navigation Zone: Structural pillars, slalom hurdles, and low ramp.
+      5. Control Hub: Desks, equipment, and resting area.
+      6. Offscreen Cameras: facility_overview, manipulation_lab, storage_bay, robot_cam.
+  -->
+
+  <include file="g1_29dof.xml"/>
+
+  <statistic center="0 0 0.8" extent="8"/>
+
+  <visual>
+    <headlight diffuse="0.5 0.5 0.5" ambient="0.3 0.3 0.3" specular="0.2 0.2 0.2"/>
+    <rgba haze="0.15 0.2 0.25 1"/>
+    <global azimuth="120" elevation="-20" offwidth="1920" offheight="1080"/>
+  </visual>
+
+  <asset>
+    <!-- Skybox -->
+    <texture type="skybox" builtin="gradient" rgb1="0.2 0.3 0.42" rgb2="0.05 0.05 0.1"
+             width="512" height="3072"/>
+    <!-- Floor Tile Texture -->
+    <texture type="2d" name="floor_tile" builtin="checker"
+             rgb1="0.78 0.80 0.84" rgb2="0.62 0.65 0.70"
+             width="512" height="512"/>
+    <material name="floor_mat" texture="floor_tile" texuniform="true"
+              texrepeat="12 12" reflectance="0.18"/>
+
+    <!-- Room Wall Materials -->
+    <material name="wall_outer" rgba="0.85 0.85 0.82 1" specular="0.1" shininess="0.2"/>
+    <material name="wall_inner" rgba="0.72 0.75 0.80 1" specular="0.15" shininess="0.3"/>
+
+    <!-- Furniture & Equipment Materials -->
+    <material name="wood_desk" rgba="0.55 0.35 0.2 1" specular="0.4" shininess="0.5"/>
+    <material name="metal_gray" rgba="0.35 0.38 0.42 1" specular="0.6" shininess="0.7"/>
+    <material name="shelf_blue" rgba="0.2 0.35 0.6 1" specular="0.5" shininess="0.6"/>
+    <material name="crate_orange" rgba="0.85 0.42 0.1 1" specular="0.3" shininess="0.4"/>
+    <material name="crate_darkblue" rgba="0.15 0.32 0.6 1" specular="0.3" shininess="0.4"/>
+    <material name="pillar_mat" rgba="0.3 0.32 0.35 1" specular="0.4" shininess="0.5"/>
+    <material name="ramp_mat" rgba="0.25 0.55 0.35 1" specular="0.2" shininess="0.3"/>
+
+    <!-- Pick & Place Object Materials -->
+    <material name="mat_red_obj" rgba="0.9 0.15 0.15 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_green_obj" rgba="0.15 0.8 0.2 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_blue_obj" rgba="0.15 0.3 0.9 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_yellow_obj" rgba="0.95 0.8 0.1 1" specular="0.6" shininess="0.8"/>
+    <material name="mat_tray" rgba="0.3 0.3 0.35 1" specular="0.4" shininess="0.5"/>
+  </asset>
+
+  <worldbody>
+    <!-- Ground Plane -->
+    <geom group="3" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
+          contype="1" conaffinity="1"/>
+
+    <!-- Ceiling Lights for all 4 rooms -->
+    <light name="light_center" pos="0 0 5.0" dir="0 0 -1" diffuse="0.7 0.7 0.7" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_manip_lab" pos="4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_storage_bay" pos="4.5 4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_nav_zone" pos="-4.5 4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+    <light name="light_control_hub" pos="-4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
+
+    <!-- Outer Facility Enclosure Walls (18m x 18m) -->
+    <geom group="3" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="3" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+
+    <!-- Interior Partition Walls with Central Doorways -->
+    <!-- North-South Partition Wall (West-East Divider) -->
+    <geom group="3" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="3" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+
+    <!-- West-East Partition Wall (North-South Divider) -->
+    <geom group="3" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="3" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 1: Pick-and-Place Manipulation Testing Lab (East-South Room)   -->
+    <!-- ==================================================================== -->
+    <body name="manipulation_workbench" pos="4.5 -4.5 0">
+      <!-- Desk Top & Legs -->
+      <geom group="3" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+
+    </body>
+
+    <!-- Pick and Place Target Objects on Workbench (Worldbody Top Level) -->
+    <body name="red_cube" pos="4.1 -4.65 0.78">
+      <freejoint name="red_cube_joint"/>
+      <geom group="3" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+    </body>
+
+    <body name="green_cylinder" pos="4.35 -4.35 0.79">
+      <freejoint name="green_cyl_joint"/>
+      <geom group="3" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+    </body>
+
+    <body name="blue_sphere" pos="4.6 -4.65 0.787">
+      <freejoint name="blue_sphere_joint"/>
+      <geom group="3" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
+    </body>
+
+    <body name="yellow_box" pos="4.1 -4.35 0.775">
+      <freejoint name="yellow_box_joint"/>
+      <geom group="3" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Target Sorting Tray / Bin on Desk -->
+    <body name="sorting_tray" pos="4.95 -4.5 0.75">
+      <geom group="3" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="3" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Manipulation Room Storage Shelving Unit along East Wall -->
+    <body name="lab_shelf_unit" pos="8.2 -4.5 0" euler="0 0 -90">
+      <geom group="3" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <!-- Spare Containers on Shelf -->
+      <geom group="3" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="3" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 2: Cargo & Industrial Storage Bay (East-North Room)            -->
+    <!-- ==================================================================== -->
+    <!-- Multi-Tier Heavy Storage Shelving Unit 1 -->
+    <body name="storage_shelf_1" pos="4.5 7.8 0">
+      <geom group="3" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <!-- Cargo Boxes on Shelf Tier 1 -->
+      <geom group="3" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="3" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
+    </body>
+
+    <!-- Stacked Cargo Crates -->
+    <body name="crate_stack_1" pos="7.0 4.0 0">
+      <geom group="3" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
+      <geom group="3" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+    </body>
+
+    <body name="crate_stack_2" pos="3.0 3.5 0">
+      <geom group="3" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 3: Navigation & Obstacle Traversal Zone (West-North Room)       -->
+    <!-- ==================================================================== -->
+    <!-- Structural Cylindrical Columns / Pillars -->
+    <geom group="3" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="3" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+
+    <!-- Slalom Navigation Crates -->
+    <body name="slalom_crate_1" pos="-3.0 6.5 0">
+      <geom group="3" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
+    </body>
+    <body name="slalom_crate_2" pos="-6.5 3.5 0">
+      <geom group="3" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+    </body>
+
+    <!-- Low Slope Ramp (Slope & elevation traversal test) -->
+    <body name="slope_ramp" pos="-5.5 1.8 0.08" euler="0 -5 0">
+      <geom group="3" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- ZONE 4: Control Station & Rest Hub (West-South Room)                -->
+    <!-- ==================================================================== -->
+    <body name="control_station_desk" pos="-5.5 -5.5 0">
+      <geom group="3" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="3" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+
+      <geom group="3" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
+    </body>
+
+
+    <!-- ==================================================================== -->
+    <!-- CAMERA PRESETS                                                       -->
+    <!-- ==================================================================== -->
+    <!-- Overview Top-Isometric View of Facility -->
+    <camera name="facility_overview" pos="11.0 -11.0 10.0" xyaxes="0.707 0.707 0 -0.4 0.4 0.82" fovy="55"/>
+    <!-- Close-up View of Pick-and-Place Manipulation Lab -->
+    <camera name="manipulation_lab" pos="4.5 -7.2 2.4" xyaxes="1 0 0 0 0.5 0.866" fovy="50"/>
+    <!-- View of Storage Bay -->
+    <camera name="storage_bay" pos="4.5 1.5 2.5" xyaxes="1 0 0 0 0.35 0.93" fovy="55"/>
+    <!-- View down Central Corridor Doorway Intersection -->
+    <camera name="corridor_hub" pos="-3.5 0 2.2" xyaxes="0 1 0 -0.25 0 0.96" fovy="60"/>
+    <!-- Tracking Camera Following Unitree G1 -->
+    <camera name="robot_cam" pos="2.5 -2.5 2.2" xyaxes="0.707 0.707 0 -0.3 0.3 0.9" fovy="55"/>
+  </worldbody>
+</mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
@@ -4,7 +4,7 @@
     changes only:
       * includes the vendored g1_29dof.xml rather than g1_rl.xml, since unitree_mujoco
         stages scenes against its own model directory;
-      * every geom carries group="3", because the LiDAR sweep masks to that group so the
+      * every geom carries group="2", because the LiDAR sweep masks to that group so the
         robot's own collision shell cannot occlude the world.
     Staged into the vendored model directory at launch, so relative includes resolve.
 
@@ -65,7 +65,7 @@
 
   <worldbody>
     <!-- Ground Plane -->
-    <geom group="3" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
+    <geom group="2" name="ground" type="plane" size="30 30 0.01" material="floor_mat"
           contype="1" conaffinity="1"/>
 
     <!-- Ceiling Lights for all 4 rooms -->
@@ -76,19 +76,19 @@
     <light name="light_control_hub" pos="-4.5 -4.5 4.5" dir="0 0 -1" diffuse="0.6 0.6 0.6" specular="0.3 0.3 0.3" castshadow="true"/>
 
     <!-- Outer Facility Enclosure Walls (18m x 18m) -->
-    <geom group="3" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
-    <geom group="3" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_north" type="box" size="9.2 0.2 1.6" pos="0 9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_south" type="box" size="9.2 0.2 1.6" pos="0 -9.1 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_east" type="box" size="0.2 9.2 1.6" pos="9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
+    <geom group="2" name="wall_west" type="box" size="0.2 9.2 1.6" pos="-9.1 0 1.6" material="wall_outer" contype="1" conaffinity="1"/>
 
     <!-- Interior Partition Walls with Central Doorways -->
     <!-- North-South Partition Wall (West-East Divider) -->
-    <geom group="3" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
-    <geom group="3" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_ns_north" type="box" size="0.15 3.5 1.3" pos="0 5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_ns_south" type="box" size="0.15 3.5 1.3" pos="0 -5.5 1.3" material="wall_inner" contype="1" conaffinity="1"/>
 
     <!-- West-East Partition Wall (North-South Divider) -->
-    <geom group="3" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
-    <geom group="3" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_we_west" type="box" size="3.5 0.15 1.3" pos="-5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
+    <geom group="2" name="part_we_east" type="box" size="3.5 0.15 1.3" pos="5.5 0 1.3" material="wall_inner" contype="1" conaffinity="1"/>
 
 
     <!-- ==================================================================== -->
@@ -96,57 +96,57 @@
     <!-- ==================================================================== -->
     <body name="manipulation_workbench" pos="4.5 -4.5 0">
       <!-- Desk Top & Legs -->
-      <geom group="3" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_1" type="box" size="0.04 0.04 0.35" pos="0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_2" type="box" size="0.04 0.04 0.35" pos="-0.8 0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_3" type="box" size="0.04 0.04 0.35" pos="0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="desk_leg_4" type="box" size="0.04 0.04 0.35" pos="-0.8 -0.45 0.35" material="metal_gray" contype="1" conaffinity="1"/>
 
     </body>
 
     <!-- Pick and Place Target Objects on Workbench (Worldbody Top Level) -->
     <body name="red_cube" pos="4.1 -4.65 0.78">
       <freejoint name="red_cube_joint"/>
-      <geom group="3" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+      <geom group="2" type="box" size="0.03 0.03 0.03" material="mat_red_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
     </body>
 
     <body name="green_cylinder" pos="4.35 -4.35 0.79">
       <freejoint name="green_cyl_joint"/>
-      <geom group="3" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
+      <geom group="2" type="cylinder" size="0.03 0.04" material="mat_green_obj" mass="0.15" contype="1" conaffinity="1" friction="1 0.005 0.0001"/>
     </body>
 
     <body name="blue_sphere" pos="4.6 -4.65 0.787">
       <freejoint name="blue_sphere_joint"/>
-      <geom group="3" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
+      <geom group="2" type="sphere" size="0.037" material="mat_blue_obj" mass="0.1" contype="1" conaffinity="1" friction="0.8 0.005 0.0001"/>
     </body>
 
     <body name="yellow_box" pos="4.1 -4.35 0.775">
       <freejoint name="yellow_box_joint"/>
-      <geom group="3" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
+      <geom group="2" type="box" size="0.04 0.025 0.025" material="mat_yellow_obj" mass="0.12" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Target Sorting Tray / Bin on Desk -->
     <body name="sorting_tray" pos="4.95 -4.5 0.75">
-      <geom group="3" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
-      <geom group="3" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_base" type="box" size="0.18 0.18 0.01" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_1" type="box" size="0.18 0.01 0.03" pos="0 0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_2" type="box" size="0.18 0.01 0.03" pos="0 -0.17 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_3" type="box" size="0.01 0.18 0.03" pos="0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
+      <geom group="2" name="tray_wall_4" type="box" size="0.01 0.18 0.03" pos="-0.17 0 0.03" material="mat_tray" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Manipulation Room Storage Shelving Unit along East Wall -->
     <body name="lab_shelf_unit" pos="8.2 -4.5 0" euler="0 0 -90">
-      <geom group="3" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_frame" type="box" size="0.3 1.2 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_1" type="box" size="0.3 1.2 0.015" pos="0 0 0.5" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_2" type="box" size="0.3 1.2 0.015" pos="0 0 1.0" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post1" type="box" size="0.025 0.025 0.6" pos="0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post2" type="box" size="0.025 0.025 0.6" pos="-0.28 1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post3" type="box" size="0.025 0.025 0.6" pos="0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="lab_shelf_post4" type="box" size="0.025 0.025 0.6" pos="-0.28 -1.15 0.6" material="metal_gray" contype="1" conaffinity="1"/>
 
       <!-- Spare Containers on Shelf -->
-      <geom group="3" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
-      <geom group="3" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
+      <geom group="2" name="container_1" type="box" size="0.18 0.22 0.12" pos="0 0.4 0.64" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="2" name="container_2" type="box" size="0.18 0.22 0.12" pos="0 -0.4 0.64" material="crate_darkblue" contype="1" conaffinity="1"/>
     </body>
 
 
@@ -155,27 +155,27 @@
     <!-- ==================================================================== -->
     <!-- Multi-Tier Heavy Storage Shelving Unit 1 -->
     <body name="storage_shelf_1" pos="4.5 7.8 0">
-      <geom group="3" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier0" type="box" size="0.4 1.5 0.02" pos="0 0 0.02" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier1" type="box" size="0.4 1.5 0.02" pos="0 0 0.6" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_tier2" type="box" size="0.4 1.5 0.02" pos="0 0 1.2" material="shelf_blue" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post1" type="box" size="0.03 0.03 0.7" pos="0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post2" type="box" size="0.03 0.03 0.7" pos="-0.37 1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post3" type="box" size="0.03 0.03 0.7" pos="0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="shelf_1_post4" type="box" size="0.03 0.03 0.7" pos="-0.37 -1.45 0.7" material="metal_gray" contype="1" conaffinity="1"/>
 
       <!-- Cargo Boxes on Shelf Tier 1 -->
-      <geom group="3" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
-      <geom group="3" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
+      <geom group="2" name="box_on_shelf_1" type="box" size="0.25 0.3 0.18" pos="0 0.6 0.8" material="crate_orange" contype="1" conaffinity="1"/>
+      <geom group="2" name="box_on_shelf_2" type="box" size="0.25 0.3 0.18" pos="0 -0.6 0.8" material="crate_darkblue" contype="1" conaffinity="1"/>
     </body>
 
     <!-- Stacked Cargo Crates -->
     <body name="crate_stack_1" pos="7.0 4.0 0">
-      <geom group="3" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
-      <geom group="3" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="crate_1a" type="box" size="0.5 0.5 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="20"/>
+      <geom group="2" name="crate_1b" type="box" size="0.4 0.4 0.25" pos="0 0 0.85" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
     </body>
 
     <body name="crate_stack_2" pos="3.0 3.5 0">
-      <geom group="3" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
+      <geom group="2" name="crate_2a" type="box" size="0.45 0.6 0.35" pos="0 0 0.35" material="crate_darkblue" contype="1" conaffinity="1" mass="25"/>
     </body>
 
 
@@ -183,20 +183,20 @@
     <!-- ZONE 3: Navigation & Obstacle Traversal Zone (West-North Room)       -->
     <!-- ==================================================================== -->
     <!-- Structural Cylindrical Columns / Pillars -->
-    <geom group="3" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
-    <geom group="3" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="2" name="pillar_1" type="cylinder" size="0.25 1.6" pos="-3.5 3.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
+    <geom group="2" name="pillar_2" type="cylinder" size="0.25 1.6" pos="-6.5 6.5 1.6" material="pillar_mat" contype="1" conaffinity="1"/>
 
     <!-- Slalom Navigation Crates -->
     <body name="slalom_crate_1" pos="-3.0 6.5 0">
-      <geom group="3" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="slalom_1" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_orange" contype="1" conaffinity="1" mass="15"/>
     </body>
     <body name="slalom_crate_2" pos="-6.5 3.5 0">
-      <geom group="3" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
+      <geom group="2" name="slalom_2" type="box" size="0.4 0.4 0.3" pos="0 0 0.3" material="crate_darkblue" contype="1" conaffinity="1" mass="15"/>
     </body>
 
     <!-- Low Slope Ramp (Slope & elevation traversal test) -->
     <body name="slope_ramp" pos="-5.5 1.8 0.08" euler="0 -5 0">
-      <geom group="3" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
+      <geom group="2" name="ramp_surface" type="box" size="1.2 0.75 0.08" material="ramp_mat" contype="1" conaffinity="1" friction="1 0.01 0.001"/>
     </body>
 
 
@@ -204,13 +204,13 @@
     <!-- ZONE 4: Control Station & Rest Hub (West-South Room)                -->
     <!-- ==================================================================== -->
     <body name="control_station_desk" pos="-5.5 -5.5 0">
-      <geom group="3" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
-      <geom group="3" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_top" type="box" size="1.1 0.5 0.03" pos="0 0 0.72" material="wood_desk" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg1" type="box" size="0.04 0.04 0.35" pos="1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg2" type="box" size="0.04 0.04 0.35" pos="-1.0 0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg3" type="box" size="0.04 0.04 0.35" pos="1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="ctrl_leg4" type="box" size="0.04 0.04 0.35" pos="-1.0 -0.4 0.35" material="metal_gray" contype="1" conaffinity="1"/>
 
-      <geom group="3" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
+      <geom group="2" name="trash_bin" type="cylinder" size="0.12 0.2" pos="-1.3 0 0.2" material="metal_gray" contype="1" conaffinity="1"/>
     </body>
 
 

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
@@ -227,5 +227,10 @@
     <camera name="corridor_hub" pos="-3.5 0 2.2" xyaxes="0 1 0 -0.25 0 0.96" fovy="60"/>
     <!-- Tracking Camera Following Unitree G1 -->
     <camera name="robot_cam" pos="2.5 -2.5 2.2" xyaxes="0.707 0.707 0 -0.3 0.3 0.9" fovy="55"/>
+
+    <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes
+         cam_xpos/cam_xmat into its own snapshot every frame from torso_link's live pose,
+         because the mount belongs to the vendored robot and cannot host a camera element. -->
+    <camera name="d435i" mode="fixed" fovy="58" resolution="848 480" pos="0 0 1"/>
   </worldbody>
 </mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
@@ -7,9 +7,11 @@
        g1_flat_scene, plus a room the LiDAR can measure against: every sensor assertion is
        a geometric fact of this file rather than a check that data arrived.
 
-       Every geom here is group 3. The LiDAR sweep masks to that group, because the Mid360's
+       Every geom here is group 2. The LiDAR sweep masks to that group, because the Mid360's
        mount point sits inside the torso's own collision geom: without the mask every ray
        returns the robot's own shell at 6 cm and nothing else is ever visible.
+       Group 2 specifically: the robot occupies groups 0 and 1, and MuJoCo's viewer
+       renders only 0-2, so anything in group 3 is physically present but invisible.
 
        No sensor site or camera element here on purpose. The sweep takes torso_link's live
        pose from mjData and applies the mount offset from config, so the robot model needs
@@ -40,20 +42,20 @@
 
   <worldbody>
     <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
-    <geom name="floor" group="3" size="0 0 0.05" type="plane" material="groundplane"/>
+    <geom name="floor" group="2" size="0 0 0.05" type="plane" material="groundplane"/>
 
     <!-- 8 x 8 m room, inner wall faces at +/-4.0 m. The y walls run to +/-4.1 in x so the
          corners are closed; at 4.0 the four boxes meet along an edge and leave a gap. -->
-    <geom name="wall_px" group="3" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
-    <geom name="wall_nx" group="3" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
-    <geom name="wall_py" group="3" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
-    <geom name="wall_ny" group="3" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+    <geom name="wall_px" group="2" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" group="2" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" group="2" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" group="2" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
 
     <!-- Kept clear of the robot's spawn and of the +x teleop path the walking tests drive,
          so adding them cannot change a locomotion result. -->
-    <geom name="obstacle_box" group="3" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
+    <geom name="obstacle_box" group="2" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
           material="obstacle"/>
-    <geom name="obstacle_cyl" group="3" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+    <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
   </worldbody>
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
@@ -13,7 +13,7 @@
        Group 2 specifically: the robot occupies groups 0 and 1, and MuJoCo's viewer
        renders only 0-2, so anything in group 3 is physically present but invisible.
 
-       No sensor site or camera element here on purpose. The sweep takes torso_link's live
+       No sensor site here on purpose. The sweep takes torso_link's live
        pose from mjData and applies the mount offset from config, so the robot model needs
        no modification and g1_29dof.xml stays vendored-verbatim.
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
@@ -38,6 +38,10 @@
       reflectance="0.2"/>
     <material name="wall" rgba="0.75 0.75 0.72 1"/>
     <material name="obstacle" rgba="0.8 0.4 0.3 1"/>
+    <!-- Saturated green appears nowhere else here: the floor is blue-grey, walls grey,
+         obstacles red. That makes "is the colour stream showing the right thing at the
+         right place" a threshold on one channel rather than a judgement call. -->
+    <material name="color_target" rgba="0 0.9 0.1 1"/>
   </asset>
 
   <worldbody>
@@ -55,6 +59,13 @@
          so adding them cannot change a locomotion result. -->
     <geom name="obstacle_box" group="2" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
           material="obstacle"/>
+    <!-- Colour-check target. The camera is pitched 47.6 deg down, so its centre ray meets
+         the floor about 1.21 m ahead; this sits at that range but 0.35 m to the robot's
+         left, which puts it well inside the frame while leaving the centre pixel on bare
+         floor for the depth check to keep using. -->
+    <geom name="color_target" group="2" type="box" size="0.05 0.05 0.05" pos="1.21 0.35 0.05"
+      material="color_target"/>
+
     <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
@@ -26,7 +26,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
-    <global azimuth="-130" elevation="-20"/>
+    <global azimuth="-130" elevation="-20" offwidth="1280" offheight="720"/>
   </visual>
 
   <asset>
@@ -57,6 +57,11 @@
           material="obstacle"/>
     <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
+
+    <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes
+         cam_xpos/cam_xmat into its own snapshot every frame from torso_link's live pose,
+         because the mount belongs to the vendored robot and cannot host a camera element. -->
+    <camera name="d435i" mode="fixed" fovy="58" resolution="848 480" pos="0 0 1"/>
   </worldbody>
 
   <equality>

--- a/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_pinned_scene.xml
@@ -1,0 +1,68 @@
+<mujoco model="g1_perception_pinned_scene">
+  <!-- Perception scene with the pelvis welded. The sensor geometry tests need the robot
+       at a known pose: a free-standing G1 that has drifted or fallen still produces a valid
+       cloud, just not one whose numbers can be asserted against the room.
+
+       Walking scene with known geometry for the sensor track. Same bare floor as
+       g1_flat_scene, plus a room the LiDAR can measure against: every sensor assertion is
+       a geometric fact of this file rather than a check that data arrived.
+
+       Every geom here is group 3. The LiDAR sweep masks to that group, because the Mid360's
+       mount point sits inside the torso's own collision geom: without the mask every ray
+       returns the robot's own shell at 6 cm and nothing else is ever visible.
+
+       No sensor site or camera element here on purpose. The sweep takes torso_link's live
+       pose from mjData and applies the mount offset from config, so the robot model needs
+       no modification and g1_29dof.xml stays vendored-verbatim.
+
+       Staged into the vendored model directory at launch time so MuJoCo's relative meshdir
+       and include paths resolve. -->
+  <include file="g1_29dof.xml"/>
+
+  <statistic center="0 0 0.5" extent="2.0"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="-130" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512"
+      height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4"
+      rgb2="0.1 0.2 0.3" markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5"
+      reflectance="0.2"/>
+    <material name="wall" rgba="0.75 0.75 0.72 1"/>
+    <material name="obstacle" rgba="0.8 0.4 0.3 1"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+    <geom name="floor" group="3" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <!-- 8 x 8 m room, inner wall faces at +/-4.0 m. The y walls run to +/-4.1 in x so the
+         corners are closed; at 4.0 the four boxes meet along an edge and leave a gap. -->
+    <geom name="wall_px" group="3" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" group="3" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" group="3" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" group="3" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+
+    <!-- Kept clear of the robot's spawn and of the +x teleop path the walking tests drive,
+         so adding them cannot change a locomotion result. -->
+    <geom name="obstacle_box" group="3" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
+          material="obstacle"/>
+    <geom name="obstacle_cyl" group="3" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+          material="obstacle"/>
+  </worldbody>
+
+  <equality>
+    <!-- torso_link, not pelvis. Pinning the pelvis still leaves the waist free, and the
+         walking policy drives it: the torso pitches tens of degrees, which swings the
+         Mid360 with it and points the whole sweep at the floor. Welding the torso fixes
+         the sensor pose outright, which is the entire point of a geometry fixture. -->
+    <weld name="torso_world_pin" body1="torso_link"/>
+  </equality>
+
+</mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -9,7 +9,7 @@
        Group 2 specifically: the robot occupies groups 0 and 1, and MuJoCo's viewer
        renders only 0-2, so anything in group 3 is physically present but invisible.
 
-       No sensor site or camera element here on purpose. The sweep takes torso_link's live
+       No sensor site here on purpose. The sweep takes torso_link's live
        pose from mjData and applies the mount offset from config, so the robot model needs
        no modification and g1_29dof.xml stays vendored-verbatim.
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -22,7 +22,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
-    <global azimuth="-130" elevation="-20"/>
+    <global azimuth="-130" elevation="-20" offwidth="1280" offheight="720"/>
   </visual>
 
   <asset>
@@ -53,6 +53,11 @@
           material="obstacle"/>
     <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
+
+    <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes
+         cam_xpos/cam_xmat into its own snapshot every frame from torso_link's live pose,
+         because the mount belongs to the vendored robot and cannot host a camera element. -->
+    <camera name="d435i" mode="fixed" fovy="58" resolution="848 480" pos="0 0 1"/>
   </worldbody>
 
 </mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -1,0 +1,52 @@
+<mujoco model="g1_perception_scene">
+  <!-- Walking scene with known geometry for the sensor track. Same bare floor as
+       g1_flat_scene, plus a room the LiDAR can measure against: every sensor assertion is
+       a geometric fact of this file rather than a check that data arrived.
+
+       No sensor site or camera element here on purpose. The sweep takes torso_link's live
+       pose from mjData and applies the mount offset from config, so the robot model needs
+       no modification and g1_29dof.xml stays vendored-verbatim.
+
+       Staged into the vendored model directory at launch time so MuJoCo's relative meshdir
+       and include paths resolve. -->
+  <include file="g1_29dof.xml"/>
+
+  <statistic center="0 0 0.5" extent="2.0"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="-130" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512"
+      height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4"
+      rgb2="0.1 0.2 0.3" markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5"
+      reflectance="0.2"/>
+    <material name="wall" rgba="0.75 0.75 0.72 1"/>
+    <material name="obstacle" rgba="0.8 0.4 0.3 1"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+
+    <!-- 8 x 8 m room, inner wall faces at +/-4.0 m. The y walls run to +/-4.1 in x so the
+         corners are closed; at 4.0 the four boxes meet along an edge and leave a gap. -->
+    <geom name="wall_px" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+
+    <!-- Kept clear of the robot's spawn and of the +x teleop path the walking tests drive,
+         so adding them cannot change a locomotion result. -->
+    <geom name="obstacle_box" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
+          material="obstacle"/>
+    <geom name="obstacle_cyl" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+          material="obstacle"/>
+  </worldbody>
+
+</mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -3,9 +3,11 @@
        g1_flat_scene, plus a room the LiDAR can measure against: every sensor assertion is
        a geometric fact of this file rather than a check that data arrived.
 
-       Every geom here is group 3. The LiDAR sweep masks to that group, because the Mid360's
+       Every geom here is group 2. The LiDAR sweep masks to that group, because the Mid360's
        mount point sits inside the torso's own collision geom: without the mask every ray
        returns the robot's own shell at 6 cm and nothing else is ever visible.
+       Group 2 specifically: the robot occupies groups 0 and 1, and MuJoCo's viewer
+       renders only 0-2, so anything in group 3 is physically present but invisible.
 
        No sensor site or camera element here on purpose. The sweep takes torso_link's live
        pose from mjData and applies the mount offset from config, so the robot model needs
@@ -36,20 +38,20 @@
 
   <worldbody>
     <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
-    <geom name="floor" group="3" size="0 0 0.05" type="plane" material="groundplane"/>
+    <geom name="floor" group="2" size="0 0 0.05" type="plane" material="groundplane"/>
 
     <!-- 8 x 8 m room, inner wall faces at +/-4.0 m. The y walls run to +/-4.1 in x so the
          corners are closed; at 4.0 the four boxes meet along an edge and leave a gap. -->
-    <geom name="wall_px" group="3" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
-    <geom name="wall_nx" group="3" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
-    <geom name="wall_py" group="3" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
-    <geom name="wall_ny" group="3" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+    <geom name="wall_px" group="2" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" group="2" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" group="2" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" group="2" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
 
     <!-- Kept clear of the robot's spawn and of the +x teleop path the walking tests drive,
          so adding them cannot change a locomotion result. -->
-    <geom name="obstacle_box" group="3" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
+    <geom name="obstacle_box" group="2" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
           material="obstacle"/>
-    <geom name="obstacle_cyl" group="3" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+    <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
   </worldbody>
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -3,6 +3,10 @@
        g1_flat_scene, plus a room the LiDAR can measure against: every sensor assertion is
        a geometric fact of this file rather than a check that data arrived.
 
+       Every geom here is group 3. The LiDAR sweep masks to that group, because the Mid360's
+       mount point sits inside the torso's own collision geom: without the mask every ray
+       returns the robot's own shell at 6 cm and nothing else is ever visible.
+
        No sensor site or camera element here on purpose. The sweep takes torso_link's live
        pose from mjData and applies the mount offset from config, so the robot model needs
        no modification and g1_29dof.xml stays vendored-verbatim.
@@ -32,20 +36,20 @@
 
   <worldbody>
     <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
-    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    <geom name="floor" group="3" size="0 0 0.05" type="plane" material="groundplane"/>
 
     <!-- 8 x 8 m room, inner wall faces at +/-4.0 m. The y walls run to +/-4.1 in x so the
          corners are closed; at 4.0 the four boxes meet along an edge and leave a gap. -->
-    <geom name="wall_px" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
-    <geom name="wall_nx" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
-    <geom name="wall_py" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
-    <geom name="wall_ny" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
+    <geom name="wall_px" group="3" type="box" size="0.05 4.0 1.25" pos="4.05 0 1.25" material="wall"/>
+    <geom name="wall_nx" group="3" type="box" size="0.05 4.0 1.25" pos="-4.05 0 1.25" material="wall"/>
+    <geom name="wall_py" group="3" type="box" size="4.1 0.05 1.25" pos="0 4.05 1.25" material="wall"/>
+    <geom name="wall_ny" group="3" type="box" size="4.1 0.05 1.25" pos="0 -4.05 1.25" material="wall"/>
 
     <!-- Kept clear of the robot's spawn and of the +x teleop path the walking tests drive,
          so adding them cannot change a locomotion result. -->
-    <geom name="obstacle_box" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
+    <geom name="obstacle_box" group="3" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
           material="obstacle"/>
-    <geom name="obstacle_cyl" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
+    <geom name="obstacle_cyl" group="3" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
   </worldbody>
 

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -34,6 +34,10 @@
       reflectance="0.2"/>
     <material name="wall" rgba="0.75 0.75 0.72 1"/>
     <material name="obstacle" rgba="0.8 0.4 0.3 1"/>
+    <!-- Saturated green appears nowhere else here: the floor is blue-grey, walls grey,
+         obstacles red. That makes "is the colour stream showing the right thing at the
+         right place" a threshold on one channel rather than a judgement call. -->
+    <material name="color_target" rgba="0 0.9 0.1 1"/>
   </asset>
 
   <worldbody>
@@ -51,6 +55,13 @@
          so adding them cannot change a locomotion result. -->
     <geom name="obstacle_box" group="2" type="box" size="0.3 0.3 0.5" pos="2.0 1.6 0.5"
           material="obstacle"/>
+    <!-- Colour-check target. The camera is pitched 47.6 deg down, so its centre ray meets
+         the floor about 1.21 m ahead; this sits at that range but 0.35 m to the robot's
+         left, which puts it well inside the frame while leaving the centre pixel on bare
+         floor for the depth check to keep using. -->
+    <geom name="color_target" group="2" type="box" size="0.05 0.05 0.05" pos="1.21 0.35 0.05"
+      material="color_target"/>
+
     <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
 

--- a/workspace/src/g1_bringup/package.xml
+++ b/workspace/src/g1_bringup/package.xml
@@ -23,6 +23,8 @@
   <depend>unitree_go</depend>
 
   <depend>g1_description</depend>
+  <depend>g1_state_estimation</depend>
+  <depend>g1_sensor_relay</depend>
   <depend>robot_state_publisher</depend>
   <depend>controller_manager</depend>
   <depend>joint_state_broadcaster</depend>

--- a/workspace/src/g1_bringup/package.xml
+++ b/workspace/src/g1_bringup/package.xml
@@ -38,6 +38,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>xvfb</exec_depend>
+  <exec_depend>rviz2</exec_depend>
 
   <!-- Runtime dependency for loco.launch.py. -->
   <exec_depend>g1_locomotion</exec_depend>

--- a/workspace/src/g1_bringup/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_bringup/src/motion_service_sim_node.cpp
@@ -130,6 +130,11 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
 
     // Best-effort, depth 1 — matches unitree_mujoco's /lowstate publisher.
     const auto lowstate_qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile();
+    // Off unless asked for. This work lands on the ~1 kHz /lowstate callback, which is the
+    // walking policy's own path, so only the sensor track pays for it. sim.launch.py turns
+    // it on together with sensors, because that is what needs pelvis -> torso_link.
+    publish_lower_joints_ = declare_parameter<bool>("publish_lower_joint_states", false);
+
     // Latest-only: robot_state_publisher merges by joint name, so this coexists with
     // joint_state_broadcaster's arm-only publication rather than competing with it.
     lower_joint_pub_ = create_publisher<sensor_msgs::msg::JointState>(

--- a/workspace/src/g1_bringup/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_bringup/src/motion_service_sim_node.cpp
@@ -130,7 +130,20 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
 
     // Best-effort, depth 1 — matches unitree_mujoco's /lowstate publisher.
     const auto lowstate_qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort().durability_volatile();
-    lowstate_sub_           = create_subscription<unitree_hg::msg::LowState>(
+    // Latest-only: robot_state_publisher merges by joint name, so this coexists with
+    // joint_state_broadcaster's arm-only publication rather than competing with it.
+    lower_joint_pub_ = create_publisher<sensor_msgs::msg::JointState>(
+        "/joint_states",
+        rclcpp::QoS(rclcpp::KeepLast(1)));
+    lower_joint_msg_.name.reserve(kNumLowerMotors);
+    lower_joint_msg_.position.resize(kNumLowerMotors);
+    lower_joint_msg_.velocity.resize(kNumLowerMotors);
+    for (int i = 0; i < kNumLowerMotors; ++i)
+    {
+        lower_joint_msg_.name.emplace_back(kDdsMotorOrder[i]);
+    }
+
+    lowstate_sub_ = create_subscription<unitree_hg::msg::LowState>(
         "/lowstate",
         lowstate_qos,
         [this](const unitree_hg::msg::LowState::ConstSharedPtr& msg) { lowstateCallback(msg); });
@@ -303,6 +316,21 @@ bool MotionServiceSim::setUpWalkPolicy()
 
 void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSharedPtr& msg)
 {
+    // Legs and waist, which nothing else publishes. Motor index equals kDdsMotorOrder
+    // index, asserted by test_walk_policy's joint-order check. Decimated to ~100 Hz:
+    // /lowstate is ~1 kHz and robot_state_publisher has no use for that.
+    if (publish_lower_joints_ && ++lower_joint_decimate_ >= 10)
+    {
+        lower_joint_decimate_         = 0;
+        lower_joint_msg_.header.stamp = now();
+        for (int i = 0; i < kNumLowerMotors; ++i)
+        {
+            lower_joint_msg_.position[i] = msg->motor_state[i].q;
+            lower_joint_msg_.velocity[i] = msg->motor_state[i].dq;
+        }
+        lower_joint_pub_->publish(lower_joint_msg_);
+    }
+
     // Refreshed every sample, unlike hold_q_ below: the policy observes live joint state.
     for (std::size_t i = 0; i < kNumBodyMotors; ++i)
     {

--- a/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
@@ -1,0 +1,217 @@
+"""The converged track's LiDAR measures the room it is actually in.
+
+Geometry, not plumbing. The cloud is published in the sensor frame, and the simulator
+also publishes the sensor's exact world pose, so the points can be put into world
+coordinates and checked against facts of g1_perception_pinned_scene.xml: floor at z=0,
+inner wall faces at +/-4.0 m.
+
+Runs with the pelvis pinned. Not for convenience: a free-standing G1 drifts and its waist
+leans (the torso pitches tens of degrees), so the numbers would move under the test
+without anything being wrong.
+"""
+
+import math
+import os
+import time
+import unittest
+from collections import deque
+
+import launch_testing
+import numpy as np
+import pytest
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from geometry_msgs.msg import PoseStamped
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import PointCloud2
+
+CLOUD_TOPIC = "/livox/lidar"
+POSE_TOPIC = "/g1_sensor_relay/sensor_pose"
+
+# config/sim_sensors.yaml
+EXPECTED_POINTS = 360 * 32
+CONFIGURED_RATE_HZ = 10.0
+RANGE_MIN = 0.1
+RANGE_MAX = 40.0
+
+# mjcf/g1_perception_pinned_scene.xml: inner wall faces at +/-4.0, floor at z=0, walls 2.5 tall.
+ROOM_HALF = 4.0
+WALL_TOP = 2.5
+
+BRINGUP_TIMEOUT_S = 90.0
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("g1_bringup"), "launch", "sim.launch.py")
+        ),
+        launch_arguments={"sensors": "true", "pin_pelvis": "true"}.items(),
+    )
+    return (
+        LaunchDescription(
+            [sim, TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()])]
+        ),
+        {},
+    )
+
+
+def quat_to_matrix(q):
+    """geometry_msgs Quaternion to a 3x3 rotation matrix."""
+    x, y, z, w = q.x, q.y, q.z, q.w
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+        [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+        [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+    ])
+
+
+class LidarGeometryTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_lidar_geometry")
+        # Bounded: 11520-point clouds at 10 Hz over a long bring-up would otherwise be
+        # hundreds of megabytes, the resource-starvation shape that bit milestone 3.
+        cls.clouds = deque(maxlen=4)
+        cls.poses = deque(maxlen=4)
+        cls.stamps = deque(maxlen=512)
+        cls.node.create_subscription(
+            PointCloud2, CLOUD_TOPIC, cls._on_cloud, qos_profile_sensor_data
+        )
+        cls.node.create_subscription(
+            PoseStamped, POSE_TOPIC, cls.poses.append, qos_profile_sensor_data
+        )
+        cls._wait(lambda: len(cls.clouds) > 0 and len(cls.poses) > 0, BRINGUP_TIMEOUT_S)
+
+    @classmethod
+    def _on_cloud(cls, msg):
+        cls.clouds.append(msg)
+        cls.stamps.append(time.time())
+
+    @classmethod
+    def _wait(cls, predicate, timeout_s):
+        end = time.time() + timeout_s
+        while time.time() < end:
+            rclpy.spin_once(cls.node, timeout_sec=0.05)
+            if predicate():
+                return True
+        return False
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def latest_cloud(self):
+        self.assertTrue(self.clouds, f"nothing published on {CLOUD_TOPIC}")
+        return self.clouds[-1]
+
+    def sensor_points(self, msg):
+        n = msg.width * msg.height
+        raw = np.frombuffer(msg.data, dtype=np.uint8).reshape(n, msg.point_step)
+        return (
+            np.frombuffer(raw[:, 0:12].tobytes(), dtype=np.float32)
+            .reshape(n, 3)
+            .astype(np.float64)
+        )
+
+    def world_returns(self):
+        """Actual returns, in world coordinates, using the simulator's own sensor pose."""
+        self.assertTrue(self.poses, f"nothing published on {POSE_TOPIC}")
+        cloud = self.latest_cloud()
+        pose = self.poses[-1]
+
+        pts = self.sensor_points(cloud)
+        # A zero point is "no return", not a point at the sensor origin.
+        hit = np.linalg.norm(pts, axis=1) > 1e-6
+        rotation = quat_to_matrix(pose.pose.orientation)
+        origin = np.array(
+            [pose.pose.position.x, pose.pose.position.y, pose.pose.position.z]
+        )
+        return (rotation @ pts[hit].T).T + origin, origin
+
+    def test_01_streams_at_the_configured_rate(self):
+        self.stamps.clear()
+        self.spin(3.0)
+        self.assertGreater(len(self.stamps), 2, f"{CLOUD_TOPIC} is not streaming")
+        rate = (len(self.stamps) - 1) / (self.stamps[-1] - self.stamps[0])
+        self.assertGreater(rate, 7.0, f"{rate:.2f} Hz, configured {CONFIGURED_RATE_HZ}")
+        self.assertLess(rate, 13.0, f"{rate:.2f} Hz, configured {CONFIGURED_RATE_HZ}")
+
+    def test_02_cloud_layout_matches_the_configured_sweep(self):
+        msg = self.latest_cloud()
+        self.assertEqual(msg.header.frame_id, "mid360_link")
+        self.assertEqual(msg.width * msg.height, EXPECTED_POINTS)
+        self.assertEqual([f.name for f in msg.fields][:3], ["x", "y", "z"])
+        self.assertEqual(msg.point_step, 12)
+
+    def test_03_returns_are_in_range_and_plentiful(self):
+        pts = self.sensor_points(self.latest_cloud())
+        ranges = np.linalg.norm(pts, axis=1)
+        hit = ranges > 1e-6
+        self.assertGreater(
+            hit.mean(), 0.5, f"only {100 * hit.mean():.1f}% of rays returned inside a closed room"
+        )
+        self.assertGreaterEqual(ranges[hit].min(), RANGE_MIN - 1e-3)
+        self.assertLessEqual(ranges[hit].max(), RANGE_MAX)
+
+    def test_04_the_sensor_is_where_the_mount_puts_it(self):
+        """Height above the floor, from the vendored URDF mount on a pinned pelvis.
+
+        Not a round number by choice: it is the waist chain plus mid360_joint's own offset,
+        so a wrong mount or a wrong torso pose moves it.
+        """
+        _, origin = self.world_returns()
+        self.assertAlmostEqual(
+            origin[2],
+            1.275,
+            delta=0.08,
+            msg=f"sensor at z={origin[2]:.4f}; the Mid360 sits ~1.275 m up on a pinned G1",
+        )
+        self.assertLess(abs(origin[0]), 0.5, "sensor drifted in x on a pinned pelvis")
+        self.assertLess(abs(origin[1]), 0.5, "sensor drifted in y on a pinned pelvis")
+
+    def test_05_every_return_lies_inside_the_room(self):
+        """The decisive geometric check: the cloud describes this room and no other."""
+        world, _ = self.world_returns()
+        self.assertGreater(len(world), 1000, "too few returns to characterise the room")
+
+        inside = (
+            (np.abs(world[:, 0]) <= ROOM_HALF + 0.02)
+            & (np.abs(world[:, 1]) <= ROOM_HALF + 0.02)
+            & (world[:, 2] >= -0.02)
+            & (world[:, 2] <= WALL_TOP + 0.02)
+        )
+        self.assertGreater(
+            inside.mean(),
+            0.99,
+            f"only {100 * inside.mean():.2f}% of returns are inside the room; the walls sit "
+            f"at +/-{ROOM_HALF} m and the floor at z=0",
+        )
+
+    def test_06_the_floor_and_the_walls_are_both_seen(self):
+        """A cloud that saw only the floor would still pass test_05."""
+        world, _ = self.world_returns()
+
+        floor = np.abs(world[:, 2]) < 0.05
+        self.assertGreater(
+            int(floor.sum()), 200, f"only {floor.sum()} returns on the floor plane"
+        )
+
+        # Every wall, so a sweep that lost a sector fails rather than averaging out.
+        for axis, sign, name in ((0, 1, "+x"), (0, -1, "-x"), (1, 1, "+y"), (1, -1, "-y")):
+            on_wall = np.abs(world[:, axis] - sign * ROOM_HALF) < 0.05
+            self.assertGreater(
+                int(on_wall.sum()), 20, f"only {on_wall.sum()} returns on the {name} wall"
+            )

--- a/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
@@ -51,7 +51,12 @@ def generate_test_description():
         PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory("g1_bringup"), "launch", "sim.launch.py")
         ),
-        launch_arguments={"sensors": "true", "pin_pelvis": "true"}.items(),
+        launch_arguments={
+            "sensors": "true",
+            "pin_pelvis": "true",
+            # The small bare room this test's numbers come from, not the facility.
+            "world": "perception",
+        }.items(),
     )
     return (
         LaunchDescription(

--- a/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
+++ b/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
@@ -4,6 +4,26 @@
   <!-- Verbatim upstream description; xacro:include discards <robot> wrapper. -->
   <xacro:include filename="g1_29dof_with_hand_rev_1_0.urdf"/>
 
+  <!-- REP-145 optical frames. The vendored URDF stops at d435_link, which is a body frame
+       (x forward, y left, z up); every ROS depth consumer, rviz's DepthCloud included,
+       assumes the optical convention (z forward, x right, y down). Publishing a depth
+       image in the body frame projects it rotated 90 degrees, which looks like a broken
+       sensor rather than a wrong frame. Added here rather than in the vendored file so
+       that stays verbatim. -->
+  <link name="camera_depth_optical_frame"/>
+  <joint name="camera_depth_optical_joint" type="fixed">
+    <parent link="d435_link"/>
+    <child link="camera_depth_optical_frame"/>
+    <origin xyz="0 0 0" rpy="-1.5707963267948966 0 -1.5707963267948966"/>
+  </joint>
+
+  <link name="camera_color_optical_frame"/>
+  <joint name="camera_color_optical_joint" type="fixed">
+    <parent link="d435_link"/>
+    <child link="camera_color_optical_frame"/>
+    <origin xyz="0 0 0" rpy="-1.5707963267948966 0 -1.5707963267948966"/>
+  </joint>
+
   <!-- Load tunable YAML for ROS 2 control parameters. -->
   <xacro:property name="arm_sdk_params" value="${xacro.load_yaml('../config/arm_sdk_params.yaml')}"/>
 

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -4,6 +4,7 @@ project(g1_sensor_relay)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 # Framing and validation, free of ROS and sockets so the wire format tests without a
 # simulator or a running graph.
@@ -16,7 +17,7 @@ target_compile_features(frame_reader PUBLIC cxx_std_17)
 
 add_executable(g1_sensor_relay src/g1_sensor_relay_node.cpp)
 target_link_libraries(g1_sensor_relay PUBLIC frame_reader)
-ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs)
+ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs geometry_msgs)
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS frame_reader EXPORT export_${PROJECT_NAME} DESTINATION lib)

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_sensor_relay)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+# Framing and validation, free of ROS and sockets so the wire format tests without a
+# simulator or a running graph.
+add_library(frame_reader src/frame_reader.cpp)
+target_include_directories(frame_reader PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(frame_reader PUBLIC cxx_std_17)
+
+add_executable(g1_sensor_relay src/g1_sensor_relay_node.cpp)
+target_link_libraries(g1_sensor_relay PUBLIC frame_reader)
+ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS frame_reader EXPORT export_${PROJECT_NAME} DESTINATION lib)
+install(TARGETS g1_sensor_relay DESTINATION lib/${PROJECT_NAME})
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gmock REQUIRED)
+  ament_add_gmock(test_frame_reader test/test_frame_reader.cpp)
+  target_link_libraries(test_frame_reader frame_reader)
+  # The wire-format drift check reads both copies of sensor_frame.h by relative path.
+  set_tests_properties(test_frame_reader PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # Lint checks use workspace-root configs (see g1_description/CMakeLists.txt).
+  find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+  set(_clang_format_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+  if(CLANG_FORMAT_EXECUTABLE AND EXISTS "${_clang_format_config}")
+    file(GLOB_RECURSE _format_sources
+      "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp"
+    )
+    add_test(
+      NAME clang_format_check_g1_sensor_relay
+      COMMAND ${CLANG_FORMAT_EXECUTABLE} --style=file:${_clang_format_config} --dry-run --Werror
+        ${_format_sources}
+    )
+  else()
+    message(WARNING
+      "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_sensor_relay test")
+  endif()
+endif()
+
+ament_package()

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
@@ -48,9 +48,9 @@ struct CloudFrame
     /// rgb8, row-major, top-down, same dimensions as `depth`. Empty when colour is off.
     std::vector<std::uint8_t> rgb;
     double                    sim_time_s = 0.0;
-    double             sensor_pos[3]{};
-    double             sensor_quat[4]{};
-    std::vector<float> points;
+    double                    sensor_pos[3]{};
+    double                    sensor_quat[4]{};
+    std::vector<float>        points;
 };
 
 /**

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
@@ -45,7 +45,9 @@ struct CloudFrame
     std::uint32_t      height   = 0;
     float              fovy_deg = 0.0f;
     std::vector<float> depth;
-    double             sim_time_s = 0.0;
+    /// rgb8, row-major, top-down, same dimensions as `depth`. Empty when colour is off.
+    std::vector<std::uint8_t> rgb;
+    double                    sim_time_s = 0.0;
     double             sensor_pos[3]{};
     double             sensor_quat[4]{};
     std::vector<float> points;

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
@@ -1,0 +1,64 @@
+#ifndef G1_SENSOR_RELAY__FRAME_READER_HPP_
+#define G1_SENSOR_RELAY__FRAME_READER_HPP_
+
+/**
+ * @file frame_reader.hpp
+ * @brief Framing and validation for the simulator's sensor stream, free of ROS and sockets.
+ *
+ * Split out so the wire format is testable without a simulator, a socket or a running
+ * graph, same discipline as g1_state_estimation's odom_math.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "g1_sensor_relay/sensor_frame.h"
+
+namespace g1_sensor_relay
+{
+
+/// Why a frame was rejected. Anything but Ok means the bytes are not trustworthy.
+enum class FrameStatus
+{
+    Ok,
+    Incomplete,  ///< Not enough bytes yet; wait for more.
+    BadMagic,    ///< Not our stream, or the stream desynchronised.
+    BadVersion,  ///< Producer and consumer disagree on the layout.
+    BadKind,     ///< A frame type this build does not know.
+    BadLength,   ///< payload_bytes disagrees with point_count, or exceeds the sane cap.
+};
+
+/// A validated point cloud frame. Points are xyz triples in the sensor frame.
+struct CloudFrame
+{
+    double             sim_time_s = 0.0;
+    double             sensor_pos[3]{};
+    double             sensor_quat[4]{};
+    std::vector<float> points;
+};
+
+/**
+ * @brief Refuses a frame larger than this many points.
+ *
+ * A desynchronised stream produces a garbage length, and trusting it means a multi-gigabyte
+ * allocation. Well above any resolution we would configure.
+ */
+inline constexpr std::uint32_t kMaxPoints = 4'000'000;
+
+/**
+ * @brief Attempts to take one frame from the front of `buffer`.
+ *
+ * On FrameStatus::Ok the consumed bytes are erased from `buffer` and `out` is filled. On
+ * Incomplete nothing is consumed. On any other status the caller must drop the connection:
+ * the stream cannot be resynchronised, and pretending otherwise turns a framing bug into
+ * plausible-looking point clouds.
+ */
+FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out);
+
+/// Human-readable status, for logging.
+const char* toString(FrameStatus status);
+
+}  // namespace g1_sensor_relay
+
+#endif  // G1_SENSOR_RELAY__FRAME_READER_HPP_

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
@@ -29,9 +29,22 @@ enum class FrameStatus
     BadLength,   ///< payload_bytes disagrees with point_count, or exceeds the sane cap.
 };
 
-/// A validated point cloud frame. Points are xyz triples in the sensor frame.
+/// What a validated frame turned out to be.
+enum class FrameKind
+{
+    PointCloud,
+    Depth,
+};
+
+/// A validated frame. `kind` says which payload interpretation applies: `points` is xyz
+/// triples in the sensor frame, `depth` is metres, row-major, top-down.
 struct CloudFrame
 {
+    FrameKind          kind     = FrameKind::PointCloud;
+    std::uint32_t      width    = 0;
+    std::uint32_t      height   = 0;
+    float              fovy_deg = 0.0f;
+    std::vector<float> depth;
     double             sim_time_s = 0.0;
     double             sensor_pos[3]{};
     double             sensor_quat[4]{};

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
@@ -1,0 +1,55 @@
+#ifndef GROVE_G1_SENSOR_FRAME_H_
+#define GROVE_G1_SENSOR_FRAME_H_
+
+// Wire format between the patched unitree_mujoco and g1_sensor_relay.
+//
+// Shared verbatim by both sides: the copy under workspace/vendor is the one compiled into
+// the simulator, and g1_sensor_relay includes the same file. Keep them identical; a
+// test in g1_sensor_relay asserts the two copies match byte for byte.
+
+#include <cstdint>
+
+namespace grove_g1
+{
+
+// Bumped whenever the layout below changes. The relay refuses a frame it does not know
+// rather than reinterpreting bytes.
+inline constexpr uint32_t kSensorFrameVersion = 1;
+
+inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
+
+enum class SensorFrameKind : uint32_t
+{
+    PointCloud = 1,
+};
+
+// Fixed-size header, then `payload_bytes` of body. Length-prefixed so the stream can be
+// framed without parsing the body, and so a short read is detectable rather than silently
+// producing a truncated cloud.
+struct SensorFrameHeader
+{
+    uint32_t magic;          // kSensorFrameMagic
+    uint32_t version;        // kSensorFrameVersion
+    uint32_t kind;           // SensorFrameKind
+    uint32_t payload_bytes;  // body length that follows this header
+
+    // Sim time of the snapshot the frame was computed from, not wall time: the relay stamps
+    // messages with this so downstream TF lookups line up with /clock.
+    double sim_time_s;
+
+    // Sensor pose in the world at snapshot time, as position + wxyz quaternion. The relay
+    // publishes the cloud in the sensor frame, so this is carried for provenance and for
+    // the relay's own sanity checks rather than to transform the points.
+    double sensor_pos[3];
+    double sensor_quat[4];
+
+    // PointCloud: number of points that follow, each 3 floats (x, y, z) in the sensor frame.
+    uint32_t point_count;
+    uint32_t reserved;
+};
+
+static_assert(sizeof(SensorFrameHeader) == 88, "wire layout changed; bump kSensorFrameVersion");
+
+}  // namespace grove_g1
+
+#endif  // GROVE_G1_SENSOR_FRAME_H_

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
@@ -13,8 +13,9 @@ namespace grove_g1
 {
 
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
-// rather than reinterpreting bytes. v2 added the depth-image fields.
-inline constexpr uint32_t kSensorFrameVersion = 2;
+// rather than reinterpreting bytes. v2 added the depth-image fields; v3 appends colour
+// to the depth payload.
+inline constexpr uint32_t kSensorFrameVersion = 3;
 
 inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
 
@@ -51,7 +52,10 @@ struct SensorFrameHeader
     uint32_t height;
     float    fovy_deg;
 
-    uint32_t reserved;
+    // Depth: bytes of rgb8 colour appended after the depth floats, or 0 when colour is
+    // off. Both come from one mjr_readPixels of one render, so they share a pose, a
+    // timestamp and a frustum by construction rather than by the relay pairing them up.
+    uint32_t rgb_bytes;
 };
 
 static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
@@ -13,14 +13,15 @@ namespace grove_g1
 {
 
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
-// rather than reinterpreting bytes.
-inline constexpr uint32_t kSensorFrameVersion = 1;
+// rather than reinterpreting bytes. v2 added the depth-image fields.
+inline constexpr uint32_t kSensorFrameVersion = 2;
 
 inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
 
 enum class SensorFrameKind : uint32_t
 {
     PointCloud = 1,
+    Depth      = 2,
 };
 
 // Fixed-size header, then `payload_bytes` of body. Length-prefixed so the stream can be
@@ -33,22 +34,27 @@ struct SensorFrameHeader
     uint32_t kind;           // SensorFrameKind
     uint32_t payload_bytes;  // body length that follows this header
 
-    // Sim time of the snapshot the frame was computed from, not wall time: the relay stamps
-    // messages with this so downstream TF lookups line up with /clock.
+    // Sim time of the snapshot the frame was computed from. Carried for provenance; the
+    // relay stamps messages with its own clock, because this track publishes no /clock.
     double sim_time_s;
 
-    // Sensor pose in the world at snapshot time, as position + wxyz quaternion. The relay
-    // publishes the cloud in the sensor frame, so this is carried for provenance and for
-    // the relay's own sanity checks rather than to transform the points.
+    // Sensor pose in the world at snapshot time, as position + wxyz quaternion.
     double sensor_pos[3];
     double sensor_quat[4];
 
-    // PointCloud: number of points that follow, each 3 floats (x, y, z) in the sensor frame.
+    // PointCloud: number of points, each 3 floats (x, y, z) in the sensor frame.
     uint32_t point_count;
+
+    // Depth: image dimensions and the vertical field of view the render used. fovy is
+    // carried rather than assumed so the relay's camera_info cannot drift from the MJCF.
+    uint32_t width;
+    uint32_t height;
+    float    fovy_deg;
+
     uint32_t reserved;
 };
 
-static_assert(sizeof(SensorFrameHeader) == 88, "wire layout changed; bump kSensorFrameVersion");
+static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");
 
 }  // namespace grove_g1
 

--- a/workspace/src/g1_sensor_relay/package.xml
+++ b/workspace/src/g1_sensor_relay/package.xml
@@ -17,6 +17,7 @@
 
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/workspace/src/g1_sensor_relay/package.xml
+++ b/workspace/src/g1_sensor_relay/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_sensor_relay</name>
+  <version>0.1.0</version>
+  <description>
+    Publishes sensor data sampled inside the patched unitree_mujoco. The simulator
+    computes the sweep against its own mjData and hands finished frames over a local
+    socket; this node turns them into ROS 2 messages. The split exists because
+    unitree_sdk2 already owns the CycloneDDS domain in that process and rmw_cyclonedds
+    cannot share it. See README.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_sensor_relay/src/frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/src/frame_reader.cpp
@@ -1,0 +1,83 @@
+#include "g1_sensor_relay/frame_reader.hpp"
+
+#include <cstring>
+
+namespace g1_sensor_relay
+{
+
+FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
+{
+    using grove_g1::SensorFrameHeader;
+    using grove_g1::SensorFrameKind;
+
+    if (buffer.size() < sizeof(SensorFrameHeader))
+    {
+        return FrameStatus::Incomplete;
+    }
+
+    SensorFrameHeader header;
+    std::memcpy(&header, buffer.data(), sizeof(header));
+
+    if (header.magic != grove_g1::kSensorFrameMagic)
+    {
+        return FrameStatus::BadMagic;
+    }
+    if (header.version != grove_g1::kSensorFrameVersion)
+    {
+        return FrameStatus::BadVersion;
+    }
+    if (header.kind != static_cast<std::uint32_t>(SensorFrameKind::PointCloud))
+    {
+        return FrameStatus::BadKind;
+    }
+    if (header.point_count > kMaxPoints)
+    {
+        return FrameStatus::BadLength;
+    }
+    // Checked before the length is trusted for anything: a desynchronised stream otherwise
+    // reserves whatever garbage it read.
+    if (header.payload_bytes != header.point_count * 3u * sizeof(float))
+    {
+        return FrameStatus::BadLength;
+    }
+
+    const std::size_t total = sizeof(header) + header.payload_bytes;
+    if (buffer.size() < total)
+    {
+        return FrameStatus::Incomplete;
+    }
+
+    out.sim_time_s = header.sim_time_s;
+    std::memcpy(out.sensor_pos, header.sensor_pos, sizeof(out.sensor_pos));
+    std::memcpy(out.sensor_quat, header.sensor_quat, sizeof(out.sensor_quat));
+    out.points.resize(static_cast<std::size_t>(header.point_count) * 3u);
+    if (header.payload_bytes > 0)
+    {
+        std::memcpy(out.points.data(), buffer.data() + sizeof(header), header.payload_bytes);
+    }
+
+    buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(total));
+    return FrameStatus::Ok;
+}
+
+const char* toString(FrameStatus status)
+{
+    switch (status)
+    {
+        case FrameStatus::Ok:
+            return "ok";
+        case FrameStatus::Incomplete:
+            return "incomplete";
+        case FrameStatus::BadMagic:
+            return "bad magic (stream desynchronised or not ours)";
+        case FrameStatus::BadVersion:
+            return "version mismatch between simulator and relay";
+        case FrameStatus::BadKind:
+            return "unknown frame kind";
+        case FrameStatus::BadLength:
+            return "payload length inconsistent with point count";
+    }
+    return "unknown";
+}
+
+}  // namespace g1_sensor_relay

--- a/workspace/src/g1_sensor_relay/src/frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/src/frame_reader.cpp
@@ -81,15 +81,17 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     {
         out.kind = FrameKind::Depth;
         out.points.clear();
-        const std::size_t px = static_cast<std::size_t>(header.width) * header.height;
+        const std::size_t px          = static_cast<std::size_t>(header.width) * header.height;
         const std::size_t depth_bytes = px * sizeof(float);
         out.depth.resize(px);
         std::memcpy(out.depth.data(), buffer.data() + sizeof(header), depth_bytes);
         out.rgb.resize(header.rgb_bytes);
         if (header.rgb_bytes != 0)
         {
-            std::memcpy(out.rgb.data(), buffer.data() + sizeof(header) + depth_bytes,
-                        header.rgb_bytes);
+            std::memcpy(
+                out.rgb.data(),
+                buffer.data() + sizeof(header) + depth_bytes,
+                header.rgb_bytes);
         }
     }
 

--- a/workspace/src/g1_sensor_relay/src/frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/src/frame_reader.cpp
@@ -26,19 +26,30 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     {
         return FrameStatus::BadVersion;
     }
-    if (header.kind != static_cast<std::uint32_t>(SensorFrameKind::PointCloud))
+    const bool is_cloud = header.kind == static_cast<std::uint32_t>(SensorFrameKind::PointCloud);
+    const bool is_depth = header.kind == static_cast<std::uint32_t>(SensorFrameKind::Depth);
+    if (!is_cloud && !is_depth)
     {
         return FrameStatus::BadKind;
     }
-    if (header.point_count > kMaxPoints)
+    // Every length is checked before it is trusted for anything: a desynchronised stream
+    // otherwise reserves whatever garbage it read.
+    if (is_cloud)
     {
-        return FrameStatus::BadLength;
+        if (header.point_count > kMaxPoints ||
+            header.payload_bytes != header.point_count * 3u * sizeof(float))
+        {
+            return FrameStatus::BadLength;
+        }
     }
-    // Checked before the length is trusted for anything: a desynchronised stream otherwise
-    // reserves whatever garbage it read.
-    if (header.payload_bytes != header.point_count * 3u * sizeof(float))
+    else
     {
-        return FrameStatus::BadLength;
+        const std::uint64_t pixels =
+            static_cast<std::uint64_t>(header.width) * static_cast<std::uint64_t>(header.height);
+        if (pixels == 0 || pixels > kMaxPoints || header.payload_bytes != pixels * sizeof(float))
+        {
+            return FrameStatus::BadLength;
+        }
     }
 
     const std::size_t total = sizeof(header) + header.payload_bytes;
@@ -50,10 +61,25 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     out.sim_time_s = header.sim_time_s;
     std::memcpy(out.sensor_pos, header.sensor_pos, sizeof(out.sensor_pos));
     std::memcpy(out.sensor_quat, header.sensor_quat, sizeof(out.sensor_quat));
-    out.points.resize(static_cast<std::size_t>(header.point_count) * 3u);
-    if (header.payload_bytes > 0)
+    out.width    = header.width;
+    out.height   = header.height;
+    out.fovy_deg = header.fovy_deg;
+    if (is_cloud)
     {
-        std::memcpy(out.points.data(), buffer.data() + sizeof(header), header.payload_bytes);
+        out.kind = FrameKind::PointCloud;
+        out.depth.clear();
+        out.points.resize(static_cast<std::size_t>(header.point_count) * 3u);
+        if (header.payload_bytes > 0)
+        {
+            std::memcpy(out.points.data(), buffer.data() + sizeof(header), header.payload_bytes);
+        }
+    }
+    else
+    {
+        out.kind = FrameKind::Depth;
+        out.points.clear();
+        out.depth.resize(static_cast<std::size_t>(header.width) * header.height);
+        std::memcpy(out.depth.data(), buffer.data() + sizeof(header), header.payload_bytes);
     }
 
     buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(total));

--- a/workspace/src/g1_sensor_relay/src/frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/src/frame_reader.cpp
@@ -46,7 +46,10 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     {
         const std::uint64_t pixels =
             static_cast<std::uint64_t>(header.width) * static_cast<std::uint64_t>(header.height);
-        if (pixels == 0 || pixels > kMaxPoints || header.payload_bytes != pixels * sizeof(float))
+        const std::uint64_t expect =
+            pixels * sizeof(float) + static_cast<std::uint64_t>(header.rgb_bytes);
+        if (pixels == 0 || pixels > kMaxPoints || header.payload_bytes != expect ||
+            (header.rgb_bytes != 0 && header.rgb_bytes != pixels * 3u))
         {
             return FrameStatus::BadLength;
         }
@@ -78,8 +81,16 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     {
         out.kind = FrameKind::Depth;
         out.points.clear();
-        out.depth.resize(static_cast<std::size_t>(header.width) * header.height);
-        std::memcpy(out.depth.data(), buffer.data() + sizeof(header), header.payload_bytes);
+        const std::size_t px = static_cast<std::size_t>(header.width) * header.height;
+        const std::size_t depth_bytes = px * sizeof(float);
+        out.depth.resize(px);
+        std::memcpy(out.depth.data(), buffer.data() + sizeof(header), depth_bytes);
+        out.rgb.resize(header.rgb_bytes);
+        if (header.rgb_bytes != 0)
+        {
+            std::memcpy(out.rgb.data(), buffer.data() + sizeof(header) + depth_bytes,
+                        header.rgb_bytes);
+        }
     }
 
     buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(total));

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -40,7 +40,10 @@ public:
         frame_id_       = declare_parameter<std::string>("frame_id", "mid360_link");
         world_frame_id_ = declare_parameter<std::string>("world_frame_id", "world");
         const std::string topic = declare_parameter<std::string>("topic", "/livox/lidar");
-        poll_hz_                = declare_parameter<double>("poll_hz", 200.0);
+        // 500 Hz, not 200: a depth+colour frame is ~2.9 MB and the socket hands over about
+        // one receive buffer per wakeup, so the poll rate sets how fast a frame can land.
+        // At 200 Hz the sender hit its retry deadline mid-frame and reset the connection.
+        poll_hz_                = declare_parameter<double>("poll_hz", 500.0);
 
         // Sensor QoS: only the newest cloud matters, and a reliable publisher against a
         // best-effort subscriber is the usual reason nothing shows up in rviz.
@@ -52,8 +55,12 @@ public:
         // already has a parent through robot_state_publisher, and a second one would make
         // the tree ambiguous. It is what lets a test check cloud geometry against the room
         // before odom -> pelvis exists.
+        // REP-145 optical frames, not d435_link. Depth consumers assume z forward / x right
+        // / y down; handed the body frame they project the cloud rotated 90 degrees.
         depth_frame_id_ =
             declare_parameter<std::string>("depth_frame_id", "camera_depth_optical_frame");
+        color_frame_id_ =
+            declare_parameter<std::string>("color_frame_id", "camera_color_optical_frame");
         depth_pub_ = create_publisher<sensor_msgs::msg::Image>(
             declare_parameter<std::string>("depth_topic", "/camera/aligned_depth_to_color/image_raw"),
             rclcpp::SensorDataQoS());
@@ -63,6 +70,9 @@ public:
             declare_parameter<std::string>(
                 "depth_info_topic",
                 "/camera/aligned_depth_to_color/camera_info"),
+            rclcpp::SensorDataQoS());
+        color_pub_ = create_publisher<sensor_msgs::msg::Image>(
+            declare_parameter<std::string>("color_topic", "/camera/color/image_raw"),
             rclcpp::SensorDataQoS());
         info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
             declare_parameter<std::string>("info_topic", "/camera/color/camera_info"),
@@ -238,8 +248,26 @@ private:
         info.p          = { f, 0, cx, 0, 0, f, cy, 0, 0, 0, 1, 0 };
 
         depth_pub_->publish(std::move(img));
-        info_pub_->publish(info);
         depth_info_pub_->publish(info);
+
+        // Same render, so the colour stream shares the depth intrinsics exactly; a real
+        // D435i only gets that from its align_depth_to_color step.
+        info.header.frame_id = color_frame_id_;
+        info_pub_->publish(info);
+
+        if (!frame.rgb.empty())
+        {
+            sensor_msgs::msg::Image color;
+            color.header.stamp    = img.header.stamp;
+            color.header.frame_id = color_frame_id_;
+            color.height          = frame.height;
+            color.width           = frame.width;
+            color.encoding        = "rgb8";
+            color.is_bigendian    = 0;
+            color.step            = frame.width * 3;
+            color.data.assign(frame.rgb.begin(), frame.rgb.end());
+            color_pub_->publish(std::move(color));
+        }
     }
 
     void publish(const CloudFrame& frame)
@@ -293,6 +321,7 @@ private:
     std::string frame_id_;
     std::string world_frame_id_;
     std::string depth_frame_id_;
+    std::string color_frame_id_;
     double      poll_hz_ = 200.0;
 
     int                       listen_fd_ = -1;
@@ -302,6 +331,7 @@ private:
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr   cloud_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr         depth_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr         color_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr    info_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr    depth_info_pub_;
     rclcpp::TimerBase::SharedPtr                                  timer_;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -40,10 +40,12 @@ public:
         frame_id_       = declare_parameter<std::string>("frame_id", "mid360_link");
         world_frame_id_ = declare_parameter<std::string>("world_frame_id", "world");
         const std::string topic = declare_parameter<std::string>("topic", "/livox/lidar");
-        // 500 Hz, not 200: a depth+colour frame is ~2.9 MB and the socket hands over about
-        // one receive buffer per wakeup, so the poll rate sets how fast a frame can land.
-        // At 200 Hz the sender hit its retry deadline mid-frame and reset the connection.
-        poll_hz_                = declare_parameter<double>("poll_hz", 500.0);
+        // 500 Hz rather than 200 as margin for the simulator's fallback path: when it cannot
+        // force a large send buffer, a ~2.9 MB depth+colour frame arrives about one receive
+        // buffer per wakeup, and at 200 Hz the sender hit its retry deadline mid-frame and
+        // reset the connection. With the buffer forced the frame lands in one go and the
+        // rate does not matter; polling this often costs only a recv that returns EAGAIN.
+        poll_hz_ = declare_parameter<double>("poll_hz", 500.0);
 
         // Sensor QoS: only the newest cloud matters, and a reliable publisher against a
         // best-effort subscriber is the usual reason nothing shows up in rviz.
@@ -88,7 +90,7 @@ public:
         }
 
         // Polled rather than event-driven on purpose: one node, one thread, no executor
-        // surprises, and the cost is a nonblocking accept plus a read at 200 Hz.
+        // surprises, and the cost is a nonblocking accept plus a read at 500 Hz.
         timer_ =
             create_wall_timer(std::chrono::duration<double>(1.0 / poll_hz_), [this]() { poll(); });
 
@@ -164,7 +166,7 @@ private:
         }
 
         // Drain whatever is available, then publish every complete frame in it. Draining
-        // fully matters: at 200 Hz polling against 10 Hz frames the socket is usually
+        // fully matters: at 500 Hz polling against 10 Hz frames the socket is usually
         // empty, but after any hiccup several frames can be queued.
         std::uint8_t chunk[65536];
         for (;;)
@@ -322,7 +324,7 @@ private:
     std::string world_frame_id_;
     std::string depth_frame_id_;
     std::string color_frame_id_;
-    double      poll_hz_ = 200.0;
+    double      poll_hz_ = 500.0;
 
     int                       listen_fd_ = -1;
     int                       client_fd_ = -1;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -14,10 +14,13 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cmath>
 #include <cstring>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <string>
 #include <vector>
@@ -49,6 +52,15 @@ public:
         // already has a parent through robot_state_publisher, and a second one would make
         // the tree ambiguous. It is what lets a test check cloud geometry against the room
         // before odom -> pelvis exists.
+        depth_frame_id_ =
+            declare_parameter<std::string>("depth_frame_id", "camera_depth_optical_frame");
+        depth_pub_ = create_publisher<sensor_msgs::msg::Image>(
+            declare_parameter<std::string>("depth_topic", "/camera/aligned_depth_to_color/image_raw"),
+            rclcpp::SensorDataQoS());
+        info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
+            declare_parameter<std::string>("info_topic", "/camera/color/camera_info"),
+            rclcpp::SensorDataQoS());
+
         pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>(
             "~/sensor_pose",
             rclcpp::SensorDataQoS());
@@ -177,8 +189,49 @@ private:
                 closeClient();
                 return;
             }
-            publish(frame);
+            if (frame.kind == FrameKind::Depth)
+            {
+                publishDepth(frame);
+            }
+            else
+            {
+                publish(frame);
+            }
         }
+    }
+
+    void publishDepth(const CloudFrame& frame)
+    {
+        sensor_msgs::msg::Image img;
+        img.header.stamp    = now();
+        img.header.frame_id = depth_frame_id_;
+        img.height          = frame.height;
+        img.width           = frame.width;
+        // 32FC1 metres. The simulator linearises MuJoCo's non-linear depth buffer before
+        // sending, so nothing downstream has to know about znear/zfar.
+        img.encoding     = "32FC1";
+        img.is_bigendian = 0;
+        img.step         = frame.width * sizeof(float);
+        img.data.resize(frame.depth.size() * sizeof(float));
+        std::memcpy(img.data.data(), frame.depth.data(), img.data.size());
+
+        sensor_msgs::msg::CameraInfo info;
+        info.header           = img.header;
+        info.height           = frame.height;
+        info.width            = frame.width;
+        info.distortion_model = "plumb_bob";
+        info.d.assign(5, 0.0);
+        // fovy is vertical in MuJoCo, and is carried in the frame rather than assumed so
+        // camera_info cannot drift from what the render actually used.
+        const double f  = frame.height / (2.0 * std::tan(frame.fovy_deg * M_PI / 180.0 / 2.0));
+        const double cx = frame.width / 2.0;
+        const double cy = frame.height / 2.0;
+        info.k          = { f, 0, cx, 0, f, cy, 0, 0, 1 };
+        info.r          = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+        info.p          = { f, 0, cx, 0, 0, f, cy, 0, 0, 0, 1, 0 };
+
+        depth_pub_->publish(std::move(img));
+        info_pub_->publish(info);
     }
 
     void publish(const CloudFrame& frame)
@@ -231,6 +284,7 @@ private:
     std::string socket_path_;
     std::string frame_id_;
     std::string world_frame_id_;
+    std::string depth_frame_id_;
     double      poll_hz_ = 200.0;
 
     int                       listen_fd_ = -1;
@@ -239,6 +293,8 @@ private:
 
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr   cloud_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr         depth_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr    info_pub_;
     rclcpp::TimerBase::SharedPtr                                  timer_;
 };
 

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -1,0 +1,224 @@
+/**
+ * @file g1_sensor_relay_node.cpp
+ * @brief Turns sensor frames sampled inside unitree_mujoco into ROS 2 messages.
+ *
+ * The simulator computes the sweep against its own mjData, because that is the only place
+ * the scene exists, and hands finished frames over a local socket. This node owns the ROS
+ * side. The split is forced: unitree_sdk2 already calls dds_create_domain in that process
+ * and rmw_cyclonedds does the same unconditionally, so only one of them can live there.
+ */
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <string>
+#include <vector>
+
+#include "g1_sensor_relay/frame_reader.hpp"
+
+namespace g1_sensor_relay
+{
+
+class SensorRelay : public rclcpp::Node
+{
+public:
+    SensorRelay()
+      : rclcpp::Node("g1_sensor_relay")
+    {
+        socket_path_ = declare_parameter<std::string>("socket_path", "/tmp/g1_sensors.sock");
+        frame_id_    = declare_parameter<std::string>("frame_id", "mid360_link");
+        const std::string topic = declare_parameter<std::string>("topic", "/livox/lidar");
+        poll_hz_                = declare_parameter<double>("poll_hz", 200.0);
+
+        // Sensor QoS: only the newest cloud matters, and a reliable publisher against a
+        // best-effort subscriber is the usual reason nothing shows up in rviz.
+        cloud_pub_ =
+            create_publisher<sensor_msgs::msg::PointCloud2>(topic, rclcpp::SensorDataQoS());
+
+        if (!openListener())
+        {
+            throw std::runtime_error("could not open " + socket_path_);
+        }
+
+        // Polled rather than event-driven on purpose: one node, one thread, no executor
+        // surprises, and the cost is a nonblocking accept plus a read at 200 Hz.
+        timer_ =
+            create_wall_timer(std::chrono::duration<double>(1.0 / poll_hz_), [this]() { poll(); });
+
+        RCLCPP_INFO(
+            get_logger(),
+            "Listening on %s, publishing %s in frame %s",
+            socket_path_.c_str(),
+            topic.c_str(),
+            frame_id_.c_str());
+    }
+
+    ~SensorRelay() override
+    {
+        closeClient();
+        if (listen_fd_ >= 0)
+        {
+            ::close(listen_fd_);
+        }
+        // The simulator reconnects by path, so a stale node must not leave one behind.
+        ::unlink(socket_path_.c_str());
+    }
+
+private:
+    bool openListener()
+    {
+        // A leftover socket file from a crashed run makes bind() fail with EADDRINUSE, and
+        // the launch would look broken for a reason that has nothing to do with this run.
+        ::unlink(socket_path_.c_str());
+
+        listen_fd_ = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+        if (listen_fd_ < 0)
+        {
+            RCLCPP_ERROR(get_logger(), "socket(): %s", std::strerror(errno));
+            return false;
+        }
+        sockaddr_un addr{};
+        addr.sun_family = AF_UNIX;
+        std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+        if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+        {
+            RCLCPP_ERROR(get_logger(), "bind(%s): %s", socket_path_.c_str(), std::strerror(errno));
+            return false;
+        }
+        if (::listen(listen_fd_, 1) != 0)
+        {
+            RCLCPP_ERROR(get_logger(), "listen(): %s", std::strerror(errno));
+            return false;
+        }
+        return true;
+    }
+
+    void closeClient()
+    {
+        if (client_fd_ >= 0)
+        {
+            ::close(client_fd_);
+            client_fd_ = -1;
+        }
+        buffer_.clear();
+    }
+
+    void poll()
+    {
+        if (client_fd_ < 0)
+        {
+            const int fd = ::accept4(listen_fd_, nullptr, nullptr, SOCK_NONBLOCK);
+            if (fd < 0)
+            {
+                return;
+            }
+            client_fd_ = fd;
+            RCLCPP_INFO(get_logger(), "Simulator connected.");
+        }
+
+        // Drain whatever is available, then publish every complete frame in it. Draining
+        // fully matters: at 200 Hz polling against 10 Hz frames the socket is usually
+        // empty, but after any hiccup several frames can be queued.
+        std::uint8_t chunk[65536];
+        for (;;)
+        {
+            const ssize_t n = ::recv(client_fd_, chunk, sizeof(chunk), MSG_DONTWAIT);
+            if (n > 0)
+            {
+                buffer_.insert(buffer_.end(), chunk, chunk + n);
+                continue;
+            }
+            if (n == 0)
+            {
+                RCLCPP_INFO(get_logger(), "Simulator disconnected.");
+                closeClient();
+                return;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+                break;
+            }
+            RCLCPP_WARN(get_logger(), "recv(): %s", std::strerror(errno));
+            closeClient();
+            return;
+        }
+
+        for (;;)
+        {
+            CloudFrame        frame;
+            const FrameStatus status = tryReadFrame(buffer_, frame);
+            if (status == FrameStatus::Incomplete)
+            {
+                return;
+            }
+            if (status != FrameStatus::Ok)
+            {
+                // Unrecoverable by design: a desynchronised stream cannot be realigned, and
+                // guessing would publish plausible-looking nonsense.
+                RCLCPP_ERROR(get_logger(), "Dropping connection: %s", toString(status));
+                closeClient();
+                return;
+            }
+            publish(frame);
+        }
+    }
+
+    void publish(const CloudFrame& frame)
+    {
+        sensor_msgs::msg::PointCloud2 msg;
+        // Stamped from the simulator's own clock so downstream TF lookups line up with
+        // /clock rather than with wall time.
+        msg.header.stamp = rclcpp::Time(static_cast<int64_t>(frame.sim_time_s * 1e9), RCL_ROS_TIME);
+        msg.header.frame_id = frame_id_;
+
+        const std::size_t points = frame.points.size() / 3;
+        msg.height               = 1;
+        msg.width                = static_cast<std::uint32_t>(points);
+        msg.is_bigendian         = false;
+        msg.is_dense             = false;
+        msg.point_step           = 12;
+        msg.row_step             = msg.point_step * msg.width;
+
+        msg.fields.resize(3);
+        const char* names[3] = { "x", "y", "z" };
+        for (int i = 0; i < 3; ++i)
+        {
+            msg.fields[i].name     = names[i];
+            msg.fields[i].offset   = static_cast<std::uint32_t>(i * 4);
+            msg.fields[i].datatype = sensor_msgs::msg::PointField::FLOAT32;
+            msg.fields[i].count    = 1;
+        }
+
+        msg.data.resize(frame.points.size() * sizeof(float));
+        std::memcpy(msg.data.data(), frame.points.data(), msg.data.size());
+        cloud_pub_->publish(std::move(msg));
+    }
+
+    std::string socket_path_;
+    std::string frame_id_;
+    double      poll_hz_ = 200.0;
+
+    int                       listen_fd_ = -1;
+    int                       client_fd_ = -1;
+    std::vector<std::uint8_t> buffer_;
+
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
+    rclcpp::TimerBase::SharedPtr                                timer_;
+};
+
+}  // namespace g1_sensor_relay
+
+int main(int argc, char** argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<g1_sensor_relay::SensorRelay>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -184,9 +184,12 @@ private:
     void publish(const CloudFrame& frame)
     {
         sensor_msgs::msg::PointCloud2 msg;
-        // Stamped from the simulator's own clock so downstream TF lookups line up with
-        // /clock rather than with wall time.
-        msg.header.stamp = rclcpp::Time(static_cast<int64_t>(frame.sim_time_s * 1e9), RCL_ROS_TIME);
+        // now(), not the simulator's internal time. unitree_mujoco publishes no /clock, so
+        // everything else on this track (TF included) is stamped with wall time; stamping
+        // clouds with sim-seconds-since-start put them decades in the past and no consumer
+        // could transform them. now() also stays correct if a /clock ever appears, because
+        // it follows this node's use_sim_time.
+        msg.header.stamp    = now();
         msg.header.frame_id = frame_id_;
 
         const std::size_t points = frame.points.size() / 3;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -15,6 +15,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -32,8 +33,9 @@ public:
     SensorRelay()
       : rclcpp::Node("g1_sensor_relay")
     {
-        socket_path_ = declare_parameter<std::string>("socket_path", "/tmp/g1_sensors.sock");
-        frame_id_    = declare_parameter<std::string>("frame_id", "mid360_link");
+        socket_path_    = declare_parameter<std::string>("socket_path", "/tmp/g1_sensors.sock");
+        frame_id_       = declare_parameter<std::string>("frame_id", "mid360_link");
+        world_frame_id_ = declare_parameter<std::string>("world_frame_id", "world");
         const std::string topic = declare_parameter<std::string>("topic", "/livox/lidar");
         poll_hz_                = declare_parameter<double>("poll_hz", 200.0);
 
@@ -41,6 +43,15 @@ public:
         // best-effort subscriber is the usual reason nothing shows up in rviz.
         cloud_pub_ =
             create_publisher<sensor_msgs::msg::PointCloud2>(topic, rclcpp::SensorDataQoS());
+
+        // The simulator knows the sensor's world pose exactly and already sends it in the
+        // frame header. Published as plain diagnostic data rather than TF: mid360_link
+        // already has a parent through robot_state_publisher, and a second one would make
+        // the tree ambiguous. It is what lets a test check cloud geometry against the room
+        // before odom -> pelvis exists.
+        pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>(
+            "~/sensor_pose",
+            rclcpp::SensorDataQoS());
 
         if (!openListener())
         {
@@ -198,19 +209,34 @@ private:
 
         msg.data.resize(frame.points.size() * sizeof(float));
         std::memcpy(msg.data.data(), frame.points.data(), msg.data.size());
+
+        geometry_msgs::msg::PoseStamped pose;
+        pose.header             = msg.header;
+        pose.header.frame_id    = world_frame_id_;
+        pose.pose.position.x    = frame.sensor_pos[0];
+        pose.pose.position.y    = frame.sensor_pos[1];
+        pose.pose.position.z    = frame.sensor_pos[2];
+        pose.pose.orientation.w = frame.sensor_quat[0];
+        pose.pose.orientation.x = frame.sensor_quat[1];
+        pose.pose.orientation.y = frame.sensor_quat[2];
+        pose.pose.orientation.z = frame.sensor_quat[3];
+        pose_pub_->publish(pose);
+
         cloud_pub_->publish(std::move(msg));
     }
 
     std::string socket_path_;
     std::string frame_id_;
+    std::string world_frame_id_;
     double      poll_hz_ = 200.0;
 
     int                       listen_fd_ = -1;
     int                       client_fd_ = -1;
     std::vector<std::uint8_t> buffer_;
 
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
-    rclcpp::TimerBase::SharedPtr                                timer_;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr   cloud_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
+    rclcpp::TimerBase::SharedPtr                                  timer_;
 };
 
 }  // namespace g1_sensor_relay

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -57,6 +57,13 @@ public:
         depth_pub_ = create_publisher<sensor_msgs::msg::Image>(
             declare_parameter<std::string>("depth_topic", "/camera/aligned_depth_to_color/image_raw"),
             rclcpp::SensorDataQoS());
+        // Same intrinsics, second namespace: rviz's DepthCloud looks for camera_info
+        // beside the depth image, and a real D435i with align_depth publishes both.
+        depth_info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
+            declare_parameter<std::string>(
+                "depth_info_topic",
+                "/camera/aligned_depth_to_color/camera_info"),
+            rclcpp::SensorDataQoS());
         info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
             declare_parameter<std::string>("info_topic", "/camera/color/camera_info"),
             rclcpp::SensorDataQoS());
@@ -232,6 +239,7 @@ private:
 
         depth_pub_->publish(std::move(img));
         info_pub_->publish(info);
+        depth_info_pub_->publish(info);
     }
 
     void publish(const CloudFrame& frame)
@@ -295,6 +303,7 @@ private:
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr         depth_pub_;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr    info_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr    depth_info_pub_;
     rclcpp::TimerBase::SharedPtr                                  timer_;
 };
 

--- a/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
@@ -35,6 +35,39 @@ std::vector<std::uint8_t> makeFrame(std::uint32_t point_count, double sim_time =
     return bytes;
 }
 
+// Depth frames carry `width * height` floats and, when colour is on, `width * height * 3`
+// rgb bytes behind them in the same payload.
+std::vector<std::uint8_t> makeDepthFrame(std::uint32_t w, std::uint32_t h, bool with_color)
+{
+    const std::uint32_t pixels = w * h;
+    const std::uint32_t rgb    = with_color ? pixels * 3u : 0u;
+
+    SensorFrameHeader header{};
+    header.magic          = grove_g1::kSensorFrameMagic;
+    header.version        = grove_g1::kSensorFrameVersion;
+    header.kind           = static_cast<std::uint32_t>(grove_g1::SensorFrameKind::Depth);
+    header.width          = w;
+    header.height         = h;
+    header.fovy_deg       = 58.0f;
+    header.rgb_bytes      = rgb;
+    header.payload_bytes  = pixels * sizeof(float) + rgb;
+    header.sim_time_s     = 2.5;
+    header.sensor_quat[0] = 1.0;
+
+    std::vector<std::uint8_t> bytes(sizeof(header) + header.payload_bytes);
+    std::memcpy(bytes.data(), &header, sizeof(header));
+    for (std::uint32_t i = 0; i < pixels; ++i)
+    {
+        const float d = 1.0f + static_cast<float>(i);
+        std::memcpy(bytes.data() + sizeof(header) + i * sizeof(float), &d, sizeof(float));
+    }
+    for (std::uint32_t i = 0; i < rgb; ++i)
+    {
+        bytes[sizeof(header) + pixels * sizeof(float) + i] = static_cast<std::uint8_t>(i & 0xFF);
+    }
+    return bytes;
+}
+
 }  // namespace
 
 TEST(FrameReader, ReadsAWholeFrameAndConsumesExactlyIt)
@@ -150,4 +183,62 @@ TEST(WireFormat, TheTwoCopiesOfSensorFrameAreIdentical)
     sb << b.rdbuf();
     EXPECT_EQ(sa.str(), sb.str())
         << "workspace/vendor/unitree_mujoco/sensor_frame.h and the relay's copy have drifted";
+}
+
+TEST(FrameReader, ReadsADepthFrameWithColour)
+{
+    auto       bytes = makeDepthFrame(4, 3, /*with_color=*/true);
+    CloudFrame frame;
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_TRUE(bytes.empty());
+    EXPECT_EQ(frame.kind, FrameKind::Depth);
+    EXPECT_EQ(frame.width, 4u);
+    EXPECT_EQ(frame.height, 3u);
+    EXPECT_EQ(frame.depth.size(), 12u);
+    EXPECT_EQ(frame.rgb.size(), 36u);
+    EXPECT_FLOAT_EQ(frame.depth.front(), 1.0f);
+    EXPECT_FLOAT_EQ(frame.depth.back(), 12.0f);
+    // The colour bytes must come from behind the depth floats, not overlap them.
+    EXPECT_EQ(frame.rgb.front(), 0u);
+    EXPECT_EQ(frame.rgb.back(), 35u);
+}
+
+TEST(FrameReader, ReadsADepthFrameWithoutColour)
+{
+    auto       bytes = makeDepthFrame(4, 3, /*with_color=*/false);
+    CloudFrame frame;
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_EQ(frame.depth.size(), 12u);
+    EXPECT_TRUE(frame.rgb.empty());
+}
+
+TEST(FrameReader, RefusesAnRgbLengthThatDoesNotMatchThePixelCount)
+{
+    // The payload length still adds up, so only the rgb_bytes == pixels*3 rule catches
+    // this. Without it the relay would publish an rgb8 image of the wrong size.
+    auto              bytes = makeDepthFrame(4, 3, /*with_color=*/true);
+    SensorFrameHeader header{};
+    std::memcpy(&header, bytes.data(), sizeof(header));
+    header.rgb_bytes -= 1;
+    header.payload_bytes -= 1;
+    bytes.resize(bytes.size() - 1);
+    std::memcpy(bytes.data(), &header, sizeof(header));
+
+    CloudFrame frame;
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+}
+
+TEST(FrameReader, RefusesAnAbsurdImageSizeBeforeAllocating)
+{
+    // 60000 x 60000 would be 14 GB of depth. The pixel cap has to reject it from the
+    // header alone, before any resize.
+    auto              bytes = makeDepthFrame(2, 2, /*with_color=*/false);
+    SensorFrameHeader header{};
+    std::memcpy(&header, bytes.data(), sizeof(header));
+    header.width  = 60000;
+    header.height = 60000;
+    std::memcpy(bytes.data(), &header, sizeof(header));
+
+    CloudFrame frame;
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
 }

--- a/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
@@ -1,0 +1,153 @@
+#include <gmock/gmock.h>
+
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include "g1_sensor_relay/frame_reader.hpp"
+
+using namespace g1_sensor_relay;
+using grove_g1::SensorFrameHeader;
+
+namespace
+{
+
+std::vector<std::uint8_t> makeFrame(std::uint32_t point_count, double sim_time = 1.5)
+{
+    SensorFrameHeader header{};
+    header.magic          = grove_g1::kSensorFrameMagic;
+    header.version        = grove_g1::kSensorFrameVersion;
+    header.kind           = static_cast<std::uint32_t>(grove_g1::SensorFrameKind::PointCloud);
+    header.point_count    = point_count;
+    header.payload_bytes  = point_count * 3u * sizeof(float);
+    header.sim_time_s     = sim_time;
+    header.sensor_pos[2]  = 1.26;
+    header.sensor_quat[0] = 1.0;
+
+    std::vector<std::uint8_t> bytes(sizeof(header) + header.payload_bytes);
+    std::memcpy(bytes.data(), &header, sizeof(header));
+    for (std::uint32_t i = 0; i < point_count * 3u; ++i)
+    {
+        const float v = static_cast<float>(i);
+        std::memcpy(bytes.data() + sizeof(header) + i * sizeof(float), &v, sizeof(float));
+    }
+    return bytes;
+}
+
+}  // namespace
+
+TEST(FrameReader, ReadsAWholeFrameAndConsumesExactlyIt)
+{
+    auto       bytes = makeFrame(4);
+    const auto size  = bytes.size();
+    CloudFrame frame;
+
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_TRUE(bytes.empty()) << "consumed " << (size - bytes.size()) << " of " << size;
+    EXPECT_EQ(frame.points.size(), 12u);
+    EXPECT_DOUBLE_EQ(frame.sim_time_s, 1.5);
+    EXPECT_FLOAT_EQ(frame.points[11], 11.0f);
+}
+
+TEST(FrameReader, WaitsWhenTheFrameIsOnlyPartlyArrived)
+{
+    const auto full = makeFrame(8);
+    CloudFrame frame;
+
+    // A stream socket splits writes anywhere; every prefix must be safe to retry.
+    for (std::size_t n = 0; n < full.size(); ++n)
+    {
+        std::vector<std::uint8_t> partial(full.begin(), full.begin() + n);
+        const auto                before = partial.size();
+        EXPECT_EQ(tryReadFrame(partial, frame), FrameStatus::Incomplete) << "at " << n << " bytes";
+        EXPECT_EQ(partial.size(), before) << "consumed bytes from an incomplete frame";
+    }
+}
+
+TEST(FrameReader, ReadsBackToBackFramesFromOneBuffer)
+{
+    auto       bytes  = makeFrame(2, 1.0);
+    const auto second = makeFrame(3, 2.0);
+    bytes.insert(bytes.end(), second.begin(), second.end());
+
+    CloudFrame frame;
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_DOUBLE_EQ(frame.sim_time_s, 1.0);
+    EXPECT_EQ(frame.points.size(), 6u);
+
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_DOUBLE_EQ(frame.sim_time_s, 2.0);
+    EXPECT_EQ(frame.points.size(), 9u);
+    EXPECT_TRUE(bytes.empty());
+}
+
+TEST(FrameReader, RejectsGarbageRatherThanGuessing)
+{
+    CloudFrame frame;
+
+    auto bad_magic = makeFrame(2);
+    bad_magic[0] ^= 0xFF;
+    EXPECT_EQ(tryReadFrame(bad_magic, frame), FrameStatus::BadMagic);
+
+    auto                bad_version = makeFrame(2);
+    const std::uint32_t v           = grove_g1::kSensorFrameVersion + 1;
+    std::memcpy(bad_version.data() + 4, &v, sizeof(v));
+    EXPECT_EQ(tryReadFrame(bad_version, frame), FrameStatus::BadVersion);
+
+    auto                bad_kind = makeFrame(2);
+    const std::uint32_t k        = 99;
+    std::memcpy(bad_kind.data() + 8, &k, sizeof(k));
+    EXPECT_EQ(tryReadFrame(bad_kind, frame), FrameStatus::BadKind);
+}
+
+TEST(FrameReader, RefusesALengthThatDoesNotMatchThePointCount)
+{
+    // The failure mode that matters: a desynchronised stream yields a plausible header whose
+    // length is nonsense. Trusting it means allocating whatever it says.
+    auto                bytes = makeFrame(4);
+    const std::uint32_t lie   = 4u * 3u * sizeof(float) + 4u;
+    std::memcpy(bytes.data() + 12, &lie, sizeof(lie));
+
+    CloudFrame frame;
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+}
+
+TEST(FrameReader, RefusesAnAbsurdPointCountBeforeAllocating)
+{
+    auto                bytes = makeFrame(1);
+    const std::uint32_t huge  = kMaxPoints + 1;
+    std::memcpy(bytes.data() + 80, &huge, sizeof(huge));
+    // Keep payload_bytes consistent so only the cap can reject it.
+    const std::uint32_t payload = huge * 3u * sizeof(float);
+    std::memcpy(bytes.data() + 12, &payload, sizeof(payload));
+
+    CloudFrame frame;
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+}
+
+TEST(FrameReader, HandlesAnEmptyCloud)
+{
+    auto       bytes = makeFrame(0);
+    CloudFrame frame;
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    EXPECT_TRUE(frame.points.empty());
+}
+
+TEST(WireFormat, TheTwoCopiesOfSensorFrameAreIdentical)
+{
+    // The simulator compiles its own copy under workspace/vendor. If they drift, the relay
+    // reinterprets bytes and the failure looks like corrupt geometry, not a build problem.
+    const char* ours   = "include/g1_sensor_relay/sensor_frame.h";
+    const char* theirs = "../../vendor/unitree_mujoco/sensor_frame.h";
+
+    std::ifstream a(ours), b(theirs);
+    ASSERT_TRUE(a.is_open()) << "cannot open " << ours;
+    ASSERT_TRUE(b.is_open()) << "cannot open " << theirs;
+
+    std::stringstream sa, sb;
+    sa << a.rdbuf();
+    sb << b.rdbuf();
+    EXPECT_EQ(sa.str(), sb.str())
+        << "workspace/vendor/unitree_mujoco/sensor_frame.h and the relay's copy have drifted";
+}

--- a/workspace/src/g1_sim/README.md
+++ b/workspace/src/g1_sim/README.md
@@ -1,6 +1,20 @@
 # g1_sim
 
-**SIM-ONLY.** The perception simulation track: a simplified mobile body carrying a 3D LiDAR and an
+**SIM-ONLY, and now a SANDBOX rather than the perception track.** The LiDAR and depth camera moved
+onto the real G1 in `g1_bringup` (`sensors:=true`), where perception, arms and locomotion share one
+simulation. This package survives because it starts in seconds and needs no walking policy, balance
+or DDS bridge, so a sensor question can be answered without touching the timing-critical track.
+
+Three conditions keep it from becoming a second stack: it gains **no new capability** (no Nav2, no
+MoveIt, no manipulation), new work targets the converged track, and if it goes two milestones unused
+it should be deleted.
+
+**It also keeps a defect the converged track does not have.** The sandbox uses the vendor
+`mujoco_3d_lidar` plugin, whose raycast lets ~4% of returns through walls (see below). The converged
+track hand-rolls its sweep with `mj_ray` and does not carry that bug forward, so a leak seen here
+says nothing about the real track, and a sandbox result must never be used to characterise it.
+
+The perception simulation track: a simplified mobile body carrying a 3D LiDAR and an
 RGB-D camera in MuJoCo, run through `mujoco_ros2_control`.
 
 This is a **second, independent simulation track**. `unitree_mujoco` (driven by `g1_bringup`) is

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(unitree_go REQUIRED)
+find_package(unitree_hg REQUIRED)
 
 # Frame and staleness math, deliberately free of ROS so it tests without a node or DDS.
 add_library(odom_math src/odom_math.cpp)
@@ -29,7 +30,7 @@ target_compile_features(g1_odometry_publisher_node PUBLIC cxx_std_17)
 target_link_libraries(g1_odometry_publisher_node PUBLIC odom_math)
 ament_target_dependencies(g1_odometry_publisher_node PUBLIC
   rclcpp rclcpp_lifecycle lifecycle_msgs nav_msgs sensor_msgs geometry_msgs tf2_ros tf2_msgs
-  unitree_go)
+  unitree_go unitree_hg)
 
 add_executable(g1_odometry_publisher src/g1_odometry_publisher_main.cpp)
 target_link_libraries(g1_odometry_publisher PUBLIC g1_odometry_publisher_node)

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(unitree_go REQUIRED)
 
 # Frame and staleness math, deliberately free of ROS so it tests without a node or DDS.
 add_library(odom_math src/odom_math.cpp)
@@ -27,7 +28,8 @@ target_include_directories(g1_odometry_publisher_node PUBLIC
 target_compile_features(g1_odometry_publisher_node PUBLIC cxx_std_17)
 target_link_libraries(g1_odometry_publisher_node PUBLIC odom_math)
 ament_target_dependencies(g1_odometry_publisher_node PUBLIC
-  rclcpp rclcpp_lifecycle lifecycle_msgs nav_msgs sensor_msgs geometry_msgs tf2_ros tf2_msgs)
+  rclcpp rclcpp_lifecycle lifecycle_msgs nav_msgs sensor_msgs geometry_msgs tf2_ros tf2_msgs
+  unitree_go)
 
 add_executable(g1_odometry_publisher src/g1_odometry_publisher_main.cpp)
 target_link_libraries(g1_odometry_publisher PUBLIC g1_odometry_publisher_node)

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -17,6 +17,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "tf2_ros/transform_broadcaster.h"
+#include "unitree_go/msg/sport_mode_state.hpp"
 
 namespace g1_state_estimation
 {
@@ -48,14 +49,21 @@ private:
     bool readParameters();
 
     void onBaseState(const sensor_msgs::msg::JointState::SharedPtr msg);
+    void onSportModeState(const unitree_go::msg::SportModeState::SharedPtr msg);
+    /// Shared tail of both callbacks: staleness bookkeeping against a new stamp.
+    void noteSample(const rclcpp::Time& stamp);
     void onTimer();
 
     rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr            base_state_sub_;
+    rclcpp::Subscription<unitree_go::msg::SportModeState>::SharedPtr         sport_state_sub_;
     rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
     std::unique_ptr<tf2_ros::TransformBroadcaster>                           tf_broadcaster_;
     rclcpp::TimerBase::SharedPtr                                             timer_;
 
-    OdometrySource           source_ = OdometrySource::Hardware;
+    OdometrySource source_ = OdometrySource::Hardware;
+    /// Topic the configured source actually reads. Held as a string because only one
+    /// of the two subscriptions exists, and the other is null.
+    std::string              source_topic_;
     std::string              odom_frame_id_;
     std::string              base_frame_id_;
     std::vector<std::string> base_joint_names_;
@@ -67,7 +75,12 @@ private:
     std::array<double, 36>   pose_covariance_{};
     std::array<double, 36>   twist_covariance_{};
 
-    PlanarPose   pose_;
+    PlanarPose pose_;
+    /// Height and full orientation. The planar track has neither (its body has no z
+    /// DoF and cannot tilt); a walking G1 has both, so they are carried separately
+    /// rather than forced through PlanarPose.
+    double       pose_z_ = 0.0;
+    Quaternion   orientation_;
     PlanarTwist  world_twist_;
     bool         have_sample_ = false;
     rclcpp::Time last_sample_stamp_;

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -18,6 +18,7 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "tf2_ros/transform_broadcaster.h"
 #include "unitree_go/msg/sport_mode_state.hpp"
+#include "unitree_hg/msg/low_state.hpp"
 
 namespace g1_state_estimation
 {
@@ -50,12 +51,14 @@ private:
 
     void onBaseState(const sensor_msgs::msg::JointState::SharedPtr msg);
     void onSportModeState(const unitree_go::msg::SportModeState::SharedPtr msg);
+    void onLowState(const unitree_hg::msg::LowState::SharedPtr msg);
     /// Shared tail of both callbacks: staleness bookkeeping against a new stamp.
     void noteSample(const rclcpp::Time& stamp);
     void onTimer();
 
     rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr            base_state_sub_;
     rclcpp::Subscription<unitree_go::msg::SportModeState>::SharedPtr         sport_state_sub_;
+    rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr               low_state_sub_;
     rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
     std::unique_ptr<tf2_ros::TransformBroadcaster>                           tf_broadcaster_;
     rclcpp::TimerBase::SharedPtr                                             timer_;
@@ -79,8 +82,11 @@ private:
     /// Height and full orientation. The planar track has neither (its body has no z
     /// DoF and cannot tilt); a walking G1 has both, so they are carried separately
     /// rather than forced through PlanarPose.
-    double       pose_z_ = 0.0;
-    Quaternion   orientation_;
+    double     pose_z_ = 0.0;
+    Quaternion orientation_;
+    /// Set once a usable orientation has arrived. Until then nothing is published:
+    /// an unusable quaternion must not reach TF (see onLowState).
+    bool         have_orientation_ = false;
     PlanarTwist  world_twist_;
     bool         have_sample_ = false;
     rclcpp::Time last_sample_stamp_;

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -86,10 +86,15 @@ private:
     Quaternion orientation_;
     /// Set once a usable orientation has arrived. Until then nothing is published:
     /// an unusable quaternion must not reach TF (see onLowState).
-    bool         have_orientation_ = false;
-    PlanarTwist  world_twist_;
-    bool         have_sample_ = false;
-    rclcpp::Time last_sample_stamp_;
+    bool have_orientation_ = false;
+    /// Wall time the orientation last changed. Position and orientation come from separate
+    /// topics, so one can die while the other keeps flowing; without this the node would
+    /// publish a frozen orientation under a fresh stamp, which is the exact failure this
+    /// publisher exists to refuse.
+    std::chrono::steady_clock::time_point last_orientation_wall_{};
+    PlanarTwist                           world_twist_;
+    bool                                  have_sample_ = false;
+    rclcpp::Time                          last_sample_stamp_;
     /// Wall time at which the sample stamp last changed.
     std::chrono::steady_clock::time_point last_advance_wall_{};
     /// Throttling clock for the staleness warnings; the ROS clock freezes with the sim.

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
@@ -19,8 +19,9 @@ namespace g1_state_estimation
 /// Where the base pose comes from. Anything else is a configuration error.
 enum class OdometrySource
 {
-    SimGroundTruth,  ///< MuJoCo generalized coordinates. Exact, and sim-only.
-    Hardware,        ///< Not implemented: the real G1 publishes no odometry at all.
+    SimGroundTruth,     ///< MuJoCo generalized coordinates via planar joints. Sim-only.
+    SimSportModeState,  ///< The converged track: pelvis pose from /sportmodestate. Sim-only.
+    Hardware,           ///< Not implemented: the real G1 publishes no odometry at all.
 };
 
 /**

--- a/workspace/src/g1_state_estimation/package.xml
+++ b/workspace/src/g1_state_estimation/package.xml
@@ -21,6 +21,7 @@
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_msgs</depend>
+  <depend>unitree_go</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>

--- a/workspace/src/g1_state_estimation/package.xml
+++ b/workspace/src/g1_state_estimation/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_msgs</depend>
   <depend>unitree_go</depend>
+  <depend>unitree_hg</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -119,6 +120,13 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
             "~/sport_state",
             baseStateQos(),
             std::bind(&G1OdometryPublisher::onSportModeState, this, std::placeholders::_1));
+        // Orientation comes from /lowstate, not /sportmodestate: unitree_mujoco leaves the
+        // latter's imu_state at all zeros, and tf2 normalises a zero quaternion straight to
+        // NaN, which it then silently drops.
+        low_state_sub_ = create_subscription<unitree_hg::msg::LowState>(
+            "~/imu_state",
+            baseStateQos(),
+            std::bind(&G1OdometryPublisher::onLowState, this, std::placeholders::_1));
     }
     else
     {
@@ -144,6 +152,7 @@ G1OdometryPublisher::on_cleanup(const rclcpp_lifecycle::State&)
     timer_.reset();
     base_state_sub_.reset();
     sport_state_sub_.reset();
+    low_state_sub_.reset();
     odom_pub_.reset();
     tf_broadcaster_.reset();
     have_sample_ = false;
@@ -175,6 +184,7 @@ G1OdometryPublisher::on_shutdown(const rclcpp_lifecycle::State&)
     timer_.reset();
     base_state_sub_.reset();
     sport_state_sub_.reset();
+    low_state_sub_.reset();
     odom_pub_.reset();
     tf_broadcaster_.reset();
     return CallbackReturn::SUCCESS;
@@ -230,19 +240,39 @@ void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState
     pose_.y = msg->position[1];
     pose_z_ = msg->position[2];
 
-    // Full orientation, unlike the planar track: a walking robot rolls and pitches, and
-    // flattening that to yaw would tilt every sensor frame hanging off base_link.
-    orientation_.w = msg->imu_state.quaternion[0];
-    orientation_.x = msg->imu_state.quaternion[1];
-    orientation_.y = msg->imu_state.quaternion[2];
-    orientation_.z = msg->imu_state.quaternion[3];
-    pose_.yaw      = quaternionToYaw(orientation_);
-
     world_twist_ =
         PlanarTwist{ msg->velocity[0], msg->velocity[1], static_cast<double>(msg->yaw_speed) };
 
     // This message carries no header stamp, so the arrival time is the only stamp available.
     noteSample(now());
+}
+
+void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr msg)
+{
+    // Full orientation, unlike the planar track: a walking robot rolls and pitches, and
+    // flattening that to yaw would tilt every sensor frame hanging off the base.
+    const Quaternion q{ msg->imu_state.quaternion[1],
+                        msg->imu_state.quaternion[2],
+                        msg->imu_state.quaternion[3],
+                        msg->imu_state.quaternion[0] };
+
+    // Validate before it can reach TF. tf2 normalises, so a zero-norm quaternion becomes
+    // NaN and the transform is dropped with a message that points at tf2 rather than here.
+    const double norm2 = q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z;
+    if (!std::isfinite(norm2) || norm2 < 0.5)
+    {
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            steady_clock_,
+            5000,
+            "IMU quaternion is unusable (norm^2 %.3f); not publishing an orientation.",
+            norm2);
+        return;
+    }
+
+    orientation_      = q;
+    pose_.yaw         = quaternionToYaw(orientation_);
+    have_orientation_ = true;
 }
 
 void G1OdometryPublisher::noteSample(const rclcpp::Time& stamp)
@@ -260,6 +290,15 @@ void G1OdometryPublisher::noteSample(const rclcpp::Time& stamp)
 
 void G1OdometryPublisher::onTimer()
 {
+    if (source_ == OdometrySource::SimSportModeState && !have_orientation_)
+    {
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            steady_clock_,
+            5000,
+            "Waiting for a usable IMU orientation.");
+        return;
+    }
     if (!have_sample_)
     {
         RCLCPP_WARN_THROTTLE(

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -157,7 +157,8 @@ G1OdometryPublisher::on_cleanup(const rclcpp_lifecycle::State&)
     low_state_sub_.reset();
     odom_pub_.reset();
     tf_broadcaster_.reset();
-    have_sample_ = false;
+    have_sample_      = false;
+    have_orientation_ = false;
     return CallbackReturn::SUCCESS;
 }
 
@@ -238,6 +239,18 @@ void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState
     // framepos/framelinvel on the pelvis imu site, so this is exact MuJoCo state, not an
     // estimate. It is also why the hardware branch still refuses: the real G1 publishes the
     // hg variant of this message, which has none of these fields.
+    if (!std::isfinite(msg->position[0]) || !std::isfinite(msg->position[1]) ||
+        !std::isfinite(msg->position[2]))
+    {
+        // A diverged MuJoCo publishes NaN here, and tf2 drops NaN transforms silently, so
+        // the symptom would be a frame that simply stops existing.
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            steady_clock_,
+            5000,
+            "Discarding a non-finite position sample.");
+        return;
+    }
     pose_.x = msg->position[0];
     pose_.y = msg->position[1];
     pose_z_ = msg->position[2];
@@ -272,9 +285,17 @@ void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr 
         return;
     }
 
-    orientation_      = q;
-    pose_.yaw         = quaternionToYaw(orientation_);
-    have_orientation_ = true;
+    // Normalise: norm^2 >= 0.5 admits 4.0 just as happily as 1.0, and an unnormalised
+    // quaternion on /tf is a scale error nothing downstream reports.
+    const double inv = 1.0 / std::sqrt(norm2);
+    orientation_.w   = q.w * inv;
+    orientation_.x   = q.x * inv;
+    orientation_.y   = q.y * inv;
+    orientation_.z   = q.z * inv;
+
+    pose_.yaw              = quaternionToYaw(orientation_);
+    have_orientation_      = true;
+    last_orientation_wall_ = std::chrono::steady_clock::now();
 }
 
 void G1OdometryPublisher::noteSample(const rclcpp::Time& stamp)
@@ -315,6 +336,27 @@ void G1OdometryPublisher::onTimer()
     // Sim time alone cannot see a wedged simulator: /clock comes from the same process as
     // the base state, so it freezes too and `elapsed` stays at zero. Hence the wall budget.
     const double elapsed = (now() - last_sample_stamp_).seconds();
+    if (source_ == OdometrySource::SimSportModeState)
+    {
+        const double orientation_age =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - last_orientation_wall_)
+                .count();
+        if (isStale(orientation_age, wall_timeout_s_))
+        {
+            RCLCPP_WARN_THROTTLE(
+                get_logger(),
+                steady_clock_,
+                2000,
+                "Orientation has not advanced for %.3f s (limit %.3f); stopped publishing "
+                "%s -> %s. Position alone would be a frozen attitude under a fresh stamp.",
+                orientation_age,
+                wall_timeout_s_,
+                odom_frame_id_.c_str(),
+                base_frame_id_.c_str());
+            return;
+        }
+    }
+
     const double wall_elapsed =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - last_advance_wall_).count();
     if (isStale(elapsed, source_timeout_s_) || isStale(wall_elapsed, wall_timeout_s_))

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -48,8 +48,8 @@ bool G1OdometryPublisher::readParameters()
     {
         RCLCPP_ERROR(
             get_logger(),
-            "odometry_source='%s' is not a known source. Use 'sim_ground_truth' or "
-            "'hardware'.",
+            "odometry_source='%s' is not a known source. Use 'sim_ground_truth' (planar "
+            "sandbox), 'sim_sportmodestate' (converged track) or 'hardware'.",
             source_name.c_str());
         return false;
     }
@@ -113,10 +113,20 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
     {
         odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("~/odom", rclcpp::QoS(10));
     }
-    base_state_sub_ = create_subscription<sensor_msgs::msg::JointState>(
-        "~/base_state",
-        baseStateQos(),
-        std::bind(&G1OdometryPublisher::onBaseState, this, std::placeholders::_1));
+    if (source_ == OdometrySource::SimSportModeState)
+    {
+        sport_state_sub_ = create_subscription<unitree_go::msg::SportModeState>(
+            "~/sport_state",
+            baseStateQos(),
+            std::bind(&G1OdometryPublisher::onSportModeState, this, std::placeholders::_1));
+    }
+    else
+    {
+        base_state_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+            "~/base_state",
+            baseStateQos(),
+            std::bind(&G1OdometryPublisher::onBaseState, this, std::placeholders::_1));
+    }
 
     RCLCPP_INFO(
         get_logger(),
@@ -124,7 +134,7 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
         "estimate; it has no drift, noise or latency.",
         odom_frame_id_.c_str(),
         base_frame_id_.c_str(),
-        base_state_sub_->get_topic_name());
+        sport_state_sub_ ? sport_state_sub_->get_topic_name() : base_state_sub_->get_topic_name());
     return CallbackReturn::SUCCESS;
 }
 
@@ -133,6 +143,7 @@ G1OdometryPublisher::on_cleanup(const rclcpp_lifecycle::State&)
 {
     timer_.reset();
     base_state_sub_.reset();
+    sport_state_sub_.reset();
     odom_pub_.reset();
     tf_broadcaster_.reset();
     have_sample_ = false;
@@ -163,6 +174,7 @@ G1OdometryPublisher::on_shutdown(const rclcpp_lifecycle::State&)
 {
     timer_.reset();
     base_state_sub_.reset();
+    sport_state_sub_.reset();
     odom_pub_.reset();
     tf_broadcaster_.reset();
     return CallbackReturn::SUCCESS;
@@ -203,7 +215,38 @@ void G1OdometryPublisher::onBaseState(const sensor_msgs::msg::JointState::Shared
     const bool         unstamped = msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0;
     const rclcpp::Time stamp =
         unstamped ? now() : rclcpp::Time(msg->header.stamp, get_clock()->get_clock_type());
+    orientation_ = yawToQuaternion(pose_.yaw);
+    pose_z_      = base_height_m_;
+    noteSample(stamp);
+}
 
+void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState::SharedPtr msg)
+{
+    // The converged track's ground truth. unitree_mujoco fills position and velocity from
+    // framepos/framelinvel on the pelvis imu site, so this is exact MuJoCo state, not an
+    // estimate. It is also why the hardware branch still refuses: the real G1 publishes the
+    // hg variant of this message, which has none of these fields.
+    pose_.x = msg->position[0];
+    pose_.y = msg->position[1];
+    pose_z_ = msg->position[2];
+
+    // Full orientation, unlike the planar track: a walking robot rolls and pitches, and
+    // flattening that to yaw would tilt every sensor frame hanging off base_link.
+    orientation_.w = msg->imu_state.quaternion[0];
+    orientation_.x = msg->imu_state.quaternion[1];
+    orientation_.y = msg->imu_state.quaternion[2];
+    orientation_.z = msg->imu_state.quaternion[3];
+    pose_.yaw      = quaternionToYaw(orientation_);
+
+    world_twist_ =
+        PlanarTwist{ msg->velocity[0], msg->velocity[1], static_cast<double>(msg->yaw_speed) };
+
+    // This message carries no header stamp, so the arrival time is the only stamp available.
+    noteSample(now());
+}
+
+void G1OdometryPublisher::noteSample(const rclcpp::Time& stamp)
+{
     // Time of the last stamp CHANGE, not of the last message: a wedged simulator can keep
     // republishing the same sample forever. Order matters, rclcpp::Time::operator!= throws
     // on mismatched clock types and last_sample_stamp_ starts out RCL_SYSTEM_TIME.
@@ -224,7 +267,7 @@ void G1OdometryPublisher::onTimer()
             steady_clock_,
             5000,
             "No base state received yet on %s; publishing nothing.",
-            base_state_sub_->get_topic_name());
+            source_topic_.c_str());
         return;
     }
 
@@ -253,7 +296,7 @@ void G1OdometryPublisher::onTimer()
         return;
     }
 
-    const Quaternion   orientation = yawToQuaternion(pose_.yaw);
+    const Quaternion   orientation = orientation_;
     const PlanarTwist  body_twist  = toBodyTwist(world_twist_, pose_.yaw);
     const rclcpp::Time stamp       = last_sample_stamp_;
 
@@ -263,7 +306,7 @@ void G1OdometryPublisher::onTimer()
     tf.child_frame_id          = base_frame_id_;
     tf.transform.translation.x = pose_.x;
     tf.transform.translation.y = pose_.y;
-    tf.transform.translation.z = base_height_m_;
+    tf.transform.translation.z = pose_z_;
     tf.transform.rotation.x    = orientation.x;
     tf.transform.rotation.y    = orientation.y;
     tf.transform.rotation.z    = orientation.z;
@@ -282,7 +325,7 @@ void G1OdometryPublisher::onTimer()
     odom.child_frame_id        = base_frame_id_;
     odom.pose.pose.position.x  = pose_.x;
     odom.pose.pose.position.y  = pose_.y;
-    odom.pose.pose.position.z  = base_height_m_;
+    odom.pose.pose.position.z  = pose_z_;
     odom.pose.pose.orientation = tf.transform.rotation;
     odom.twist.twist.linear.x  = body_twist.vx;
     odom.twist.twist.linear.y  = body_twist.vy;

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -136,6 +136,8 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
             std::bind(&G1OdometryPublisher::onBaseState, this, std::placeholders::_1));
     }
 
+    source_topic_ =
+        sport_state_sub_ ? sport_state_sub_->get_topic_name() : base_state_sub_->get_topic_name();
     RCLCPP_INFO(
         get_logger(),
         "Configured on sim ground truth: %s -> %s from %s. This is exact MuJoCo state, not an "

--- a/workspace/src/g1_state_estimation/src/odom_math.cpp
+++ b/workspace/src/g1_state_estimation/src/odom_math.cpp
@@ -13,6 +13,11 @@ bool parseOdometrySource(const std::string& name, OdometrySource& out)
         out = OdometrySource::SimGroundTruth;
         return true;
     }
+    if (name == "sim_sportmodestate")
+    {
+        out = OdometrySource::SimSportModeState;
+        return true;
+    }
     if (name == "hardware")
     {
         out = OdometrySource::Hardware;

--- a/workspace/src/g1_state_estimation/test/test_odom_math.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odom_math.cpp
@@ -30,11 +30,24 @@ TEST(ParseOdometrySource, AcceptsTheTwoKnownNames)
     EXPECT_EQ(source, OdometrySource::Hardware);
 }
 
+TEST(ParseOdometrySource, AcceptsTheConvergedTrackSource)
+{
+    OdometrySource source = OdometrySource::Hardware;
+    ASSERT_TRUE(parseOdometrySource("sim_sportmodestate", source));
+    EXPECT_EQ(source, OdometrySource::SimSportModeState);
+}
+
 TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
 {
     // A typo must not silently become sim ground truth, which would fabricate transforms.
     OdometrySource source = OdometrySource::SimGroundTruth;
-    for (const char* name : { "", "sim", "SIM_GROUND_TRUTH", "ground_truth", "hardware " })
+    for (const char* name : { "",
+                              "sim",
+                              "SIM_GROUND_TRUTH",
+                              "ground_truth",
+                              "hardware ",
+                              "sportmodestate",
+                              "sim_sportmode" })
     {
         EXPECT_FALSE(parseOdometrySource(name, source)) << "accepted " << name;
         EXPECT_EQ(source, OdometrySource::SimGroundTruth);

--- a/workspace/vendor/unitree_mujoco/sensor_frame.h
+++ b/workspace/vendor/unitree_mujoco/sensor_frame.h
@@ -1,0 +1,55 @@
+#ifndef GROVE_G1_SENSOR_FRAME_H_
+#define GROVE_G1_SENSOR_FRAME_H_
+
+// Wire format between the patched unitree_mujoco and g1_sensor_relay.
+//
+// Shared verbatim by both sides: the copy under workspace/vendor is the one compiled into
+// the simulator, and g1_sensor_relay includes the same file. Keep them identical; a
+// test in g1_sensor_relay asserts the two copies match byte for byte.
+
+#include <cstdint>
+
+namespace grove_g1
+{
+
+// Bumped whenever the layout below changes. The relay refuses a frame it does not know
+// rather than reinterpreting bytes.
+inline constexpr uint32_t kSensorFrameVersion = 1;
+
+inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
+
+enum class SensorFrameKind : uint32_t
+{
+    PointCloud = 1,
+};
+
+// Fixed-size header, then `payload_bytes` of body. Length-prefixed so the stream can be
+// framed without parsing the body, and so a short read is detectable rather than silently
+// producing a truncated cloud.
+struct SensorFrameHeader
+{
+    uint32_t magic;          // kSensorFrameMagic
+    uint32_t version;        // kSensorFrameVersion
+    uint32_t kind;           // SensorFrameKind
+    uint32_t payload_bytes;  // body length that follows this header
+
+    // Sim time of the snapshot the frame was computed from, not wall time: the relay stamps
+    // messages with this so downstream TF lookups line up with /clock.
+    double sim_time_s;
+
+    // Sensor pose in the world at snapshot time, as position + wxyz quaternion. The relay
+    // publishes the cloud in the sensor frame, so this is carried for provenance and for
+    // the relay's own sanity checks rather than to transform the points.
+    double sensor_pos[3];
+    double sensor_quat[4];
+
+    // PointCloud: number of points that follow, each 3 floats (x, y, z) in the sensor frame.
+    uint32_t point_count;
+    uint32_t reserved;
+};
+
+static_assert(sizeof(SensorFrameHeader) == 88, "wire layout changed; bump kSensorFrameVersion");
+
+}  // namespace grove_g1
+
+#endif  // GROVE_G1_SENSOR_FRAME_H_

--- a/workspace/vendor/unitree_mujoco/sensor_frame.h
+++ b/workspace/vendor/unitree_mujoco/sensor_frame.h
@@ -13,8 +13,9 @@ namespace grove_g1
 {
 
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
-// rather than reinterpreting bytes. v2 added the depth-image fields.
-inline constexpr uint32_t kSensorFrameVersion = 2;
+// rather than reinterpreting bytes. v2 added the depth-image fields; v3 appends colour
+// to the depth payload.
+inline constexpr uint32_t kSensorFrameVersion = 3;
 
 inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
 
@@ -51,7 +52,10 @@ struct SensorFrameHeader
     uint32_t height;
     float    fovy_deg;
 
-    uint32_t reserved;
+    // Depth: bytes of rgb8 colour appended after the depth floats, or 0 when colour is
+    // off. Both come from one mjr_readPixels of one render, so they share a pose, a
+    // timestamp and a frustum by construction rather than by the relay pairing them up.
+    uint32_t rgb_bytes;
 };
 
 static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");

--- a/workspace/vendor/unitree_mujoco/sensor_frame.h
+++ b/workspace/vendor/unitree_mujoco/sensor_frame.h
@@ -13,14 +13,15 @@ namespace grove_g1
 {
 
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
-// rather than reinterpreting bytes.
-inline constexpr uint32_t kSensorFrameVersion = 1;
+// rather than reinterpreting bytes. v2 added the depth-image fields.
+inline constexpr uint32_t kSensorFrameVersion = 2;
 
 inline constexpr uint32_t kSensorFrameMagic = 0x47314C44;  // "G1LD"
 
 enum class SensorFrameKind : uint32_t
 {
     PointCloud = 1,
+    Depth      = 2,
 };
 
 // Fixed-size header, then `payload_bytes` of body. Length-prefixed so the stream can be
@@ -33,22 +34,27 @@ struct SensorFrameHeader
     uint32_t kind;           // SensorFrameKind
     uint32_t payload_bytes;  // body length that follows this header
 
-    // Sim time of the snapshot the frame was computed from, not wall time: the relay stamps
-    // messages with this so downstream TF lookups line up with /clock.
+    // Sim time of the snapshot the frame was computed from. Carried for provenance; the
+    // relay stamps messages with its own clock, because this track publishes no /clock.
     double sim_time_s;
 
-    // Sensor pose in the world at snapshot time, as position + wxyz quaternion. The relay
-    // publishes the cloud in the sensor frame, so this is carried for provenance and for
-    // the relay's own sanity checks rather than to transform the points.
+    // Sensor pose in the world at snapshot time, as position + wxyz quaternion.
     double sensor_pos[3];
     double sensor_quat[4];
 
-    // PointCloud: number of points that follow, each 3 floats (x, y, z) in the sensor frame.
+    // PointCloud: number of points, each 3 floats (x, y, z) in the sensor frame.
     uint32_t point_count;
+
+    // Depth: image dimensions and the vertical field of view the render used. fovy is
+    // carried rather than assumed so the relay's camera_info cannot drift from the MJCF.
+    uint32_t width;
+    uint32_t height;
+    float    fovy_deg;
+
     uint32_t reserved;
 };
 
-static_assert(sizeof(SensorFrameHeader) == 88, "wire layout changed; bump kSensorFrameVersion");
+static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");
 
 }  // namespace grove_g1
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -17,9 +17,14 @@ namespace
 
 struct Config
 {
-    bool        enabled       = false;
-    double      rate_hz       = 10.0;
-    std::string node_name     = "g1_sim_sensors";
+    bool        enabled          = false;
+    double      rate_hz          = 10.0;
+    std::string node_name        = "g1_sim_sensors";
+    // Delay after mjData appears before rclcpp::init(). The Unitree SDK calls
+    // dds_create_domain EXPLICITLY and that fails if the domain already exists, so ROS must
+    // not get there first. Its bridge thread polls for mjData every 500 ms and initialises
+    // immediately after, so waiting past that hands the SDK the domain.
+    double      sdk_settle_s     = 2.0;
 };
 
 struct State
@@ -53,6 +58,9 @@ Config loadConfig()
         if (root["node_name"]) {
             cfg.node_name = root["node_name"].as<std::string>();
         }
+        if (root["sdk_settle_s"]) {
+            cfg.sdk_settle_s = root["sdk_settle_s"].as<double>();
+        }
     } catch (const std::exception& e) {
         // Loud, and still off: a malformed config must not look like a working sensor.
         std::fprintf(
@@ -67,7 +75,7 @@ Config loadConfig()
     return cfg;
 }
 
-void sensorLoop(const Config cfg, rclcpp::Node::SharedPtr node, mjModel** model, mjData** data)
+void sensorLoop(const Config cfg, int argc, char** argv, mjModel** model, mjData** data)
 {
     // The model is loaded by the physics thread after this one starts, same as the SDK
     // bridge's own wait.
@@ -77,6 +85,20 @@ void sensorLoop(const Config cfg, rclcpp::Node::SharedPtr node, mjModel** model,
     if (!state().running.load(std::memory_order_relaxed)) {
         return;
     }
+
+    // Let the SDK claim the DDS domain before ROS touches it. See Config::sdk_settle_s.
+    std::this_thread::sleep_for(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<double>(cfg.sdk_settle_s)));
+    if (!state().running.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    if (!rclcpp::ok()) {
+        rclcpp::init(argc, argv);
+        state().owns_rclcpp = true;
+    }
+    auto node = std::make_shared<rclcpp::Node>(cfg.node_name);
 
     RCLCPP_INFO(
         node->get_logger(), "Sensor thread up at %.1f Hz on a model with %d geoms.", cfg.rate_hz,
@@ -106,14 +128,8 @@ void StartSensorPublisher(
         return;
     }
 
-    if (!rclcpp::ok()) {
-        rclcpp::init(argc, argv);
-        state().owns_rclcpp = true;
-    }
-    auto node = std::make_shared<rclcpp::Node>(cfg.node_name);
-
     state().running.store(true);
-    state().thread = std::thread(sensorLoop, cfg, node, model, data);
+    state().thread = std::thread(sensorLoop, cfg, argc, argv, model, data);
 }
 
 void StopSensorPublisher()

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -719,6 +719,12 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     }
 
     mj_deleteData(snapshot);
+
+    // The GL window, scene and context are deliberately NOT freed here. glfwDestroyWindow
+    // must run on the main thread, and calling it from this one segfaulted the simulator on
+    // reload. Leaking them is safe for the one case that reaches here: a model reload stops
+    // the sampler for good, so nothing touches these again, and the process frees them at
+    // exit. There is no restart path to reclaim them for.
 }
 
 }  // namespace
@@ -731,6 +737,27 @@ void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* 
     }
     state().running.store(true);
     state().thread = std::thread(sensorLoop, cfg, model, data, sim_mtx);
+}
+
+void StopSensorPublisher()
+{
+    State& s = state();
+    if (!s.running.exchange(false)) {
+        return;
+    }
+    // Blocking join, not a signal-and-hope. The sampler dereferences the model outside the
+    // sim lock -- mjv_updateScene, mjr_render and mj_ray all do, deliberately, so a render
+    // does not stall physics -- so the only safe point to free the model is after the
+    // thread has actually stopped. Signalling without joining leaves exactly the
+    // use-after-free this exists to close: a viewer Reload segfaulted the simulator.
+    // Costs up to one sample period (~100 ms) plus one sweep, on a debugging-only action.
+    if (s.thread.joinable()) {
+        s.thread.join();
+    }
+    std::fprintf(stderr,
+                 "[grove_g1] SENSORS DISABLED: the model was replaced and the sampler was "
+                 "stopped to avoid reading a freed model. Relaunch the sim to restore "
+                 "them; nothing will publish on /livox/lidar or /camera/* until then.\n");
 }
 
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include <thread>
@@ -316,9 +317,10 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
 
         // Snapshot under the lock, raycast outside it. Holding the lock across a ~32 ms
         // sweep would stall physics exactly as badly as running inline.
-        double sim_time = 0.0;
-        double torso_pos[3];
-        double torso_mat[9];
+        double     sim_time = 0.0;
+        double     torso_pos[3];
+        double     torso_mat[9];
+        const auto lock_start = std::chrono::steady_clock::now();
         {
             std::lock_guard<std::recursive_mutex> lock(*sim_mtx);
             mj_copyData(snapshot, m, *data);
@@ -326,6 +328,9 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             std::memcpy(torso_pos, snapshot->xpos + 3 * torso_id, sizeof(torso_pos));
             std::memcpy(torso_mat, snapshot->xmat + 9 * torso_id, sizeof(torso_mat));
         }
+        const double lock_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - lock_start)
+                .count();
 
         // A snapshot taken before MuJoCo has run kinematics has an all-zero xmat, and
         // mj_ray aborts the whole process on a zero-length direction ("vector length is too
@@ -385,6 +390,21 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
         std::memcpy(header.sensor_pos, origin, sizeof(origin));
         matrixToQuat(R_sensor, header.sensor_quat);
         header.point_count = static_cast<uint32_t>(n_rays);
+
+        // The snapshot is the only thing that contends with physics, so its cost is the
+        // number that matters; the ~32 ms sweep below it runs off-lock. Reported rarely
+        // rather than never: if mj_copyData ever grows, this is where it shows up.
+        {
+            static int    cycles     = 0;
+            static double lock_worst = 0.0;
+            lock_worst               = std::max(lock_worst, lock_ms);
+            if (++cycles % 300 == 0) {
+                std::fprintf(
+                    stderr, "[grove_g1] snapshot lock: worst %.3f ms over %d cycles\n", lock_worst,
+                    cycles);
+                lock_worst = 0.0;
+            }
+        }
 
         relay.send(header, points.data(), points.size() * sizeof(float));
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -32,6 +32,10 @@ struct Config
 
     // Mid360 envelope. Resolution is a real budget, not a formality: 360x32 costs ~32 ms per
     // sweep against the G1 scene, so it is configurable and the timing gate decides what ships.
+    // Which MuJoCo geom group the sweep sees. The scene puts walls, floor and obstacles in
+    // group 3; the robot's own geoms are not in it. Without this every ray returns the
+    // torso shell ~6 cm from the mount and the world is invisible.
+    int    scene_geom_group = 3;
     int    azimuth_steps   = 360;
     int    elevation_steps = 32;
     double azimuth_min     = -M_PI;
@@ -94,6 +98,9 @@ Config loadConfig()
         }
         if (root["elevation_steps"]) {
             cfg.elevation_steps = root["elevation_steps"].as<int>();
+        }
+        if (root["scene_geom_group"]) {
+            cfg.scene_geom_group = root["scene_geom_group"].as<int>();
         }
         if (root["range_max"]) {
             cfg.range_max = root["range_max"].as<double>();
@@ -266,6 +273,11 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     double R_mount[9];
     rpyToMatrix(cfg.mount_rpy, R_mount);
 
+    mjtByte geomgroup[mjNGROUP] = {0};
+    if (cfg.scene_geom_group >= 0 && cfg.scene_geom_group < mjNGROUP) {
+        geomgroup[cfg.scene_geom_group] = 1;
+    }
+
     const int n_rays = cfg.azimuth_steps * cfg.elevation_steps;
     std::fprintf(
         stderr, "[grove_g1] sensor thread up: %dx%d rays at %.1f Hz -> %s\n", cfg.azimuth_steps,
@@ -315,6 +327,16 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             std::memcpy(torso_mat, snapshot->xmat + 9 * torso_id, sizeof(torso_mat));
         }
 
+        // A snapshot taken before MuJoCo has run kinematics has an all-zero xmat, and
+        // mj_ray aborts the whole process on a zero-length direction ("vector length is too
+        // small"). Skip the cycle rather than hand it one.
+        const double row0 = torso_mat[0] * torso_mat[0] + torso_mat[1] * torso_mat[1] +
+                            torso_mat[2] * torso_mat[2];
+        if (row0 < 0.5) {
+            std::this_thread::sleep_until(next);
+            continue;
+        }
+
         // Sensor pose = torso pose composed with the fixed mount, taken live rather than
         // hardcoded: torso_link's height depends on the waist chain and the current stance,
         // so any baked-in constant is wrong the moment the robot walks.
@@ -342,9 +364,9 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
                 world_dir[r] = R_sensor[3 * r + 0] * d[0] + R_sensor[3 * r + 1] * d[1] +
                                R_sensor[3 * r + 2] * d[2];
             }
-            // flg_static=1 so walls and floor are hit at all; the robot's own geoms are
-            // legitimate returns, same as a real LiDAR seeing its own body.
-            double dist = mj_ray(m, snapshot, origin, world_dir, nullptr, 1, -1, &geomid[i]);
+            // flg_static=1 so the world-body walls and floor are hit at all. geomgroup
+            // restricts returns to the scene, keeping the robot from occluding itself.
+            double dist = mj_ray(m, snapshot, origin, world_dir, geomgroup, 1, -1, &geomid[i]);
             if (dist < cfg.range_min || dist > cfg.range_max) {
                 dist = 0.0;  // no return
             }

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -272,8 +272,8 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
         return;
     }
 
-    mjModel*  m        = *model;
-    const int torso_id = mj_name2id(m, mjOBJ_BODY, "torso_link");
+    mjModel* m        = *model;
+    int      torso_id = mj_name2id(m, mjOBJ_BODY, "torso_link");
     if (torso_id < 0) {
         std::fprintf(stderr, "[grove_g1] no torso_link in the model; sensors DISABLED\n");
         return;
@@ -320,8 +320,13 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     const auto period = std::chrono::duration<double>(1.0 / cfg.rate_hz);
     auto       next   = std::chrono::steady_clock::now();
 
+    bool reload_pending = false;
     while (state().running.load(std::memory_order_relaxed)) {
         next += std::chrono::duration_cast<std::chrono::steady_clock::duration>(period);
+        // If a sweep overruns its period, sleep_until returns immediately forever and the
+        // loop free-runs, taking sim_mtx as fast as it can. Resolution is configurable, so
+        // that is reachable rather than theoretical.
+        next = std::max(next, std::chrono::steady_clock::now());
 
         // Snapshot under the lock, raycast outside it. Holding the lock across a ~32 ms
         // sweep would stall physics exactly as badly as running inline.
@@ -339,12 +344,39 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             // mj_ray only reads geom poses, and everything this sweep can hit is a
             // primitive (the scene's boxes and plane), so no mesh BVH is involved. Two
             // arrays is both correct and far cheaper than a full mjData.
-            const mjData* live = *data;
-            std::memcpy(snapshot->geom_xpos, live->geom_xpos, sizeof(mjtNum) * 3 * m->ngeom);
-            std::memcpy(snapshot->geom_xmat, live->geom_xmat, sizeof(mjtNum) * 9 * m->ngeom);
-            sim_time = live->time;
-            std::memcpy(torso_pos, live->xpos + 3 * torso_id, sizeof(torso_pos));
-            std::memcpy(torso_mat, live->xmat + 9 * torso_id, sizeof(torso_mat));
+            // The viewer's Reload button and drag-and-drop both replace the model and
+            // free the old one (main.cc reassigns m/d). A latched pointer would dangle,
+            // and the memcpy below would size itself from a freed model's ngeom.
+            if (*model != m) {
+                reload_pending = true;
+            } else {
+                const mjData* live = *data;
+                std::memcpy(
+                    snapshot->geom_xpos, live->geom_xpos, sizeof(mjtNum) * 3 * m->ngeom);
+                std::memcpy(
+                    snapshot->geom_xmat, live->geom_xmat, sizeof(mjtNum) * 9 * m->ngeom);
+                sim_time = live->time;
+                std::memcpy(torso_pos, live->xpos + 3 * torso_id, sizeof(torso_pos));
+                std::memcpy(torso_mat, live->xmat + 9 * torso_id, sizeof(torso_mat));
+            }
+        }
+
+        // Rebuilt outside the lock: mj_makeData allocates, and physics must not wait on it.
+        if (reload_pending) {
+            reload_pending = false;
+            mj_deleteData(snapshot);
+            m        = *model;
+            snapshot = mj_makeData(m);
+            torso_id = mj_name2id(m, mjOBJ_BODY, "torso_link");
+            std::fprintf(stderr, "[grove_g1] model reloaded; sensor snapshot rebuilt\n");
+            if (torso_id < 0) {
+                std::fprintf(
+                    stderr, "[grove_g1] reloaded model has no torso_link; sensors DISABLED\n");
+                mj_deleteData(snapshot);
+                return;
+            }
+            std::this_thread::sleep_until(next);
+            continue;
         }
         const double lock_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - lock_start)

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -45,6 +45,7 @@ struct Config
     int    scene_geom_group = 2;
 
     bool camera_enabled = false;
+    bool camera_color   = true;
     int  camera_width   = 848;
     int  camera_height  = 480;
     // d435_joint in the vendored URDF, relative to torso_link. Same provenance as the
@@ -113,6 +114,9 @@ Config loadConfig()
         }
         if (root["elevation_steps"]) {
             cfg.elevation_steps = root["elevation_steps"].as<int>();
+        }
+        if (root["camera_color"]) {
+            cfg.camera_color = root["camera_color"].as<bool>();
         }
         if (root["camera_enabled"]) {
             cfg.camera_enabled = root["camera_enabled"].as<bool>();
@@ -239,7 +243,12 @@ private:
     {
         const char* p        = static_cast<const char*>(buf);
         std::size_t sent     = 0;
-        const auto  deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(20);
+        // 20 ms covered a 1.6 MB depth frame but not the 2.9 MB depth+colour one: the
+        // receiver drains roughly a socket buffer per wakeup, so the budget has to cover
+        // enough of its wakeups to move the whole payload. Still well inside the 100 ms
+        // frame period, and this waits off the sim lock, so overrunning it costs nothing
+        // on the physics side.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(80);
         while (sent < bytes) {
             // MSG_NOSIGNAL is load-bearing: without it a vanished relay raises SIGPIPE and
             // kills the simulator.
@@ -352,6 +361,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     mjvCamera   cam_cam;
     GLFWwindow* cam_win = nullptr;
     std::vector<unsigned char> cam_rgb;
+    std::vector<unsigned char> cam_payload;
     std::vector<float>         cam_depth;
     if (cfg.camera_enabled) {
         if (glfwInit() && (glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE), true) &&
@@ -599,7 +609,8 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
                 mjv_updateScene(m, snapshot, &cam_opt, nullptr, &cam_cam, mjCAT_ALL, &cam_scn);
                 mjrRect vp{0, 0, cfg.camera_width, cfg.camera_height};
                 mjr_render(vp, &cam_scn, &cam_con);
-                mjr_readPixels(nullptr, cam_depth.data(), vp, &cam_con);
+                mjr_readPixels(cfg.camera_color ? cam_rgb.data() : nullptr, cam_depth.data(),
+                               vp, &cam_con);
 
                 // mjr_readPixels hands back the raw OpenGL depth buffer: non-linear, in
                 // [0,1]. Publishing it as metres would look plausible at every distance and
@@ -627,19 +638,38 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
                                      cam_depth.begin() + static_cast<std::size_t>(y + 1) * w,
                                      cam_depth.begin() + static_cast<std::size_t>(h - 1 - y) * w);
                 }
+                if (cfg.camera_color) {
+                    const std::size_t stride = static_cast<std::size_t>(w) * 3;
+                    for (int y = 0; y < h / 2; ++y) {
+                        std::swap_ranges(cam_rgb.begin() + static_cast<std::size_t>(y) * stride,
+                                         cam_rgb.begin() + static_cast<std::size_t>(y + 1) * stride,
+                                         cam_rgb.begin() +
+                                             static_cast<std::size_t>(h - 1 - y) * stride);
+                    }
+                }
 
                 SensorFrameHeader dh{};
                 dh.magic         = kSensorFrameMagic;
                 dh.version       = kSensorFrameVersion;
                 dh.kind          = static_cast<uint32_t>(SensorFrameKind::Depth);
-                dh.payload_bytes = static_cast<uint32_t>(cam_depth.size() * sizeof(float));
+                const std::size_t depth_bytes = cam_depth.size() * sizeof(float);
+                const std::size_t rgb_bytes    = cfg.camera_color ? cam_rgb.size() : 0;
+                dh.payload_bytes = static_cast<uint32_t>(depth_bytes + rgb_bytes);
+                dh.rgb_bytes     = static_cast<uint32_t>(rgb_bytes);
                 dh.sim_time_s    = sim_time;
                 std::memcpy(dh.sensor_pos, cam_pos, sizeof(cam_pos));
                 matrixToQuat(R_body, dh.sensor_quat);
                 dh.width    = static_cast<uint32_t>(w);
                 dh.height   = static_cast<uint32_t>(h);
                 dh.fovy_deg = static_cast<float>(m->cam_fovy[cam_id]);
-                relay.send(dh, cam_depth.data(), cam_depth.size() * sizeof(float));
+                // Colour rides in the same frame rather than a second one: it came from the
+                // same render, so pairing it up downstream could only lose that guarantee.
+                cam_payload.resize(depth_bytes + rgb_bytes);
+                std::memcpy(cam_payload.data(), cam_depth.data(), depth_bytes);
+                if (rgb_bytes != 0) {
+                    std::memcpy(cam_payload.data() + depth_bytes, cam_rgb.data(), rgb_bytes);
+                }
+                relay.send(dh, cam_payload.data(), cam_payload.size());
             }
             const auto cam_t2 = std::chrono::steady_clock::now();
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -1,0 +1,132 @@
+#include "sensor_publisher.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace grove_g1
+{
+namespace
+{
+
+struct Config
+{
+    bool        enabled       = false;
+    double      rate_hz       = 10.0;
+    std::string node_name     = "g1_sim_sensors";
+};
+
+struct State
+{
+    std::thread       thread;
+    std::atomic<bool> running{false};
+    bool              owns_rclcpp = false;
+};
+
+State& state()
+{
+    static State s;
+    return s;
+}
+
+// Reads GROVE_G1_SENSOR_CONFIG. Absent or unreadable means sensors stay off, which is the
+// default the locomotion suites run under.
+Config loadConfig()
+{
+    Config cfg;
+    const char* path = std::getenv("GROVE_G1_SENSOR_CONFIG");
+    if (path == nullptr || *path == '\0') {
+        return cfg;
+    }
+    try {
+        const YAML::Node root = YAML::LoadFile(path);
+        cfg.enabled = root["enabled"] ? root["enabled"].as<bool>() : true;
+        if (root["rate_hz"]) {
+            cfg.rate_hz = root["rate_hz"].as<double>();
+        }
+        if (root["node_name"]) {
+            cfg.node_name = root["node_name"].as<std::string>();
+        }
+    } catch (const std::exception& e) {
+        // Loud, and still off: a malformed config must not look like a working sensor.
+        std::fprintf(
+            stderr, "[grove_g1] sensor config '%s' failed to load (%s); sensors DISABLED\n", path,
+            e.what());
+        cfg.enabled = false;
+    }
+    if (cfg.rate_hz <= 0.0) {
+        std::fprintf(stderr, "[grove_g1] rate_hz must be positive; sensors DISABLED\n");
+        cfg.enabled = false;
+    }
+    return cfg;
+}
+
+void sensorLoop(const Config cfg, rclcpp::Node::SharedPtr node, mjModel** model, mjData** data)
+{
+    // The model is loaded by the physics thread after this one starts, same as the SDK
+    // bridge's own wait.
+    while (state().running.load(std::memory_order_relaxed) && *data == nullptr) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if (!state().running.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    RCLCPP_INFO(
+        node->get_logger(), "Sensor thread up at %.1f Hz on a model with %d geoms.", cfg.rate_hz,
+        (*model)->ngeom);
+
+    const auto period = std::chrono::duration<double>(1.0 / cfg.rate_hz);
+    auto       next   = std::chrono::steady_clock::now();
+    while (state().running.load(std::memory_order_relaxed) && rclcpp::ok()) {
+        next += std::chrono::duration_cast<std::chrono::steady_clock::duration>(period);
+        // Sweep and publish land here.
+        std::this_thread::sleep_until(next);
+    }
+}
+
+}  // namespace
+
+void StartSensorPublisher(
+    mjModel** model, mjData** data, std::recursive_mutex* sim_mtx, int argc, char** argv)
+{
+    (void)sim_mtx;
+
+    const Config cfg = loadConfig();
+    if (!cfg.enabled) {
+        return;
+    }
+    if (state().running.load()) {
+        return;
+    }
+
+    if (!rclcpp::ok()) {
+        rclcpp::init(argc, argv);
+        state().owns_rclcpp = true;
+    }
+    auto node = std::make_shared<rclcpp::Node>(cfg.node_name);
+
+    state().running.store(true);
+    state().thread = std::thread(sensorLoop, cfg, node, model, data);
+}
+
+void StopSensorPublisher()
+{
+    if (!state().running.exchange(false)) {
+        return;
+    }
+    if (state().thread.joinable()) {
+        state().thread.join();
+    }
+    if (state().owns_rclcpp && rclcpp::ok()) {
+        rclcpp::shutdown();
+    }
+}
+
+}  // namespace grove_g1

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -19,6 +19,8 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <GLFW/glfw3.h>
+
 #include "sensor_frame.h"
 
 namespace grove_g1
@@ -41,6 +43,14 @@ struct Config
     // Group 2 and not 3, because MuJoCo's viewer renders only groups 0-2: scene geometry in
     // group 3 is physically present, hit by rays, and completely invisible on screen.
     int    scene_geom_group = 2;
+
+    bool camera_enabled = false;
+    int  camera_width   = 848;
+    int  camera_height  = 480;
+    // d435_joint in the vendored URDF, relative to torso_link. Same provenance as the
+    // LiDAR mount, and equally not to be confused with g1_sim's torso-folded values.
+    double cam_xyz[3] = {0.0576235, 0.01753, 0.42987};
+    double cam_rpy[3] = {0.0, 0.8307767239493009, 0.0};
     int    azimuth_steps   = 360;
     int    elevation_steps = 32;
     double azimuth_min     = -M_PI;
@@ -103,6 +113,9 @@ Config loadConfig()
         }
         if (root["elevation_steps"]) {
             cfg.elevation_steps = root["elevation_steps"].as<int>();
+        }
+        if (root["camera_enabled"]) {
+            cfg.camera_enabled = root["camera_enabled"].as<bool>();
         }
         if (root["scene_geom_group"]) {
             cfg.scene_geom_group = root["scene_geom_group"].as<int>();
@@ -211,6 +224,10 @@ private:
             ::close(fd);
             return false;
         }
+        // Depth frames are ~1.6 MB; the default buffer would force a retry on every one.
+        const int snd = 4 * 1024 * 1024;
+        ::setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd, sizeof(snd));
+
         fd_ = fd;
         std::fprintf(stderr, "[grove_g1] connected to relay at %s\n", path_.c_str());
         return true;
@@ -220,8 +237,9 @@ private:
     // and resynchronising is not worth the code, so the connection is dropped and remade.
     bool sendAll(const void* buf, std::size_t bytes, bool frame_started)
     {
-        const char* p    = static_cast<const char*>(buf);
-        std::size_t sent = 0;
+        const char* p        = static_cast<const char*>(buf);
+        std::size_t sent     = 0;
+        const auto  deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(20);
         while (sent < bytes) {
             // MSG_NOSIGNAL is load-bearing: without it a vanished relay raises SIGPIPE and
             // kills the simulator.
@@ -235,6 +253,15 @@ private:
                     // None of this frame is on the wire yet, so dropping it is clean.
                     logThrottled("relay slow; dropping frame", slow_log_);
                     return false;
+                }
+                // A depth frame is ~1.6 MB and will not fit the socket buffer in one go, so
+                // EAGAIN mid-frame is normal rather than a fault. Wait briefly for the relay
+                // to drain. This is off the sim lock, so it delays only this thread, never
+                // physics; past the deadline the frame is abandoned and the connection reset
+                // rather than left desynchronised.
+                if (std::chrono::steady_clock::now() < deadline) {
+                    std::this_thread::sleep_for(std::chrono::microseconds(200));
+                    continue;
                 }
                 closeFd();
                 logThrottled("partial write; reconnecting", slow_log_);
@@ -281,6 +308,9 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
 
     double R_mount[9];
     rpyToMatrix(cfg.mount_rpy, R_mount);
+    double R_cam_mount[9];
+    rpyToMatrix(cfg.cam_rpy, R_cam_mount);
+    const int cam_id = mj_name2id(m, mjOBJ_CAMERA, "d435i");
 
     mjtByte geomgroup[mjNGROUP] = {0};
     if (cfg.scene_geom_group >= 0 && cfg.scene_geom_group < mjNGROUP) {
@@ -313,6 +343,43 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
 
     mjData*     snapshot = mj_makeData(m);
     RelaySocket relay(cfg.socket_path);
+
+    // S3 spike scaffolding. Its own GL context on this thread: measured safe alongside the
+    // viewer's, and glfwCreateWindow off the main thread works here despite the docs.
+    mjvScene    cam_scn;
+    mjrContext  cam_con;
+    mjvOption   cam_opt;
+    mjvCamera   cam_cam;
+    GLFWwindow* cam_win = nullptr;
+    std::vector<unsigned char> cam_rgb;
+    std::vector<float>         cam_depth;
+    if (cfg.camera_enabled) {
+        if (glfwInit() && (glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE), true) &&
+            (cam_win = glfwCreateWindow(cfg.camera_width, cfg.camera_height, "g1cam", nullptr,
+                                        nullptr)) != nullptr) {
+            glfwMakeContextCurrent(cam_win);
+            mjv_defaultScene(&cam_scn);
+            mjv_makeScene(m, &cam_scn, 2000);
+            mjr_defaultContext(&cam_con);
+            mjr_makeContext(m, &cam_con, mjFONTSCALE_100);
+            mjr_setBuffer(mjFB_OFFSCREEN, &cam_con);
+            mjv_defaultOption(&cam_opt);
+            mjv_defaultCamera(&cam_cam);
+            // FIXED and bound to our camera element, not FREE. A free camera ignores
+            // cam_xpos/cam_xmat entirely and orbits its own default pose, so every pose
+            // written below would be silently discarded and the depth would be identical
+            // whatever the robot did.
+            cam_cam.type       = mjCAMERA_FIXED;
+            cam_cam.fixedcamid = mj_name2id(m, mjOBJ_CAMERA, "d435i");
+            cam_rgb.resize(static_cast<std::size_t>(cfg.camera_width) * cfg.camera_height * 3);
+            cam_depth.resize(static_cast<std::size_t>(cfg.camera_width) * cfg.camera_height);
+            std::fprintf(stderr, "[grove_g1] camera: offscreen %dx%d ready\n",
+                         cam_con.offWidth, cam_con.offHeight);
+        } else {
+            std::fprintf(stderr, "[grove_g1] camera: GL setup FAILED; disabled\n");
+            cam_win = nullptr;
+        }
+    }
 
     std::vector<float> points(static_cast<std::size_t>(n_rays) * 3);
     std::vector<int>   geomid(static_cast<std::size_t>(n_rays));
@@ -462,6 +529,128 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
                     stderr, "[grove_g1] snapshot lock: worst %.3f ms over %d cycles\n", lock_worst,
                     cycles);
                 lock_worst = 0.0;
+            }
+        }
+
+        if (cam_win != nullptr && cam_id >= 0) {
+            // Transform arrays only, never mj_copyData: the copy is what MuJoCo refuses
+            // when the live stack is in use, and refusing aborts the process (S3, test A).
+            const auto cam_t0 = std::chrono::steady_clock::now();
+            double     cam_torso_pos[3];
+            double     cam_torso_mat[9];
+            {
+                std::lock_guard<std::recursive_mutex> lock(*sim_mtx);
+                const mjData* live = *data;
+                std::memcpy(snapshot->xpos, live->xpos, sizeof(mjtNum) * 3 * m->nbody);
+                std::memcpy(snapshot->xquat, live->xquat, sizeof(mjtNum) * 4 * m->nbody);
+                std::memcpy(snapshot->xmat, live->xmat, sizeof(mjtNum) * 9 * m->nbody);
+                if (m->nsite) {
+                    std::memcpy(
+                        snapshot->site_xpos, live->site_xpos, sizeof(mjtNum) * 3 * m->nsite);
+                    std::memcpy(
+                        snapshot->site_xmat, live->site_xmat, sizeof(mjtNum) * 9 * m->nsite);
+                }
+                if (m->nlight) {
+                    std::memcpy(
+                        snapshot->light_xpos, live->light_xpos, sizeof(mjtNum) * 3 * m->nlight);
+                    std::memcpy(
+                        snapshot->light_xdir, live->light_xdir, sizeof(mjtNum) * 3 * m->nlight);
+                }
+                std::memcpy(cam_torso_pos, live->xpos + 3 * torso_id, sizeof(cam_torso_pos));
+                std::memcpy(cam_torso_mat, live->xmat + 9 * torso_id, sizeof(cam_torso_mat));
+            }
+            const auto cam_t1 = std::chrono::steady_clock::now();
+
+            const double cam_row0 = cam_torso_mat[0] * cam_torso_mat[0] +
+                                    cam_torso_mat[1] * cam_torso_mat[1] +
+                                    cam_torso_mat[2] * cam_torso_mat[2];
+            if (std::isfinite(cam_row0) && cam_row0 >= 0.5) {
+                // Our own snapshot, so writing the camera pose straight into it is safe and
+                // avoids needing a mocap body or a camera on the vendored robot.
+                double cam_pos[3];
+                for (int r = 0; r < 3; ++r) {
+                    cam_pos[r] = cam_torso_pos[r] +
+                                 cam_torso_mat[3 * r + 0] * cfg.cam_xyz[0] +
+                                 cam_torso_mat[3 * r + 1] * cfg.cam_xyz[1] +
+                                 cam_torso_mat[3 * r + 2] * cfg.cam_xyz[2];
+                }
+                double R_body[9];
+                for (int r = 0; r < 3; ++r) {
+                    for (int c = 0; c < 3; ++c) {
+                        double acc = 0.0;
+                        for (int k = 0; k < 3; ++k) {
+                            acc += cam_torso_mat[3 * r + k] * R_cam_mount[3 * k + c];
+                        }
+                        R_body[3 * r + c] = acc;
+                    }
+                }
+                // MuJoCo cameras look down their own -z with +y up; the URDF mount frame is
+                // x forward, y left, z up. Columns are permuted rather than multiplying by a
+                // constant rotation, which is the same mapping written more directly.
+                double R_cam[9];
+                for (int r = 0; r < 3; ++r) {
+                    R_cam[3 * r + 0] = -R_body[3 * r + 1];  // cam x  <- -body y
+                    R_cam[3 * r + 1] = R_body[3 * r + 2];   // cam y  <-  body z
+                    R_cam[3 * r + 2] = -R_body[3 * r + 0];  // cam z  <- -body x
+                }
+                std::memcpy(snapshot->cam_xpos + 3 * cam_id, cam_pos, sizeof(cam_pos));
+                std::memcpy(snapshot->cam_xmat + 9 * cam_id, R_cam, sizeof(R_cam));
+
+                mjv_updateScene(m, snapshot, &cam_opt, nullptr, &cam_cam, mjCAT_ALL, &cam_scn);
+                mjrRect vp{0, 0, cfg.camera_width, cfg.camera_height};
+                mjr_render(vp, &cam_scn, &cam_con);
+                mjr_readPixels(nullptr, cam_depth.data(), vp, &cam_con);
+
+                // mjr_readPixels hands back the raw OpenGL depth buffer: non-linear, in
+                // [0,1]. Publishing it as metres would look plausible at every distance and
+                // be wrong at all of them, so it is linearised here against the model's own
+                // near/far planes.
+                // The frustum the render actually used, not vis.map. mjv_updateScene
+                // derives frustum_near/far per camera and mjr_render projects with those;
+                // reconstructing them from vis.map * stat.extent gives a different, wrong
+                // near plane and therefore a depth that is plausible at every range and
+                // correct at none.
+                const double znear = cam_scn.camera[0].frustum_near;
+                const double zfar  = cam_scn.camera[0].frustum_far;
+                for (std::size_t i = 0; i < cam_depth.size(); ++i) {
+                    const double z = cam_depth[i];
+                    cam_depth[i]   = (z >= 1.0)
+                                       ? std::numeric_limits<float>::quiet_NaN()
+                                       : static_cast<float>(
+                                             znear * zfar / (zfar - z * (zfar - znear)));
+                }
+
+                // Rows come out of GL bottom-up; ROS images are top-down.
+                const int w = cfg.camera_width, h = cfg.camera_height;
+                for (int y = 0; y < h / 2; ++y) {
+                    std::swap_ranges(cam_depth.begin() + static_cast<std::size_t>(y) * w,
+                                     cam_depth.begin() + static_cast<std::size_t>(y + 1) * w,
+                                     cam_depth.begin() + static_cast<std::size_t>(h - 1 - y) * w);
+                }
+
+                SensorFrameHeader dh{};
+                dh.magic         = kSensorFrameMagic;
+                dh.version       = kSensorFrameVersion;
+                dh.kind          = static_cast<uint32_t>(SensorFrameKind::Depth);
+                dh.payload_bytes = static_cast<uint32_t>(cam_depth.size() * sizeof(float));
+                dh.sim_time_s    = sim_time;
+                std::memcpy(dh.sensor_pos, cam_pos, sizeof(cam_pos));
+                matrixToQuat(R_body, dh.sensor_quat);
+                dh.width    = static_cast<uint32_t>(w);
+                dh.height   = static_cast<uint32_t>(h);
+                dh.fovy_deg = static_cast<float>(m->cam_fovy[cam_id]);
+                relay.send(dh, cam_depth.data(), cam_depth.size() * sizeof(float));
+            }
+            const auto cam_t2 = std::chrono::steady_clock::now();
+
+            static int    cam_n = 0;
+            static double cam_lock_ms = 0, cam_total_ms = 0;
+            cam_lock_ms += std::chrono::duration<double, std::milli>(cam_t1 - cam_t0).count();
+            cam_total_ms += std::chrono::duration<double, std::milli>(cam_t2 - cam_t0).count();
+            if (++cam_n % 100 == 0) {
+                std::fprintf(
+                    stderr, "[grove_g1] camera: %.2f ms/frame, %.3f ms under lock (%d frames)\n",
+                    cam_total_ms / cam_n, cam_lock_ms / cam_n, cam_n);
             }
         }
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -33,10 +33,13 @@ struct Config
 
     // Mid360 envelope. Resolution is a real budget, not a formality: 360x32 costs ~32 ms per
     // sweep against the G1 scene, so it is configurable and the timing gate decides what ships.
-    // Which MuJoCo geom group the sweep sees. The scene puts walls, floor and obstacles in
-    // group 3; the robot's own geoms are not in it. Without this every ray returns the
-    // torso shell ~6 cm from the mount and the world is invisible.
-    int    scene_geom_group = 3;
+    // Which MuJoCo geom group the sweep sees. Scene geometry is group 2; the robot uses
+    // groups 0 (collision) and 1 (visual). Without the mask every ray returns the torso
+    // shell ~6 cm from the mount and the world is never reached.
+    //
+    // Group 2 and not 3, because MuJoCo's viewer renders only groups 0-2: scene geometry in
+    // group 3 is physically present, hit by rays, and completely invisible on screen.
+    int    scene_geom_group = 2;
     int    azimuth_steps   = 360;
     int    elevation_steps = 32;
     double azimuth_min     = -M_PI;

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -323,10 +323,20 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
         const auto lock_start = std::chrono::steady_clock::now();
         {
             std::lock_guard<std::recursive_mutex> lock(*sim_mtx);
-            mj_copyData(snapshot, m, *data);
-            sim_time = snapshot->time;
-            std::memcpy(torso_pos, snapshot->xpos + 3 * torso_id, sizeof(torso_pos));
-            std::memcpy(torso_mat, snapshot->xmat + 9 * torso_id, sizeof(torso_mat));
+            // NOT mj_copyData. That copies the arena as well, and MuJoCo rejects it
+            // outright while another thread has the stack in use ("attempting to copy
+            // mjData while stack is in use") -- which killed the simulator, because
+            // sim.mtx does not cover the render thread's use of mjData.
+            //
+            // mj_ray only reads geom poses, and everything this sweep can hit is a
+            // primitive (the scene's boxes and plane), so no mesh BVH is involved. Two
+            // arrays is both correct and far cheaper than a full mjData.
+            const mjData* live = *data;
+            std::memcpy(snapshot->geom_xpos, live->geom_xpos, sizeof(mjtNum) * 3 * m->ngeom);
+            std::memcpy(snapshot->geom_xmat, live->geom_xmat, sizeof(mjtNum) * 9 * m->ngeom);
+            sim_time = live->time;
+            std::memcpy(torso_pos, live->xpos + 3 * torso_id, sizeof(torso_pos));
+            std::memcpy(torso_mat, live->xmat + 9 * torso_id, sizeof(torso_mat));
         }
         const double lock_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - lock_start)
@@ -393,7 +403,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
 
         // The snapshot is the only thing that contends with physics, so its cost is the
         // number that matters; the ~32 ms sweep below it runs off-lock. Reported rarely
-        // rather than never: if mj_copyData ever grows, this is where it shows up.
+        // rather than never: if the copy ever grows, this is where it shows up.
         {
             static int    cycles     = 0;
             static double lock_worst = 0.0;

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -185,10 +186,13 @@ public:
             logThrottled("relay not connected; dropping frame", connect_log_);
             return;
         }
-        if (!sendAll(&header, sizeof(header))) {
+        if (!sendAll(&header, sizeof(header), /*frame_started=*/false)) {
             return;
         }
-        sendAll(payload, payload_bytes);
+        // Mid-frame now: dropping the body would leave a header with no payload, and the
+        // relay would read the next frame's bytes as this one's points, validate them, and
+        // publish a self-consistent cloud of garbage.
+        sendAll(payload, payload_bytes, /*frame_started=*/true);
     }
 
 private:
@@ -214,7 +218,7 @@ private:
 
     // All-or-nothing by policy. A partial write desynchronises the length-prefixed stream,
     // and resynchronising is not worth the code, so the connection is dropped and remade.
-    bool sendAll(const void* buf, std::size_t bytes)
+    bool sendAll(const void* buf, std::size_t bytes, bool frame_started)
     {
         const char* p    = static_cast<const char*>(buf);
         std::size_t sent = 0;
@@ -227,7 +231,8 @@ private:
                 continue;
             }
             if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-                if (sent == 0) {
+                if (sent == 0 && !frame_started) {
+                    // None of this frame is on the wire yet, so dropping it is clean.
                     logThrottled("relay slow; dropping frame", slow_log_);
                     return false;
                 }
@@ -350,7 +355,11 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
         // small"). Skip the cycle rather than hand it one.
         const double row0 = torso_mat[0] * torso_mat[0] + torso_mat[1] * torso_mat[1] +
                             torso_mat[2] * torso_mat[2];
-        if (row0 < 0.5) {
+        // !isfinite first: NaN fails every comparison, so `row0 < 0.5` alone lets a diverged
+        // pose through and mj_ray answers a zero-length direction with mju_error, which
+        // aborts the simulator rather than returning.
+        if (!std::isfinite(row0) || row0 < 0.5 || !std::isfinite(torso_pos[0]) ||
+            !std::isfinite(torso_pos[1]) || !std::isfinite(torso_pos[2])) {
             std::this_thread::sleep_until(next);
             continue;
         }
@@ -385,13 +394,18 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             // flg_static=1 so the world-body walls and floor are hit at all. geomgroup
             // restricts returns to the scene, keeping the robot from occluding itself.
             double dist = mj_ray(m, snapshot, origin, world_dir, geomgroup, 1, -1, &geomid[i]);
-            if (dist < cfg.range_min || dist > cfg.range_max) {
-                dist = 0.0;  // no return
-            }
             const std::size_t o = static_cast<std::size_t>(i) * 3;
-            points[o + 0]       = static_cast<float>(d[0] * dist);
-            points[o + 1]       = static_cast<float>(d[1] * dist);
-            points[o + 2]       = static_cast<float>(d[2] * dist);
+            if (dist < cfg.range_min || dist > cfg.range_max) {
+                // NaN, not (0,0,0). Zero is a valid point AT the sensor, and every filter
+                // that honours is_dense=false keeps it: thousands of phantom returns
+                // stacked on the robot, straight into a costmap.
+                points[o + 0] = points[o + 1] = points[o + 2] =
+                    std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            points[o + 0] = static_cast<float>(d[0] * dist);
+            points[o + 1] = static_cast<float>(d[1] * dist);
+            points[o + 2] = static_cast<float>(d[2] * dist);
         }
 
         SensorFrameHeader header{};
@@ -439,14 +453,5 @@ void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* 
     state().thread = std::thread(sensorLoop, cfg, model, data, sim_mtx);
 }
 
-void StopSensorPublisher()
-{
-    if (!state().running.exchange(false)) {
-        return;
-    }
-    if (state().thread.joinable()) {
-        state().thread.join();
-    }
-}
 
 }  // namespace grove_g1

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -1,14 +1,23 @@
 #include "sensor_publisher.h"
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
 #include <atomic>
+#include <cerrno>
 #include <chrono>
+#include <cmath>
+#include <cstdio>
 #include <cstdlib>
-#include <memory>
+#include <cstring>
 #include <string>
 #include <thread>
+#include <vector>
 
-#include <rclcpp/rclcpp.hpp>
 #include <yaml-cpp/yaml.h>
+
+#include "sensor_frame.h"
 
 namespace grove_g1
 {
@@ -17,49 +26,77 @@ namespace
 
 struct Config
 {
-    bool        enabled          = false;
-    double      rate_hz          = 10.0;
-    std::string node_name        = "g1_sim_sensors";
-    // Delay after mjData appears before rclcpp::init(). The Unitree SDK calls
-    // dds_create_domain EXPLICITLY and that fails if the domain already exists, so ROS must
-    // not get there first. Its bridge thread polls for mjData every 500 ms and initialises
-    // immediately after, so waiting past that hands the SDK the domain.
-    double      sdk_settle_s     = 2.0;
+    bool        enabled     = false;
+    double      rate_hz     = 10.0;
+    std::string socket_path = "/tmp/g1_sensors.sock";
+
+    // Mid360 envelope. Resolution is a real budget, not a formality: 360x32 costs ~32 ms per
+    // sweep against the G1 scene, so it is configurable and the timing gate decides what ships.
+    int    azimuth_steps   = 360;
+    int    elevation_steps = 32;
+    double azimuth_min     = -M_PI;
+    double azimuth_max     = M_PI;
+    double elevation_min   = -0.12217305;  // -7 deg
+    double elevation_max   = 0.90757121;   // +52 deg
+    double range_min       = 0.1;
+    double range_max       = 40.0;
+
+    // mid360_joint in Unitree's vendored URDF, relative to torso_link. NOT the torso-folded
+    // values g1_sim uses: that fold exists only because the sandbox body has no torso.
+    double mount_xyz[3] = {0.0002835, 0.00003, 0.428434};
+    double mount_rpy[3] = {M_PI, 0.05112069379091391, 0.0};
 };
 
 struct State
 {
     std::thread       thread;
     std::atomic<bool> running{false};
-    bool              owns_rclcpp = false;
 };
 
 State& state()
 {
-    static State s;
-    return s;
+    // Deliberately leaked. unitree_mujoco's physics thread ends with exit(0), which runs
+    // static destructors while our sampler thread is still running; destroying a joinable
+    // std::thread calls std::terminate ("terminate called without an active exception").
+    // The vendor's own bridge thread sidesteps this because main() ends in pthread_exit,
+    // which skips destructors entirely. A never-destroyed singleton is the small fix.
+    static State* s = new State();
+    return *s;
 }
 
-// Reads GROVE_G1_SENSOR_CONFIG. Absent or unreadable means sensors stay off, which is the
-// default the locomotion suites run under.
+// One line per ~5 s at 10 Hz. A missing relay is a normal condition and must neither spam
+// nor be silent.
+void logThrottled(const char* what, int& counter)
+{
+    if (counter++ % 50 == 0) {
+        std::fprintf(stderr, "[grove_g1] %s\n", what);
+    }
+}
+
 Config loadConfig()
 {
-    Config cfg;
+    Config      cfg;
     const char* path = std::getenv("GROVE_G1_SENSOR_CONFIG");
     if (path == nullptr || *path == '\0') {
         return cfg;
     }
     try {
         const YAML::Node root = YAML::LoadFile(path);
-        cfg.enabled = root["enabled"] ? root["enabled"].as<bool>() : true;
+        cfg.enabled           = root["enabled"] ? root["enabled"].as<bool>() : true;
         if (root["rate_hz"]) {
             cfg.rate_hz = root["rate_hz"].as<double>();
         }
-        if (root["node_name"]) {
-            cfg.node_name = root["node_name"].as<std::string>();
+        if (root["socket_path"]) {
+            cfg.socket_path = root["socket_path"].as<std::string>();
         }
-        if (root["sdk_settle_s"]) {
-            cfg.sdk_settle_s = root["sdk_settle_s"].as<double>();
+        if (root["azimuth_steps"]) {
+            cfg.azimuth_steps = root["azimuth_steps"].as<int>();
+        }
+        if (root["elevation_steps"]) {
+            cfg.elevation_steps = root["elevation_steps"].as<int>();
+        }
+        if (root["range_max"]) {
+            cfg.range_max = root["range_max"].as<double>();
         }
     } catch (const std::exception& e) {
         // Loud, and still off: a malformed config must not look like a working sensor.
@@ -68,14 +105,147 @@ Config loadConfig()
             e.what());
         cfg.enabled = false;
     }
-    if (cfg.rate_hz <= 0.0) {
-        std::fprintf(stderr, "[grove_g1] rate_hz must be positive; sensors DISABLED\n");
+    if (cfg.rate_hz <= 0.0 || cfg.azimuth_steps <= 0 || cfg.elevation_steps <= 0) {
+        std::fprintf(stderr, "[grove_g1] sensor config has non-positive values; DISABLED\n");
         cfg.enabled = false;
     }
     return cfg;
 }
 
-void sensorLoop(const Config cfg, int argc, char** argv, mjModel** model, mjData** data)
+// Extrinsic XYZ (URDF rpy) to a row-major 3x3.
+void rpyToMatrix(const double rpy[3], double R[9])
+{
+    const double cr = std::cos(rpy[0]), sr = std::sin(rpy[0]);
+    const double cp = std::cos(rpy[1]), sp = std::sin(rpy[1]);
+    const double cy = std::cos(rpy[2]), sy = std::sin(rpy[2]);
+    R[0] = cy * cp;
+    R[1] = cy * sp * sr - sy * cr;
+    R[2] = cy * sp * cr + sy * sr;
+    R[3] = sy * cp;
+    R[4] = sy * sp * sr + cy * cr;
+    R[5] = sy * sp * cr - cy * sr;
+    R[6] = -sp;
+    R[7] = cp * sr;
+    R[8] = cp * cr;
+}
+
+void matrixToQuat(const double R[9], double q[4])
+{
+    const double t = R[0] + R[4] + R[8];
+    if (t > 0.0) {
+        const double s = std::sqrt(t + 1.0) * 2.0;
+        q[0]           = 0.25 * s;
+        q[1]           = (R[7] - R[5]) / s;
+        q[2]           = (R[2] - R[6]) / s;
+        q[3]           = (R[3] - R[1]) / s;
+    } else if (R[0] > R[4] && R[0] > R[8]) {
+        const double s = std::sqrt(1.0 + R[0] - R[4] - R[8]) * 2.0;
+        q[0]           = (R[7] - R[5]) / s;
+        q[1]           = 0.25 * s;
+        q[2]           = (R[1] + R[3]) / s;
+        q[3]           = (R[2] + R[6]) / s;
+    } else if (R[4] > R[8]) {
+        const double s = std::sqrt(1.0 + R[4] - R[0] - R[8]) * 2.0;
+        q[0]           = (R[2] - R[6]) / s;
+        q[1]           = (R[1] + R[3]) / s;
+        q[2]           = 0.25 * s;
+        q[3]           = (R[5] + R[7]) / s;
+    } else {
+        const double s = std::sqrt(1.0 + R[8] - R[0] - R[4]) * 2.0;
+        q[0]           = (R[3] - R[1]) / s;
+        q[1]           = (R[2] + R[6]) / s;
+        q[2]           = (R[5] + R[7]) / s;
+        q[3]           = 0.25 * s;
+    }
+}
+
+// Never blocks, never raises SIGPIPE, never throws. A dead or slow relay costs one dropped
+// frame, never a stalled simulator.
+class RelaySocket
+{
+public:
+    explicit RelaySocket(std::string path) : path_(std::move(path)) {}
+
+    ~RelaySocket() { closeFd(); }
+
+    void send(const SensorFrameHeader& header, const void* payload, std::size_t payload_bytes)
+    {
+        if (fd_ < 0 && !tryConnect()) {
+            logThrottled("relay not connected; dropping frame", connect_log_);
+            return;
+        }
+        if (!sendAll(&header, sizeof(header))) {
+            return;
+        }
+        sendAll(payload, payload_bytes);
+    }
+
+private:
+    bool tryConnect()
+    {
+        const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+        if (fd < 0) {
+            return false;
+        }
+        sockaddr_un addr{};
+        addr.sun_family = AF_UNIX;
+        std::strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
+
+        if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 &&
+            errno != EINPROGRESS) {
+            ::close(fd);
+            return false;
+        }
+        fd_ = fd;
+        std::fprintf(stderr, "[grove_g1] connected to relay at %s\n", path_.c_str());
+        return true;
+    }
+
+    // All-or-nothing by policy. A partial write desynchronises the length-prefixed stream,
+    // and resynchronising is not worth the code, so the connection is dropped and remade.
+    bool sendAll(const void* buf, std::size_t bytes)
+    {
+        const char* p    = static_cast<const char*>(buf);
+        std::size_t sent = 0;
+        while (sent < bytes) {
+            // MSG_NOSIGNAL is load-bearing: without it a vanished relay raises SIGPIPE and
+            // kills the simulator.
+            const ssize_t n = ::send(fd_, p + sent, bytes - sent, MSG_NOSIGNAL | MSG_DONTWAIT);
+            if (n > 0) {
+                sent += static_cast<std::size_t>(n);
+                continue;
+            }
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                if (sent == 0) {
+                    logThrottled("relay slow; dropping frame", slow_log_);
+                    return false;
+                }
+                closeFd();
+                logThrottled("partial write; reconnecting", slow_log_);
+                return false;
+            }
+            closeFd();
+            logThrottled("relay disconnected; will retry", slow_log_);
+            return false;
+        }
+        return true;
+    }
+
+    void closeFd()
+    {
+        if (fd_ >= 0) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+    }
+
+    std::string path_;
+    int         fd_          = -1;
+    int         connect_log_ = 0;
+    int         slow_log_    = 0;
+};
+
+void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive_mutex* sim_mtx)
 {
     // The model is loaded by the physics thread after this one starts, same as the SDK
     // bridge's own wait.
@@ -86,50 +256,132 @@ void sensorLoop(const Config cfg, int argc, char** argv, mjModel** model, mjData
         return;
     }
 
-    // Let the SDK claim the DDS domain before ROS touches it. See Config::sdk_settle_s.
-    std::this_thread::sleep_for(
-        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::duration<double>(cfg.sdk_settle_s)));
-    if (!state().running.load(std::memory_order_relaxed)) {
+    mjModel*  m        = *model;
+    const int torso_id = mj_name2id(m, mjOBJ_BODY, "torso_link");
+    if (torso_id < 0) {
+        std::fprintf(stderr, "[grove_g1] no torso_link in the model; sensors DISABLED\n");
         return;
     }
 
-    if (!rclcpp::ok()) {
-        rclcpp::init(argc, argv);
-        state().owns_rclcpp = true;
-    }
-    auto node = std::make_shared<rclcpp::Node>(cfg.node_name);
+    double R_mount[9];
+    rpyToMatrix(cfg.mount_rpy, R_mount);
 
-    RCLCPP_INFO(
-        node->get_logger(), "Sensor thread up at %.1f Hz on a model with %d geoms.", cfg.rate_hz,
-        (*model)->ngeom);
+    const int n_rays = cfg.azimuth_steps * cfg.elevation_steps;
+    std::fprintf(
+        stderr, "[grove_g1] sensor thread up: %dx%d rays at %.1f Hz -> %s\n", cfg.azimuth_steps,
+        cfg.elevation_steps, cfg.rate_hz, cfg.socket_path.c_str());
+
+    // Ray directions in the sensor frame never change; build them once.
+    std::vector<double> dirs(static_cast<std::size_t>(n_rays) * 3);
+    for (int a = 0; a < cfg.azimuth_steps; ++a) {
+        const double az =
+            cfg.azimuth_min +
+            (cfg.azimuth_max - cfg.azimuth_min) * a / static_cast<double>(cfg.azimuth_steps);
+        for (int e = 0; e < cfg.elevation_steps; ++e) {
+            const double el =
+                cfg.elevation_steps == 1
+                    ? cfg.elevation_min
+                    : cfg.elevation_min + (cfg.elevation_max - cfg.elevation_min) * e /
+                                              static_cast<double>(cfg.elevation_steps - 1);
+            const std::size_t i = (static_cast<std::size_t>(e) * cfg.azimuth_steps + a) * 3;
+            dirs[i + 0]         = std::cos(el) * std::cos(az);
+            dirs[i + 1]         = std::cos(el) * std::sin(az);
+            dirs[i + 2]         = std::sin(el);
+        }
+    }
+
+    mjData*     snapshot = mj_makeData(m);
+    RelaySocket relay(cfg.socket_path);
+
+    std::vector<float> points(static_cast<std::size_t>(n_rays) * 3);
+    std::vector<int>   geomid(static_cast<std::size_t>(n_rays));
 
     const auto period = std::chrono::duration<double>(1.0 / cfg.rate_hz);
     auto       next   = std::chrono::steady_clock::now();
-    while (state().running.load(std::memory_order_relaxed) && rclcpp::ok()) {
+
+    while (state().running.load(std::memory_order_relaxed)) {
         next += std::chrono::duration_cast<std::chrono::steady_clock::duration>(period);
-        // Sweep and publish land here.
+
+        // Snapshot under the lock, raycast outside it. Holding the lock across a ~32 ms
+        // sweep would stall physics exactly as badly as running inline.
+        double sim_time = 0.0;
+        double torso_pos[3];
+        double torso_mat[9];
+        {
+            std::lock_guard<std::recursive_mutex> lock(*sim_mtx);
+            mj_copyData(snapshot, m, *data);
+            sim_time = snapshot->time;
+            std::memcpy(torso_pos, snapshot->xpos + 3 * torso_id, sizeof(torso_pos));
+            std::memcpy(torso_mat, snapshot->xmat + 9 * torso_id, sizeof(torso_mat));
+        }
+
+        // Sensor pose = torso pose composed with the fixed mount, taken live rather than
+        // hardcoded: torso_link's height depends on the waist chain and the current stance,
+        // so any baked-in constant is wrong the moment the robot walks.
+        double origin[3];
+        for (int r = 0; r < 3; ++r) {
+            origin[r] = torso_pos[r] + torso_mat[3 * r + 0] * cfg.mount_xyz[0] +
+                        torso_mat[3 * r + 1] * cfg.mount_xyz[1] +
+                        torso_mat[3 * r + 2] * cfg.mount_xyz[2];
+        }
+        double R_sensor[9];
+        for (int r = 0; r < 3; ++r) {
+            for (int c = 0; c < 3; ++c) {
+                double acc = 0.0;
+                for (int k = 0; k < 3; ++k) {
+                    acc += torso_mat[3 * r + k] * R_mount[3 * k + c];
+                }
+                R_sensor[3 * r + c] = acc;
+            }
+        }
+
+        for (int i = 0; i < n_rays; ++i) {
+            const double* d = &dirs[static_cast<std::size_t>(i) * 3];
+            double        world_dir[3];
+            for (int r = 0; r < 3; ++r) {
+                world_dir[r] = R_sensor[3 * r + 0] * d[0] + R_sensor[3 * r + 1] * d[1] +
+                               R_sensor[3 * r + 2] * d[2];
+            }
+            // flg_static=1 so walls and floor are hit at all; the robot's own geoms are
+            // legitimate returns, same as a real LiDAR seeing its own body.
+            double dist = mj_ray(m, snapshot, origin, world_dir, nullptr, 1, -1, &geomid[i]);
+            if (dist < cfg.range_min || dist > cfg.range_max) {
+                dist = 0.0;  // no return
+            }
+            const std::size_t o = static_cast<std::size_t>(i) * 3;
+            points[o + 0]       = static_cast<float>(d[0] * dist);
+            points[o + 1]       = static_cast<float>(d[1] * dist);
+            points[o + 2]       = static_cast<float>(d[2] * dist);
+        }
+
+        SensorFrameHeader header{};
+        header.magic         = kSensorFrameMagic;
+        header.version       = kSensorFrameVersion;
+        header.kind          = static_cast<uint32_t>(SensorFrameKind::PointCloud);
+        header.payload_bytes = static_cast<uint32_t>(points.size() * sizeof(float));
+        header.sim_time_s    = sim_time;
+        std::memcpy(header.sensor_pos, origin, sizeof(origin));
+        matrixToQuat(R_sensor, header.sensor_quat);
+        header.point_count = static_cast<uint32_t>(n_rays);
+
+        relay.send(header, points.data(), points.size() * sizeof(float));
+
         std::this_thread::sleep_until(next);
     }
+
+    mj_deleteData(snapshot);
 }
 
 }  // namespace
 
-void StartSensorPublisher(
-    mjModel** model, mjData** data, std::recursive_mutex* sim_mtx, int argc, char** argv)
+void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* sim_mtx)
 {
-    (void)sim_mtx;
-
     const Config cfg = loadConfig();
-    if (!cfg.enabled) {
+    if (!cfg.enabled || state().running.load()) {
         return;
     }
-    if (state().running.load()) {
-        return;
-    }
-
     state().running.store(true);
-    state().thread = std::thread(sensorLoop, cfg, argc, argv, model, data);
+    state().thread = std::thread(sensorLoop, cfg, model, data, sim_mtx);
 }
 
 void StopSensorPublisher()
@@ -139,9 +391,6 @@ void StopSensorPublisher()
     }
     if (state().thread.joinable()) {
         state().thread.join();
-    }
-    if (state().owns_rclcpp && rclcpp::ok()) {
-        rclcpp::shutdown();
     }
 }
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.cc
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.cc
@@ -228,9 +228,16 @@ private:
             ::close(fd);
             return false;
         }
-        // Depth frames are ~1.6 MB; the default buffer would force a retry on every one.
+        // A depth+colour frame is ~2.9 MB, which the default buffer cannot hold, so every
+        // frame would otherwise dribble out across the relay's poll wakeups.
+        // SO_SNDBUFFORCE first: plain SO_SNDBUF is silently clamped to 2*net.core.wmem_max
+        // (~416 KB here), which is not enough and gives no error to notice. FORCE needs
+        // CAP_NET_ADMIN, which the dev container has; the plain call is the fallback for
+        // anywhere it does not, and the retry loop below still covers that case.
         const int snd = 4 * 1024 * 1024;
-        ::setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd, sizeof(snd));
+        if (::setsockopt(fd, SOL_SOCKET, SO_SNDBUFFORCE, &snd, sizeof(snd)) != 0) {
+            ::setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd, sizeof(snd));
+        }
 
         fd_ = fd;
         std::fprintf(stderr, "[grove_g1] connected to relay at %s\n", path_.c_str());
@@ -243,11 +250,13 @@ private:
     {
         const char* p        = static_cast<const char*>(buf);
         std::size_t sent     = 0;
-        // 20 ms covered a 1.6 MB depth frame but not the 2.9 MB depth+colour one: the
-        // receiver drains roughly a socket buffer per wakeup, so the budget has to cover
-        // enough of its wakeups to move the whole payload. Still well inside the 100 ms
-        // frame period, and this waits off the sim lock, so overrunning it costs nothing
-        // on the physics side.
+        // Per send, not per frame: a frame is a header plus a body, and a cycle sends both
+        // a depth and a LiDAR frame, so a fully stalled relay can hold this thread for four
+        // times this budget. That is survivable because it waits off the sim lock (every
+        // relay.send call is outside the lock_guard scopes) and the loop re-anchors its
+        // schedule afterwards -- physics is never delayed, only the sensor rate drops.
+        // With SO_SNDBUFFORCE above this should not trigger at all; it is the fallback for
+        // an unprivileged container where the buffer stays clamped.
         const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(80);
         while (sent < bytes) {
             // MSG_NOSIGNAL is load-bearing: without it a vanished relay raises SIGPIPE and
@@ -263,7 +272,7 @@ private:
                     logThrottled("relay slow; dropping frame", slow_log_);
                     return false;
                 }
-                // A depth frame is ~1.6 MB and will not fit the socket buffer in one go, so
+                // A depth+colour frame is ~2.9 MB and may not fit the socket buffer in one go, so
                 // EAGAIN mid-frame is normal rather than a fault. Wait briefly for the relay
                 // to drain. This is off the sim lock, so it delays only this thread, never
                 // physics; past the deadline the frame is abandoned and the connection reset
@@ -319,7 +328,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     rpyToMatrix(cfg.mount_rpy, R_mount);
     double R_cam_mount[9];
     rpyToMatrix(cfg.cam_rpy, R_cam_mount);
-    const int cam_id = mj_name2id(m, mjOBJ_CAMERA, "d435i");
+    int cam_id = mj_name2id(m, mjOBJ_CAMERA, "d435i");
 
     mjtByte geomgroup[mjNGROUP] = {0};
     if (cfg.scene_geom_group >= 0 && cfg.scene_geom_group < mjNGROUP) {
@@ -353,7 +362,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
     mjData*     snapshot = mj_makeData(m);
     RelaySocket relay(cfg.socket_path);
 
-    // S3 spike scaffolding. Its own GL context on this thread: measured safe alongside the
+    // offscreen render state. Its own GL context on this thread: measured safe alongside the
     // viewer's, and glfwCreateWindow off the main thread works here despite the docs.
     mjvScene    cam_scn;
     mjrContext  cam_con;
@@ -446,6 +455,18 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             snapshot = mj_makeData(m);
             torso_id = mj_name2id(m, mjOBJ_BODY, "torso_link");
             std::fprintf(stderr, "[grove_g1] model reloaded; sensor snapshot rebuilt\n");
+            // cam_scn and cam_con were built against the old model: their mesh and texture
+            // ids index freed arrays, and cam_id indexes the old model's camera list, so
+            // the memcpy into snapshot->cam_xpos would run off the new (possibly smaller)
+            // one. Rebuilding both is more code than a debugging-only Reload deserves, so
+            // the camera stops and the LiDAR carries on.
+            if (cam_win != nullptr) {
+                cam_win = nullptr;
+                cam_id  = -1;
+                std::fprintf(
+                    stderr,
+                    "[grove_g1] camera DISABLED after model reload; restart the sim for it\n");
+            }
             if (torso_id < 0) {
                 std::fprintf(
                     stderr, "[grove_g1] reloaded model has no torso_link; sensors DISABLED\n");
@@ -542,7 +563,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             }
         }
 
-        if (cam_win != nullptr && cam_id >= 0) {
+        if (cam_win != nullptr && cam_id >= 0 && !reload_pending) {
             // Transform arrays only, never mj_copyData: the copy is what MuJoCo refuses
             // when the live stack is in use, and refusing aborts the process (S3, test A).
             const auto cam_t0 = std::chrono::steady_clock::now();
@@ -550,7 +571,14 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
             double     cam_torso_mat[9];
             {
                 std::lock_guard<std::recursive_mutex> lock(*sim_mtx);
-                const mjData* live = *data;
+                // Re-checked here, not inherited from the sweep above: that lock was
+                // released in between, and a reload landing in the gap would size these
+                // copies from the old model against the new mjData.
+                if (*model != m) {
+                    reload_pending = true;
+                }
+                const mjData* live = reload_pending ? nullptr : *data;
+                if (live != nullptr) {
                 std::memcpy(snapshot->xpos, live->xpos, sizeof(mjtNum) * 3 * m->nbody);
                 std::memcpy(snapshot->xquat, live->xquat, sizeof(mjtNum) * 4 * m->nbody);
                 std::memcpy(snapshot->xmat, live->xmat, sizeof(mjtNum) * 9 * m->nbody);
@@ -568,6 +596,7 @@ void sensorLoop(const Config cfg, mjModel** model, mjData** data, std::recursive
                 }
                 std::memcpy(cam_torso_pos, live->xpos + 3 * torso_id, sizeof(cam_torso_pos));
                 std::memcpy(cam_torso_mat, live->xmat + 9 * torso_id, sizeof(cam_torso_mat));
+                }
             }
             const auto cam_t1 = std::chrono::steady_clock::now();
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.h
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.h
@@ -1,0 +1,36 @@
+#ifndef GROVE_G1_SENSOR_PUBLISHER_H_
+#define GROVE_G1_SENSOR_PUBLISHER_H_
+
+// Sensor publishing for the converged perception track. Lives outside the vendored
+// unitree_mujoco sources so the patch against them stays a few lines; see
+// workspace/patches/unitree_mujoco/README.md.
+//
+// Off unless GROVE_G1_SENSOR_CONFIG names a config file. With it unset the patched binary
+// behaves exactly like the stock one: no thread, no ROS init, no cost.
+
+#include <mujoco/mujoco.h>
+
+#include <mutex>
+
+namespace grove_g1
+{
+
+// Starts the sensor thread if configured, otherwise returns having done nothing. Non-blocking.
+//
+// model/data are the addresses of unitree_mujoco's globals, not their values: at the call
+// site the model has not loaded yet and both are still null, and they are reassigned again
+// whenever a model is dropped into the viewer. The thread waits for them the same way the
+// SDK bridge thread does.
+//
+// sim_mtx is unitree_mujoco's own simulation mutex. It is held only long enough to snapshot
+// mjData, never across the raycast: a full sweep costs ~32 ms against the G1 scene, and
+// holding the lock for that would stall physics exactly as badly as running inline.
+void StartSensorPublisher(
+    mjModel** model, mjData** data, std::recursive_mutex* sim_mtx, int argc, char** argv);
+
+// Signals the sensor thread to finish and joins it. Safe if never started.
+void StopSensorPublisher();
+
+}  // namespace grove_g1
+
+#endif  // GROVE_G1_SENSOR_PUBLISHER_H_

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.h
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.h
@@ -32,6 +32,19 @@ namespace grove_g1
 // holding the lock for that would stall physics exactly as badly as running inline.
 void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* sim_mtx);
 
+// Stops the sensor thread and BLOCKS until it has terminated. Safe to call when nothing is
+// running.
+//
+// One-way for now: nothing restarts the sampler after a reload. Restarting it against the
+// new model was tried and still faulted intermittently, so reload deliberately ends with
+// sensors off rather than with an intermittent crash. See g1_bringup's README.
+//
+// Must be called before mj_deleteModel on any path that replaces the model -- the viewer's
+// Reload button and drag-and-drop both do. The sampler reads the model outside sim_mtx on
+// purpose (a ~4.5 ms render or ~32 ms sweep under the lock would stall physics), so no
+// lock-based check can make freeing the model safe while it still runs. It has to be gone.
+void StopSensorPublisher();
+
 
 }  // namespace grove_g1
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.h
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.h
@@ -32,8 +32,6 @@ namespace grove_g1
 // holding the lock for that would stall physics exactly as badly as running inline.
 void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* sim_mtx);
 
-// Signals the sensor thread to finish and joins it. Safe if never started.
-void StopSensorPublisher();
 
 }  // namespace grove_g1
 

--- a/workspace/vendor/unitree_mujoco/sensor_publisher.h
+++ b/workspace/vendor/unitree_mujoco/sensor_publisher.h
@@ -1,12 +1,17 @@
 #ifndef GROVE_G1_SENSOR_PUBLISHER_H_
 #define GROVE_G1_SENSOR_PUBLISHER_H_
 
-// Sensor publishing for the converged perception track. Lives outside the vendored
+// Sensor sampling for the converged perception track. Lives outside the vendored
 // unitree_mujoco sources so the patch against them stays a few lines; see
 // workspace/patches/unitree_mujoco/README.md.
 //
+// Deliberately links NO ROS and NO DDS. unitree_sdk2 already owns the CycloneDDS domain in
+// this process, and rmw_cyclonedds creates its domain unconditionally, so the two cannot
+// coexist here. Sampled frames go out over a local socket to g1_sensor_relay, which is an
+// ordinary ROS node and does the publishing.
+//
 // Off unless GROVE_G1_SENSOR_CONFIG names a config file. With it unset the patched binary
-// behaves exactly like the stock one: no thread, no ROS init, no cost.
+// behaves exactly like the stock one: no thread, no socket, no cost.
 
 #include <mujoco/mujoco.h>
 
@@ -25,8 +30,7 @@ namespace grove_g1
 // sim_mtx is unitree_mujoco's own simulation mutex. It is held only long enough to snapshot
 // mjData, never across the raycast: a full sweep costs ~32 ms against the G1 scene, and
 // holding the lock for that would stall physics exactly as badly as running inline.
-void StartSensorPublisher(
-    mjModel** model, mjData** data, std::recursive_mutex* sim_mtx, int argc, char** argv);
+void StartSensorPublisher(mjModel** model, mjData** data, std::recursive_mutex* sim_mtx);
 
 // Signals the sensor thread to finish and joins it. Safe if never started.
 void StopSensorPublisher();


### PR DESCRIPTION
Moves the LiDAR and the D435i onto the real G1 simulation, so perception, arms and locomotion finally share one `unitree_mujoco` process instead of the separate `g1_sim` track.

## What's here

A patched `unitree_mujoco` samples both sensors on its own thread and ships frames over a local Unix socket to a new `g1_sensor_relay` node, which does the ROS publishing. The split exists because `unitree_sdk2` and `rmw_cyclonedds` each create their CycloneDDS domain unconditionally, so they cannot live in one process — linking ROS into the simulator was tried and does not work.

| Topic | Type | |
|---|---|---|
| `/livox/lidar` | `PointCloud2` | 360x32 sweep at 10 Hz, `mj_ray` |
| `/camera/aligned_depth_to_color/image_raw` | `Image` `32FC1` | metres; misses are NaN, not 0 |
| `/camera/color/image_raw` | `Image` `rgb8` | |
| `/camera/{color,aligned_depth_to_color}/camera_info` | `CameraInfo` | same intrinsics |

Depth and colour come from one `mjr_render`, so they share a pose, timestamp and intrinsics by construction rather than by pairing them downstream.

Run it with `ros2 launch g1_bringup sim.launch.py sensors:=true rviz:=true`. `sensors` defaults to false.

## Verification

Not "data arrives" — each claim is a geometric fact of the scene:

- **Colour position.** Green target at a known MJCF position; expected pixel computed from TF and the published `camera_info`. Predicted (338.3, 231.3), measured centroid (336.3, 232.5) — **2.3 px**. Colour reads R=0 G=208 B=28 against `rgba="0 0.9 0.1"`.
- **Depth scale.** Centre pixel 1.7264 m measured vs 1.7150 m predicted from TF.
- **Frame convention.** 407040 depth pixels projected into `odom`: 93.0% within 2 cm of z=0, **0 below the floor**.
- **Timing.** Both sensors live: render 3.26 ms/frame, 0.004 ms holding the sim lock, `/lowstate` 901.8 Hz against a 907 Hz sensor-free baseline.

## Things worth a reviewer's attention

**Optical frames.** Depth was initially published in `d435_link`, a body frame, while every depth consumer assumes REP-145 optical — the cloud projected rotated 90°. `g1_description` now adds `camera_{depth,color}_optical_frame`.

**Socket sizing.** `SO_SNDBUF` is silently clamped to `2 * net.core.wmem_max` (~416 KB here), far under a 2.9 MB depth+colour frame, which tore down the connection 447 times a run. `SO_SNDBUFFORCE` fixes it properly; the bounded retry remains as the unprivileged fallback.

**DDS participants.** The simulator's `interface: "lo"` made `unitree_sdk2` build its own Cyclone config, overriding `CYCLONEDDS_URI` and losing our `MaxAutoParticipantIndex: 60` for the default 9. It then lost the participant race against the launch's own nodes and died at startup. Second vendor patch; the launch now also checks the URI names a file that exists, since a broken URI plus `network_mode: host` would bind the real NIC.

## Known limitation

**Clicking the viewer's Reload button with `sensors:=true` kills the simulator.** Relaunch instead. The sampler reads the model outside `sim.mtx` by design, and reload frees it on the main thread, so no lock-based check helps. The hook stops the sampler with a blocking join before `mj_deleteModel` and never restarts it — that makes the first reload survivable and stops sensors cleanly, verified by real GUI clicks. A second reload still crashes, after the sampler is already gone and none of this code runs; the cause was not identified. Accepted rather than fixed: it is a debugging-only button with a one-step workaround, and sensors do not survive a reload either way. Documented in `g1_bringup`'s README.

`g1_sim` survives as a fast sandbox, demoted in its README, and gains no new capability.
