### PR TITLE
Add bringup.launch.py as the entry point, merge the RViz configs

### DIFF
--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -11,7 +11,9 @@ with Python launch files and integration tests.
 
 | File | Purpose |
 |---|---|
-| `launch/sim.launch.py` | Main entry point. Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Args: `headless` (default `true`), `sensors` (default `false`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
+| `launch/bringup.launch.py` | **The operator entry point.** Routes to bare sim or, via `mode:`, to the navigation stack. Args: `mode` (`none`/`mapping`/`localization`), `nav`, `rviz`, `sensors`, `world`, `headless`, `pin_pelvis`, `sim_start_delay_s`. |
+| `launch/sim.launch.py` | Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Still works standalone. Args: `headless` (default `true`), `sensors` (default `false`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
+| `launch/rviz.launch.py` | Starts RViz on a caller-supplied `rviz_config` path. Knows nothing about navigation. |
 | `launch/control.launch.py` | `robot_state_publisher`, `ros2_control_node` and spawners. No sim, no bridge, so it carries over to hardware unchanged. |
 | `launch/loco.launch.py` | Starts `g1_loco_bridge` and drives it configure to active off its own lifecycle events. |
 | `launch/activate_arm.launch.py` | Runs `scripts/activate_arm`, the ordered acquire step. |
@@ -34,7 +36,51 @@ What this package's own launch graph adds on top:
 | `/g1_sensor_relay/sensor_pose` | out | `geometry_msgs/msg/PoseStamped` | sensor data, diagnostics |
 | `/tf` (`odom` -> `pelvis`) | out | `tf2_msgs/msg/TFMessage` | `sensors:=true` only |
 
+## `g1_navigation` is referenced but deliberately not depended on
+
+`bringup.launch.py` includes launch files and an RViz config from `g1_navigation`, and
+`package.xml` says nothing about it. That is not an oversight.
+
+`g1_navigation` already declares `<exec_depend>g1_bringup</exec_depend>`, because navigation
+composes bring-up and not the reverse. Adding the reciprocal dependency here does not merely
+look untidy, it **does not build** — colcon refuses to order the workspace at all:
+
+```
+ERROR:colcon:colcon list: Unable to order packages topologically:
+g1_bringup: ['g1_navigation']
+g1_navigation: ['g1_bringup']
+```
+
+So the reference is a launch-time path lookup and nothing more. What follows from that:
+
+- This package builds, installs and runs with `g1_navigation` absent. Only `mode:=mapping`
+  and `mode:=localization` name it, and their absence is reported as an actionable message
+  rather than a raw ament search-path dump.
+- **colcon and rosdep cannot see this edge.** Nothing warns you if `g1_navigation` renames a
+  launch file; `mode:=mapping` fails at runtime instead. `test_launch_threading` in
+  `g1_navigation` is the compensating check — it lives there because a `test_depend` pointing
+  the other way would re-create the same cycle.
+- Do not "fix" this by adding the dependency. Its absence is load-bearing.
+
+The composition direction is unchanged: on the navigation branch this package includes
+`g1_navigation`'s `nav_sim.launch.py`, which includes `sim.launch.py` itself.
+`bringup.launch.py` routes; it does not orchestrate navigation.
+
 ## Running
+
+```bash
+# Bare simulator.
+ros2 launch g1_bringup bringup.launch.py
+
+# Build a map, with RViz.
+ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
+
+# Localize against the committed map and navigate.
+ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+```
+
+`mode:=none` is the default and never touches `g1_navigation`. The arm procedure below uses
+`sim.launch.py` directly, which is equivalent to `bringup.launch.py` with the default mode:
 
 ```bash
 # 1. Bring up sim + bridge + control stack (headless by default).

--- a/workspace/src/g1_bringup/config/g1_sensors.rviz
+++ b/workspace/src/g1_bringup/config/g1_sensors.rviz
@@ -1,13 +1,21 @@
-# RViz for the converged sensor track.
-#   ros2 launch g1_bringup sim.launch.py sensors:=true rviz:=true
+# RViz for the converged sensor track, without navigation.
+#   ros2 launch g1_bringup bringup.launch.py sensors:=true rviz:=true
+#
+# The nav-enabled counterpart is g1_navigation/config/g1_navigation.rviz. Two static files
+# rather than one generated at launch: they differ in Fixed Frame as well as in which groups
+# exist, and this stack has already been burned once by rewriting config at launch time (see
+# g1_navigation/launch/nav2.launch.py's docstring).
+#
+# The sensor group below must stay byte-identical to that file's, apart from the group's own
+# Enabled flag. test_rviz_configs in g1_navigation enforces it.
 Panels:
   - Class: rviz_common/Displays
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /LiDAR1
-        - /Depth cloud1
-        - /Colour image1
+        - /Sensors1
+        - /Sensors1/LiDAR1
+        - /Sensors1/Depth cloud1
       Splitter Ratio: 0.5
     Tree Height: 700
   - Class: rviz_common/Views
@@ -28,16 +36,14 @@ Visualization Manager:
     # The robot. Needs pelvis -> torso_link, which motion_service_sim supplies from
     # /lowstate; joint_state_broadcaster only covers the arms.
     - Class: rviz_default_plugins/RobotModel
-      Name: RobotModel
+      Name: Robot
       Enabled: true
       Description Topic:
         Value: /robot_description
-        Depth: 5
+        Depth: 1
         Durability Policy: Transient Local
         Reliability Policy: Reliable
-      Alpha: 1
-      Visual Enabled: true
-      Collision Enabled: false
+      Alpha: 0.8
 
     - Class: rviz_default_plugins/TF
       Name: TF
@@ -47,79 +53,12 @@ Visualization Manager:
       Show Arrows: false
       Marker Scale: 0.3
 
-    # Sampled inside unitree_mujoco, published by g1_sensor_relay. Best-effort to match
-    # the publisher: a Reliable subscriber here shows nothing at all.
-    - Class: rviz_default_plugins/PointCloud2
-      Name: LiDAR
-      Enabled: true
-      Topic:
-        Value: /livox/lidar
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Style: Points
-      Size (Pixels): 2
-      Alpha: 1
-      Decay Time: 0
-      Position Transformer: XYZ
-      Color Transformer: AxisColor
-      Axis: Z
-      Autocompute Intensity Bounds: true
-      Invert Rainbow: false
-
-    # Depth as a 3D cloud, projected through camera_info. This is the camera's own view
-    # of the world, so it should overlap the LiDAR returns where the two see the same
-    # surfaces; if it floats away from them, the mount or the depth scale is wrong.
-    - Class: rviz_default_plugins/DepthCloud
-      Name: Depth cloud
-      Enabled: true
-      Topic Filter: false
-      Depth Map Topic: /camera/aligned_depth_to_color/image_raw
-      Depth Map Transport Hint: raw
-      Color Transport Hint: raw
-      Queue Size: 5
-      Style: Points
-      Size (Pixels): 3
-      Alpha: 1
-      Decay Time: 0
-      Color Image Topic: /camera/color/image_raw
-      Color Transformer: RGB8
-      Occlusion Compensation:
-        Occlusion Time-Out: 30
-        Enabled: false
-
-    # The same data as a 2D panel, which is the quickest way to see that the camera is
-    # pointed where you think and is not returning a blank frame.
-    - Class: rviz_default_plugins/Image
-      Name: Depth image
-      Enabled: true
-      Topic:
-        Value: /camera/aligned_depth_to_color/image_raw
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Max Value: 4
-      Min Value: 0.5
-      Median window: 5
-      Normalize Range: false
-
-    # Colour from the same render as the depth above, so the two line up pixel for pixel.
-    - Class: rviz_default_plugins/Image
-      Name: Colour image
-      Enabled: true
-      Topic:
-        Value: /camera/color/image_raw
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Normalize Range: true
-
     - Class: rviz_default_plugins/Odometry
       Name: Odometry
       Enabled: true
       Topic:
         Value: /g1_odometry_publisher/odom
-        Depth: 10
+        Depth: 100
         Durability Policy: Volatile
         Reliability Policy: Reliable
       Keep: 100
@@ -134,24 +73,97 @@ Visualization Manager:
         Head Length: 0.1
         Head Radius: 0.06
 
-    # Where the simulator says the sensor is. Diagnostic: it is the ground truth the
-    # cloud was swept from, so it should sit exactly on the robot's Mid360.
-    - Class: rviz_default_plugins/Pose
-      Name: Sensor pose
-      Enabled: false
-      Topic:
-        Value: /g1_sensor_relay/sensor_pose
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Shape: Axes
-      Axes Length: 0.3
-      Axes Radius: 0.02
+    # BEGIN SENSOR GROUP -- kept identical to g1_navigation/config/g1_navigation.rviz
+    - Class: rviz_common/Group
+      Name: Sensors
+      Enabled: true
+      Displays:
+        # Sampled inside unitree_mujoco, published by g1_sensor_relay. Best-effort to match
+        # the publisher: a Reliable subscriber here shows nothing at all.
+        - Class: rviz_default_plugins/PointCloud2
+          Name: LiDAR
+          Enabled: true
+          Topic:
+            Value: /livox/lidar
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Style: Points
+          Size (Pixels): 2
+          Alpha: 1
+          Decay Time: 0
+          Position Transformer: XYZ
+          Color Transformer: AxisColor
+          Axis: Z
+          Autocompute Intensity Bounds: true
+          Invert Rainbow: false
+
+        # Depth as a 3D cloud, projected through camera_info. This is the camera's own view
+        # of the world, so it should overlap the LiDAR returns where the two see the same
+        # surfaces; if it floats away from them, the mount or the depth scale is wrong.
+        - Class: rviz_default_plugins/DepthCloud
+          Name: Depth cloud
+          Enabled: true
+          Topic Filter: false
+          Depth Map Topic: /camera/aligned_depth_to_color/image_raw
+          Depth Map Transport Hint: raw
+          Color Transport Hint: raw
+          Queue Size: 5
+          Style: Points
+          Size (Pixels): 3
+          Alpha: 1
+          Decay Time: 0
+          Color Image Topic: /camera/color/image_raw
+          Color Transformer: RGB8
+          Occlusion Compensation:
+            Occlusion Time-Out: 30
+            Enabled: false
+
+        # The same data as a 2D panel, which is the quickest way to see that the camera is
+        # pointed where you think and is not returning a blank frame.
+        - Class: rviz_default_plugins/Image
+          Name: Depth image
+          Enabled: true
+          Topic:
+            Value: /camera/aligned_depth_to_color/image_raw
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Max Value: 4
+          Min Value: 0.5
+          Median window: 5
+          Normalize Range: false
+
+        # Colour from the same render as the depth above, so the two line up pixel for pixel.
+        - Class: rviz_default_plugins/Image
+          Name: Colour image
+          Enabled: true
+          Topic:
+            Value: /camera/color/image_raw
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Normalize Range: true
+
+        # Where the simulator says the sensor is. Diagnostic: it is the ground truth the
+        # cloud was swept from, so it should sit exactly on the robot's Mid360.
+        - Class: rviz_default_plugins/Pose
+          Name: Sensor pose
+          Enabled: false
+          Topic:
+            Value: /g1_sensor_relay/sensor_pose
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Shape: Axes
+          Axes Length: 0.3
+          Axes Radius: 0.02
+    # END SENSOR GROUP
 
   Global Options:
     # odom, not mid360_link: the cloud is published in the sensor frame and RViz transforms
     # it here, which only works because odom -> pelvis -> torso_link -> mid360_link is now
-    # complete.
+    # complete. The nav config uses map, which does not exist without SLAM or AMCL.
     Fixed Frame: odom
     Background Color: 48; 48; 48
     Frame Rate: 30

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -1,0 +1,217 @@
+"""The operator entry point: one command for bare sim, mapping, localization or full Nav2.
+
+    ros2 launch g1_bringup bringup.launch.py                                  # bare sim
+    ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true         # + SLAM
+    ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+
+sim.launch.py and control.launch.py are unchanged and still work standalone; this file sits
+above them and adds nothing of its own except the routing.
+
+================================================================================
+g1_navigation is referenced WITHOUT being declared as a dependency. On purpose.
+================================================================================
+
+g1_navigation already declares <exec_depend>g1_bringup</exec_depend>, because navigation
+composes bring-up and not the other way round (docs/notes, M6). Adding the reciprocal
+dependency here is not merely untidy, it does not build -- colcon refuses outright:
+
+    ERROR:colcon:colcon list: Unable to order packages topologically:
+    g1_bringup: ['g1_navigation']
+    g1_navigation: ['g1_bringup']
+
+So the reference below is a launch-time path lookup and nothing else. Consequences worth
+knowing before touching it:
+
+  * g1_bringup builds, installs and runs with g1_navigation absent from the workspace. Only
+    the mode:=mapping / mode:=localization branches ever name it, and _navigation_share()
+    turns its absence into an actionable message rather than a raw ament search-path dump.
+  * colcon and rosdep cannot see this edge. Nothing will warn you if g1_navigation's launch
+    file names change; the launch fails at runtime instead.
+  * Do not "fix" this by adding the dependency. It is load-bearing that it stays absent.
+
+The direction of composition is still navigation-over-bringup: on the nav branch this file
+includes g1_navigation's nav_sim.launch.py, which includes sim.launch.py itself. This file
+routes, it does not orchestrate navigation.
+"""
+
+import os
+
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+# 'none' keeps g1_navigation entirely out of the picture; the other two route through it.
+MODES = ("none", "mapping", "localization")
+
+# sim.launch.py wants 2.0, nav_sim.launch.py wants 4.0 (more nodes start before the first
+# physics tick). Declaring either as this file's default would silently override whichever
+# child was right, because an included launch file inherits the parent's configurations.
+# The empty sentinel means "let the branch decide", and a concrete value is always forwarded.
+DEFAULT_SIM_START_DELAY_S = {"bare": "2.0", "navigation": "4.0"}
+
+
+def _navigation_share():
+    """g1_navigation's share directory, or a message an operator can act on."""
+    try:
+        return get_package_share_directory("g1_navigation")
+    except PackageNotFoundError as exc:
+        raise RuntimeError(
+            "bringup.launch.py: mode:=mapping and mode:=localization need the g1_navigation "
+            "package, which is not on the ament prefix path.\n"
+            "  - Build it:  colcon build --packages-select g1_navigation\n"
+            "  - Then source install/setup.bash again in this shell.\n"
+            "g1_bringup deliberately does not declare g1_navigation as a dependency (the two "
+            "would form a colcon dependency cycle -- see this file's docstring), so nothing "
+            "builds it for you.\n"
+            "mode:=none needs none of this and runs the simulator on its own."
+        ) from exc
+
+
+def _setup(context, *args, **kwargs):
+    mode = LaunchConfiguration("mode").perform(context)
+    if mode not in MODES:
+        raise RuntimeError(
+            f"mode:={mode!r} is not a mode. 'none' is the simulator on its own; 'mapping' "
+            f"builds a map with slam_toolbox; 'localization' runs map_server + AMCL against "
+            f"the committed one, and is what nav:=true requires."
+        )
+
+    navigating = mode != "none"
+    want_nav = LaunchConfiguration("nav").perform(context).lower() == "true"
+    want_rviz = LaunchConfiguration("rviz").perform(context).lower() == "true"
+    pin_pelvis = LaunchConfiguration("pin_pelvis").perform(context).lower() == "true"
+
+    if want_nav and mode != "localization":
+        raise RuntimeError(
+            f"nav:=true needs mode:=localization, not mode:={mode!r}. Navigating against a "
+            "map slam_toolbox is still building means the goal pose moves under the planner."
+        )
+    if pin_pelvis and navigating:
+        raise RuntimeError(
+            "pin_pelvis:=true welds the pelvis to the world and disables the walking policy, "
+            "so the robot cannot drive anywhere. It is a bare-sim debugging aid; use it with "
+            "mode:=none."
+        )
+
+    delay = LaunchConfiguration("sim_start_delay_s").perform(context)
+    if not delay:
+        delay = DEFAULT_SIM_START_DELAY_S["navigation" if navigating else "bare"]
+
+    # Every argument below is forwarded EXPLICITLY, including the ones whose values match
+    # this file's own defaults. Included launch files inherit the parent's configurations,
+    # so a child's DeclareLaunchArgument default never fires for anything declared here --
+    # relying on it is how this stack has already shipped two silent bugs (a second RViz
+    # window, and use_composition ignoring its own default).
+    if navigating:
+        launch_file = os.path.join(_navigation_share(), "launch", "nav_sim.launch.py")
+        forwarded = {
+            "mode": mode,
+            "nav": "true" if want_nav else "false",
+            "world": LaunchConfiguration("world"),
+            "headless": LaunchConfiguration("headless"),
+            "sim_start_delay_s": delay,
+            # We own RViz, below. Without this the child opens its own on the wrong config.
+            "rviz": "false",
+        }
+    else:
+        launch_file = os.path.join(
+            get_package_share_directory("g1_bringup"), "launch", "sim.launch.py"
+        )
+        forwarded = {
+            "sensors": LaunchConfiguration("sensors"),
+            "world": LaunchConfiguration("world"),
+            "headless": LaunchConfiguration("headless"),
+            "pin_pelvis": "true" if pin_pelvis else "false",
+            "sim_start_delay_s": delay,
+            "rviz": "false",
+        }
+
+    actions = [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(launch_file),
+            launch_arguments=forwarded.items(),
+        )
+    ]
+
+    if want_rviz:
+        # The nav config carries a nav2_rviz_plugins display, so it ships from g1_navigation.
+        # On the bare branch this resolves g1_bringup's own share and g1_navigation is never
+        # named -- same rule as the launch include above.
+        if navigating:
+            rviz_config = os.path.join(_navigation_share(), "config", "g1_navigation.rviz")
+        else:
+            rviz_config = os.path.join(
+                get_package_share_directory("g1_bringup"), "config", "g1_sensors.rviz"
+            )
+        actions.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(
+                        get_package_share_directory("g1_bringup"), "launch", "rviz.launch.py"
+                    )
+                ),
+                launch_arguments={"rviz_config": rviz_config}.items(),
+            )
+        )
+
+    return actions
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "mode",
+            default_value="none",
+            description="'none' runs the simulator alone and never touches g1_navigation. "
+            "'mapping' adds the scan pipeline and slam_toolbox. 'localization' adds the scan "
+            "pipeline, map_server and AMCL, and is the mode nav:=true requires.",
+        ),
+        DeclareLaunchArgument(
+            "nav",
+            default_value="false",
+            description="Start Nav2, the gait shaper and the locomotion authority bracket. "
+            "Requires mode:=localization.",
+        ),
+        DeclareLaunchArgument(
+            "rviz",
+            default_value="false",
+            description="Open RViz. mode:=none uses g1_bringup's sensor config (fixed frame "
+            "odom); the navigation modes use g1_navigation's, which adds the Nav2 display "
+            "group and is fixed on map.",
+        ),
+        DeclareLaunchArgument(
+            "sensors",
+            default_value="false",
+            description="LiDAR sweep, the relay and the odom -> base_footprint -> pelvis "
+            "chain. Only meaningful with mode:=none -- the navigation modes need it and turn "
+            "it on themselves.",
+        ),
+        DeclareLaunchArgument(
+            "world",
+            default_value="navigation",
+            description="Which scene to stage. 'navigation' is the facility the committed map "
+            "was built from; localization against any other world will not converge.",
+        ),
+        DeclareLaunchArgument(
+            "headless",
+            default_value="true",
+            description="false shows the MuJoCo viewer. Its Reload button is fatal with "
+            "sensors on; see the README.",
+        ),
+        DeclareLaunchArgument(
+            "pin_pelvis",
+            default_value="false",
+            description="SIM-ONLY debugging aid: weld the pelvis and disable the walking "
+            "policy, to exercise the arm bridge with nothing driving the legs. mode:=none only.",
+        ),
+        DeclareLaunchArgument(
+            "sim_start_delay_s",
+            default_value="",
+            description="Seconds to delay the simulator's start. Empty means the branch's own "
+            "default: 2.0 for mode:=none, 4.0 for the navigation modes, which start more nodes "
+            "before the first physics tick.",
+        ),
+        OpaqueFunction(function=_setup),
+    ])

--- a/workspace/src/g1_bringup/launch/rviz.launch.py
+++ b/workspace/src/g1_bringup/launch/rviz.launch.py
@@ -1,0 +1,32 @@
+"""Starts RViz on a caller-supplied config.
+
+Deliberately knows nothing about navigation. The caller has already decided which mode it
+is in, so it also knows which config file to hand over; duplicating that conditional here
+would give this file a reason to resolve g1_navigation's share directory, which is exactly
+what bringup.launch.py exists to keep in one place.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    rviz_config = LaunchConfiguration("rviz_config")
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "rviz_config",
+            description="Absolute path to an .rviz file. Required -- there is no default, "
+            "because the right one depends on whether navigation is running and this file "
+            "has no way to know that.",
+        ),
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            name="rviz2",
+            output="log",
+            arguments=["-d", rviz_config],
+        ),
+    ])

--- a/workspace/src/g1_navigation/CMakeLists.txt
+++ b/workspace/src/g1_navigation/CMakeLists.txt
@@ -33,6 +33,21 @@ if(BUILD_TESTING)
         "G1_LOCOMOTION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_locomotion/config"
   )
 
+  # Arguments crossing bringup.launch.py -> nav_sim.launch.py -> sim.launch.py. Lives here
+  # rather than in g1_bringup because it reads both packages' launch files, and g1_bringup
+  # cannot depend on g1_navigation without a colcon cycle. Needs no simulator.
+  ament_add_pytest_test(test_launch_threading test/test_launch_threading.py
+    ENV "G1_NAVIGATION_LAUNCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}/launch"
+        "G1_BRINGUP_LAUNCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_bringup/launch"
+  )
+
+  # The sensor display group is duplicated across two RViz configs in two packages; same
+  # cross-package blind spot as test_gait_coupling.
+  ament_add_pytest_test(test_rviz_configs test/test_rviz_configs.py
+    ENV "G1_NAVIGATION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/config"
+        "G1_BRINGUP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_bringup/config"
+  )
+
   # Headless sim integration suites. RESOURCE_LOCK matches g1_bringup's: two of these sharing
   # a DDS graph and a simulator is what makes them flaky, so they serialise against the same
   # lock g1_bringup uses rather than a separate one.

--- a/workspace/src/g1_navigation/README.md
+++ b/workspace/src/g1_navigation/README.md
@@ -14,8 +14,10 @@ Nav2-shaped leaks into the package that has to survive to hardware.
 Everything here needs `sensors:=true` on `g1_bringup`, which gates the LiDAR, the relay, the
 `odom -> base_footprint -> pelvis` chain and the waist joint states. The top-level launch passes it.
 
+**The operator entry point is `g1_bringup`'s**, matching `nav2_bringup`:
+
 ```bash
-ros2 launch g1_navigation nav_sim.launch.py mode:=mapping rviz:=true
+ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
 ```
 
 `mode:=mapping` builds a new map with slam_toolbox. `mode:=localization` runs `map_server` + AMCL
@@ -24,8 +26,15 @@ against `maps/facility` — use that when a goal pose has to mean the same thing
 To actually navigate, add `nav:=true` (which requires `mode:=localization`):
 
 ```bash
-ros2 launch g1_navigation nav_sim.launch.py mode:=localization nav:=true rviz:=true
+ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
 ```
+
+`nav_sim.launch.py` is still this package's orchestrator and still runs directly
+(`ros2 launch g1_navigation nav_sim.launch.py mode:=mapping`); `bringup.launch.py` routes to it.
+The composition direction is unchanged — navigation composes bring-up, and `g1_bringup` declares
+no dependency on this package, because the two would form a colcon cycle. See `g1_bringup`'s
+README for why that reference is deliberately undeclared, and `test_launch_threading` for the
+check that compensates.
 
 ```bash
 ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
@@ -51,6 +60,29 @@ is bang-bang — drive straight until the heading error is large, then rotate in
 This deadband is a property of the **sim walking policy**, not of the real G1's onboard MPC, which
 has no such dead zone. That is why it lives in `g1_locomotion`'s config and not in Nav2 tuning:
 hardware bring-up simply does not launch the shaper.
+
+## RViz
+
+`config/g1_navigation.rviz` carries every display in two toggleable groups: **Nav2** (map, scan,
+AMCL particle swarm, global/local plan, both costmaps, footprints, the local voxel grid) and
+**Sensors** (LiDAR, depth cloud, depth and colour images, sensor pose), which starts folded away.
+Fixed frame is `map`. `g1_bringup`'s `config/g1_sensors.rviz` is the counterpart for
+`mode:=none`: same Sensors group, no Nav2 group, fixed frame `odom` — there is no `map` frame
+without SLAM or AMCL, which is why one merged file could not serve both.
+
+Two static files rather than one rewritten at launch: they differ in fixed frame as well as in
+which groups exist, and rewriting config at launch has already cost this stack a debugging session
+(`nav2.launch.py`'s docstring). The price is drift, and `test_rviz_configs` is what stops it.
+
+This file lives here rather than in `g1_bringup` because the particle swarm is a
+`nav2_rviz_plugins` display. Shipping it from the bring-up package would give that package a Nav2
+dependency, which is the one thing the layering forbids.
+
+Displays from upstream's `nav2_default_view.rviz` that are deliberately **not** here: `Bumper Hit`
+(turtlebot hardware), `MarkerArray` on `/waypoints` (no `waypoint_follower` in `nav2_params.yaml`),
+`Trajectories` on `/marker` (DWB-only; we run RPP), `Downsampled Costmap` (Smac-only; we run
+NavFn), and the global `VoxelGrid` (the global costmap runs `obstacle_layer`, not `voxel_layer`,
+so `/global_costmap/voxel_marked_cloud` is never published). Each would be a permanently dead row.
 
 ## Composition
 
@@ -104,6 +136,8 @@ the floor about 1.2 m ahead. It is a manipulation and near-field sensor.
 | `localization.launch.py`, `config/localization.yaml`, `map_server` + AMCL | now covered: `test_navigate_to_pose` runs the whole stack in localization mode |
 | `g1_gait_shaper`'s contract, including never amplifying | `g1_locomotion`'s `test_gait_shaper` |
 | Authority released when the acquire *fails* | `g1_locomotion`'s `test_authority_release`, against a stub, no sim |
+| Arguments surviving `bringup.launch.py` -> `nav_sim.launch.py` -> `sim.launch.py` | `test_launch_threading`, no sim |
+| The sensor display group not drifting between the two RViz configs | `test_rviz_configs`, no sim |
 
 PR A shipped with localization deliberately untested; `test_navigate_to_pose` closes that, because
 it runs `map_server` + AMCL exactly as shipped.

--- a/workspace/src/g1_navigation/config/g1_navigation.rviz
+++ b/workspace/src/g1_navigation/config/g1_navigation.rviz
@@ -1,17 +1,24 @@
-# RViz for the navigation track.
-#   ros2 launch g1_navigation nav_sim.launch.py rviz:=true
+# RViz for the navigation track: Nav2 displays plus the sensor group, both toggleable.
+#   ros2 launch g1_bringup bringup.launch.py nav:=true mode:=localization rviz:=true
 #
 # Fixed frame is map, so in mapping mode nothing renders until slam_toolbox has published
 # map -> odom. That is a second or two after launch, not a fault.
+#
+# The sensor group here must stay byte-identical to g1_bringup/config/g1_sensors.rviz's,
+# apart from the group's own Enabled flag. test_rviz_configs enforces that -- the two live
+# in different packages and neither package's own tests can see the pair.
+#
+# This file lives in g1_navigation, not g1_bringup, because "Amcl Particle Swarm" is a
+# nav2_rviz_plugins class. Shipping it from g1_bringup would give the bring-up package a
+# Nav2 dependency, which is the one thing M6's layering decision forbids.
 Panels:
   - Class: rviz_common/Displays
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Map1
-        - /Scan1
-        - /Local costmap1
-        - /Global plan1
+        - /Nav21
+        - /Nav21/Map1
+        - /Nav21/Scan1
       Splitter Ratio: 0.5
     Tree Height: 700
   - Class: rviz_common/Views
@@ -20,6 +27,7 @@ Visualization Manager:
   Class: ""
   Name: root
   Displays:
+    # Always relevant, in either mode, so outside both groups.
     - Class: rviz_default_plugins/Grid
       Name: Grid
       Enabled: true
@@ -29,49 +37,7 @@ Visualization Manager:
       Alpha: 0.3
       Reference Frame: <Fixed Frame>
 
-    - Class: rviz_default_plugins/Map
-      Name: Map
-      Enabled: true
-      Topic:
-        Value: /map
-        Depth: 1
-        Durability Policy: Transient Local
-        Reliability Policy: Reliable
-      Alpha: 0.7
-      Color Scheme: map
-      Draw Behind: true
-
-    # What slam_toolbox and AMCL actually consume. If this looks right and the map does not,
-    # the problem is the matcher or the pose, not the flatten.
-    - Class: rviz_default_plugins/LaserScan
-      Name: Scan
-      Enabled: true
-      Topic:
-        Value: /scan
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Size (m): 0.04
-      Style: Points
-      Color: 255; 85; 0
-      Color Transformer: FlatColor
-
-    # The raw sweep, which is what the Nav2 costmaps eat. Shown alongside the scan so the
-    # 0.30 m floor cut the flatten applies is visible as the gap the cloud fills in.
-    - Class: rviz_default_plugins/PointCloud2
-      Name: LiDAR
-      Enabled: false
-      Topic:
-        Value: /livox/lidar
-        Depth: 5
-        Durability Policy: Volatile
-        Reliability Policy: Best Effort
-      Size (m): 0.02
-      Style: Points
-      Color Transformer: AxisColor
-      Axis: Z
-
-    # Renders because g1_description now installs the meshes from unitree_mujoco's vendored set
+    # Renders because g1_description installs the meshes from unitree_mujoco's vendored set
     # and the URDF names them package://. Before that it drew nothing and emitted ~174
     # "Could not resolve host: meshes" lines a session.
     #
@@ -87,8 +53,8 @@ Visualization Manager:
         Reliability Policy: Reliable
       Alpha: 0.8
 
-    # On, because the robot model cannot render. base_footprint and pelvis are the two worth
-    # watching: the first should stay flat on the floor, the second carries the gait's tilt.
+    # base_footprint and pelvis are the two worth watching: the first should stay flat on the
+    # floor, the second carries the gait's tilt.
     - Class: rviz_default_plugins/TF
       Name: TF
       Enabled: true
@@ -96,66 +62,6 @@ Visualization Manager:
       Show Axes: true
       Show Arrows: false
       Marker Scale: 0.4
-
-    # What the planner produced, and what the controller is actually following. If the robot
-    # is stationary with a plan on screen, the gap is the gait's dead zone, not the planner.
-    - Class: rviz_default_plugins/Path
-      Name: Global plan
-      Enabled: true
-      Topic:
-        Value: /plan
-        Depth: 1
-        Durability Policy: Volatile
-        Reliability Policy: Reliable
-      Color: 0; 200; 120
-      Line Style: Lines
-
-    - Class: rviz_default_plugins/Path
-      Name: Local plan
-      Enabled: true
-      Topic:
-        Value: /local_plan
-        Depth: 1
-        Durability Policy: Volatile
-        Reliability Policy: Reliable
-      Color: 255; 200; 0
-      Line Style: Lines
-
-    # Costmaps, not the raw map. The local one is where the 0.08 m floor cut and the 0.45 m
-    # footprint show up; if the whole floor is lethal, that cut is wrong.
-    - Class: rviz_default_plugins/Map
-      Name: Global costmap
-      Enabled: false
-      Topic:
-        Value: /global_costmap/costmap
-        Depth: 1
-        Durability Policy: Transient Local
-        Reliability Policy: Reliable
-      Alpha: 0.5
-      Color Scheme: costmap
-
-    - Class: rviz_default_plugins/Map
-      Name: Local costmap
-      Enabled: true
-      Topic:
-        Value: /local_costmap/costmap
-        Depth: 1
-        Durability Policy: Transient Local
-        Reliability Policy: Reliable
-      Alpha: 0.6
-      Color Scheme: costmap
-
-    # The ramp appears here as an obstacle. That is correct for this gait, and looks like a bug
-    # if you do not know it: slope_ramp's surface sits above the costmap's floor cut.
-    - Class: rviz_default_plugins/Polygon
-      Name: Footprint
-      Enabled: true
-      Topic:
-        Value: /local_costmap/published_footprint
-        Depth: 1
-        Durability Policy: Volatile
-        Reliability Policy: Reliable
-      Color: 0; 170; 255
 
     - Class: rviz_default_plugins/Odometry
       Name: Odometry
@@ -176,6 +82,228 @@ Visualization Manager:
         Head Length: 0.1
         Head Radius: 0.06
 
+    - Class: rviz_common/Group
+      Name: Nav2
+      Enabled: true
+      Displays:
+        - Class: rviz_default_plugins/Map
+          Name: Map
+          Enabled: true
+          Topic:
+            Value: /map
+            Depth: 1
+            Durability Policy: Transient Local
+            Reliability Policy: Reliable
+          Alpha: 0.7
+          Color Scheme: map
+          Draw Behind: true
+
+        # What slam_toolbox and AMCL actually consume. If this looks right and the map does
+        # not, the problem is the matcher or the pose, not the flatten.
+        - Class: rviz_default_plugins/LaserScan
+          Name: Scan
+          Enabled: true
+          Topic:
+            Value: /scan
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Size (m): 0.04
+          Style: Points
+          Color: 255; 85; 0
+          Color Transformer: FlatColor
+
+        # AMCL's hypothesis spread. localization.yaml runs 500-2000 particles, so a swarm
+        # that has not collapsed after a few metres of driving means the scan match is not
+        # constraining the pose.
+        - Class: nav2_rviz_plugins/ParticleCloud
+          Name: Amcl Particle Swarm
+          Enabled: true
+          Topic:
+            Value: /particle_cloud
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Shape: Arrow (Flat)
+
+        # What the planner produced, and what the controller is actually following. If the
+        # robot is stationary with a plan on screen, the gap is the gait's dead zone, not the
+        # planner.
+        - Class: rviz_default_plugins/Path
+          Name: Global plan
+          Enabled: true
+          Topic:
+            Value: /plan
+            Depth: 1
+            Durability Policy: Volatile
+            Reliability Policy: Reliable
+          Color: 0; 200; 120
+          Line Style: Lines
+
+        - Class: rviz_default_plugins/Path
+          Name: Local plan
+          Enabled: true
+          Topic:
+            Value: /local_plan
+            Depth: 1
+            Durability Policy: Volatile
+            Reliability Policy: Reliable
+          Color: 255; 200; 0
+          Line Style: Lines
+
+        # Costmaps, not the raw map. The local one is where the 0.08 m floor cut and the
+        # 0.45 m footprint show up; if the whole floor is lethal, that cut is wrong.
+        - Class: rviz_default_plugins/Map
+          Name: Global costmap
+          Enabled: false
+          Topic:
+            Value: /global_costmap/costmap
+            Depth: 1
+            Durability Policy: Transient Local
+            Reliability Policy: Reliable
+          Alpha: 0.5
+          Color Scheme: costmap
+
+        - Class: rviz_default_plugins/Map
+          Name: Local costmap
+          Enabled: true
+          Topic:
+            Value: /local_costmap/costmap
+            Depth: 1
+            Durability Policy: Transient Local
+            Reliability Policy: Reliable
+          Alpha: 0.6
+          Color Scheme: costmap
+
+        # The voxel layer's marked cells, which is the only view that shows the z band the
+        # 40-voxel column actually covers. Local only: the global costmap runs obstacle_layer,
+        # not voxel_layer, so /global_costmap/voxel_marked_cloud is never published.
+        - Class: rviz_default_plugins/PointCloud2
+          Name: Local voxel grid
+          Enabled: false
+          Topic:
+            Value: /local_costmap/voxel_marked_cloud
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Reliable
+          Style: Boxes
+          Size (m): 0.05
+          Alpha: 1
+          Color: 125; 125; 125
+          Color Transformer: FlatColor
+          Decay Time: 0
+          Position Transformer: XYZ
+          Use Fixed Frame: true
+
+        # The ramp appears here as an obstacle. That is correct for this gait, and looks like
+        # a bug if you do not know it: slope_ramp's surface sits above the costmap's floor cut.
+        - Class: rviz_default_plugins/Polygon
+          Name: Footprint
+          Enabled: true
+          Topic:
+            Value: /local_costmap/published_footprint
+            Depth: 1
+            Durability Policy: Volatile
+            Reliability Policy: Reliable
+          Color: 0; 170; 255
+
+        - Class: rviz_default_plugins/Polygon
+          Name: Global footprint
+          Enabled: false
+          Topic:
+            Value: /global_costmap/published_footprint
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Reliable
+          Color: 25; 255; 0
+
+    # BEGIN SENSOR GROUP -- kept identical to g1_bringup/config/g1_sensors.rviz
+    - Class: rviz_common/Group
+      Name: Sensors
+      Enabled: false
+      Displays:
+        # Sampled inside unitree_mujoco, published by g1_sensor_relay. Best-effort to match
+        # the publisher: a Reliable subscriber here shows nothing at all.
+        - Class: rviz_default_plugins/PointCloud2
+          Name: LiDAR
+          Enabled: true
+          Topic:
+            Value: /livox/lidar
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Style: Points
+          Size (Pixels): 2
+          Alpha: 1
+          Decay Time: 0
+          Position Transformer: XYZ
+          Color Transformer: AxisColor
+          Axis: Z
+          Autocompute Intensity Bounds: true
+          Invert Rainbow: false
+
+        # Depth as a 3D cloud, projected through camera_info. This is the camera's own view
+        # of the world, so it should overlap the LiDAR returns where the two see the same
+        # surfaces; if it floats away from them, the mount or the depth scale is wrong.
+        - Class: rviz_default_plugins/DepthCloud
+          Name: Depth cloud
+          Enabled: true
+          Topic Filter: false
+          Depth Map Topic: /camera/aligned_depth_to_color/image_raw
+          Depth Map Transport Hint: raw
+          Color Transport Hint: raw
+          Queue Size: 5
+          Style: Points
+          Size (Pixels): 3
+          Alpha: 1
+          Decay Time: 0
+          Color Image Topic: /camera/color/image_raw
+          Color Transformer: RGB8
+          Occlusion Compensation:
+            Occlusion Time-Out: 30
+            Enabled: false
+
+        # The same data as a 2D panel, which is the quickest way to see that the camera is
+        # pointed where you think and is not returning a blank frame.
+        - Class: rviz_default_plugins/Image
+          Name: Depth image
+          Enabled: true
+          Topic:
+            Value: /camera/aligned_depth_to_color/image_raw
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Max Value: 4
+          Min Value: 0.5
+          Median window: 5
+          Normalize Range: false
+
+        # Colour from the same render as the depth above, so the two line up pixel for pixel.
+        - Class: rviz_default_plugins/Image
+          Name: Colour image
+          Enabled: true
+          Topic:
+            Value: /camera/color/image_raw
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Normalize Range: true
+
+        # Where the simulator says the sensor is. Diagnostic: it is the ground truth the
+        # cloud was swept from, so it should sit exactly on the robot's Mid360.
+        - Class: rviz_default_plugins/Pose
+          Name: Sensor pose
+          Enabled: false
+          Topic:
+            Value: /g1_sensor_relay/sensor_pose
+            Depth: 5
+            Durability Policy: Volatile
+            Reliability Policy: Best Effort
+          Shape: Axes
+          Axes Length: 0.3
+          Axes Radius: 0.02
+    # END SENSOR GROUP
+
   Global Options:
     Background Color: 48; 48; 48
     Fixed Frame: map
@@ -184,7 +312,6 @@ Visualization Manager:
     - Class: rviz_default_plugins/MoveCamera
     - Class: rviz_default_plugins/FocusCamera
     - Class: rviz_default_plugins/Measure
-    # Present for PR B: nothing consumes a goal pose until Nav2's bt_navigator exists.
     - Class: rviz_default_plugins/SetGoal
       Topic:
         Value: /goal_pose

--- a/workspace/src/g1_navigation/package.xml
+++ b/workspace/src/g1_navigation/package.xml
@@ -27,6 +27,9 @@
   <exec_depend>nav2_planner</exec_depend>
   <exec_depend>nav2_regulated_pure_pursuit_controller</exec_depend>
   <exec_depend>nav2_rotation_shim_controller</exec_depend>
+  <!-- ParticleCloud, the one non-default RViz display in g1_navigation.rviz. Declaring it
+       here is why that config cannot live in g1_bringup. -->
+  <exec_depend>nav2_rviz_plugins</exec_depend>
   <exec_depend>pointcloud_to_laserscan</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>rviz2</exec_depend>
@@ -45,6 +48,7 @@
   <test_depend>nav2_msgs</test_depend>
   <test_depend>nav_msgs</test_depend>
   <test_depend>python3-numpy</test_depend>
+  <test_depend>python3-yaml</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/workspace/src/g1_navigation/test/test_launch_threading.py
+++ b/workspace/src/g1_navigation/test/test_launch_threading.py
@@ -1,0 +1,201 @@
+"""Arguments must survive every include boundary bringup.launch.py introduces.
+
+This is the failure mode this stack keeps hitting. Included launch files inherit the
+parent's configurations, so a child's own DeclareLaunchArgument default never fires for
+anything the parent declared. Both previous instances -- a second RViz window on the wrong
+config, and use_composition silently ignoring its default -- looked like successful
+launches. Nothing crashed; the wrong value simply arrived.
+
+So this walks the chain rather than launching it: bringup.launch.py -> nav_sim.launch.py ->
+sim.launch.py, resolving what each layer actually forwards to the next. It needs no
+simulator and no DDS.
+
+Lives in g1_navigation because it reads both packages' launch files, and g1_bringup cannot
+depend on g1_navigation (colcon dependency cycle -- see bringup.launch.py's docstring).
+"""
+
+import importlib.util
+import os
+
+import pytest
+from launch import LaunchContext
+from launch.actions import IncludeLaunchDescription
+from launch.utilities import normalize_to_list_of_substitutions, perform_substitutions
+
+BRINGUP_LAUNCH_DIR = os.environ["G1_BRINGUP_LAUNCH_DIR"]
+NAVIGATION_LAUNCH_DIR = os.environ["G1_NAVIGATION_LAUNCH_DIR"]
+
+
+def _load(launch_dir, name):
+    path = os.path.join(launch_dir, name)
+    spec = importlib.util.spec_from_file_location(name.replace(".", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_setup(module, **configurations):
+    """Execute a launch file's OpaqueFunction body with the given arguments already set.
+
+    Returns (actions, context). The context has to come back with them: forwarded values are
+    substitutions, and resolving them against a fresh context fails with "launch
+    configuration does not exist" rather than reporting what was actually threaded.
+    """
+    context = LaunchContext()
+    for key, value in configurations.items():
+        context.launch_configurations[key] = value
+    # Defaults for anything the caller did not set, mirroring DeclareLaunchArgument.
+    for action in module.generate_launch_description().entities:
+        name = getattr(action, "name", None)
+        if name is not None and name not in context.launch_configurations:
+            default = getattr(action, "default_value", None)
+            if default is not None:
+                context.launch_configurations[name] = perform_substitutions(context, default)
+    return module._setup(context), context
+
+
+def _resolve(context, value):
+    """launch normalises plain strings to substitutions, so nothing here is a str."""
+    if isinstance(value, str):
+        return value
+    return perform_substitutions(context, normalize_to_list_of_substitutions(value))
+
+
+def _included_path(context, action):
+    """The path an include points at, without loading it.
+
+    LaunchDescriptionSource.location repr()s its substitutions until the source has actually
+    been loaded, and loading it would execute the included launch file -- sim.launch.py would
+    run its DDS environment check. The unexpanded substitutions are only reachable through
+    the name-mangled attribute.
+    """
+    subs = action.launch_description_source._LaunchDescriptionSource__location
+    return perform_substitutions(context, subs)
+
+
+def _includes(setup_result):
+    """Every IncludeLaunchDescription in a _run_setup result as (basename, {arg: value})."""
+    actions, context = setup_result
+    found = []
+    for action in actions:
+        if not isinstance(action, IncludeLaunchDescription):
+            continue
+        args = {
+            _resolve(context, k): _resolve(context, v) for k, v in action.launch_arguments
+        }
+        found.append((os.path.basename(_included_path(context, action)), args))
+    return found
+
+
+@pytest.fixture(scope="module")
+def bringup():
+    return _load(BRINGUP_LAUNCH_DIR, "bringup.launch.py")
+
+
+@pytest.fixture(scope="module")
+def nav_sim():
+    return _load(NAVIGATION_LAUNCH_DIR, "nav_sim.launch.py")
+
+
+# --- boundary 1: bringup.launch.py -> the stack below it ------------------------------
+
+
+def test_bare_mode_routes_to_sim_and_never_names_g1_navigation(bringup):
+    result = _run_setup(bringup, mode="none")
+    assert [name for name, _ in _includes(result)] == ["sim.launch.py"]
+    # The whole point of the undeclared reference: this path must not touch the package.
+    actions, context = result
+    for action in actions:
+        if isinstance(action, IncludeLaunchDescription):
+            assert "g1_navigation" not in _included_path(context, action)
+
+
+def test_navigation_modes_route_to_nav_sim(bringup):
+    for mode in ("mapping", "localization"):
+        includes = _includes(_run_setup(bringup, mode=mode))
+        assert [name for name, _ in includes] == ["nav_sim.launch.py"], mode
+        assert includes[0][1]["mode"] == mode
+
+
+@pytest.mark.parametrize("mode,expected", [("none", "2.0"), ("mapping", "4.0")])
+def test_each_branch_supplies_its_own_start_delay(bringup, mode, expected):
+    # The child's own default can never fire, so the branch has to pick a concrete value.
+    # Getting this wrong hands sim.launch.py an empty string and float() raises.
+    args = _includes(_run_setup(bringup, mode=mode))[0][1]
+    assert args["sim_start_delay_s"] == expected
+
+
+@pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
+def test_an_explicit_start_delay_beats_the_branch_default(bringup, mode):
+    args = _includes(_run_setup(bringup, mode=mode, sim_start_delay_s="9.5"))[0][1]
+    assert args["sim_start_delay_s"] == "9.5"
+
+
+@pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
+def test_world_threads_through_unchanged(bringup, mode):
+    args = _includes(_run_setup(bringup, mode=mode, world="perception"))[0][1]
+    assert args["world"] == "perception"
+
+
+@pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
+def test_rviz_is_always_suppressed_in_the_child(bringup, mode):
+    # The exact shape of the shipped bug: without an explicit false the child inherits
+    # rviz:=true and opens a second window on the wrong config.
+    args = _includes(_run_setup(bringup, mode=mode, rviz="true"))[0][1]
+    assert args["rviz"] == "false"
+
+
+def test_rviz_config_is_chosen_per_mode(bringup):
+    bare = _includes(_run_setup(bringup, mode="none", rviz="true"))
+    nav = _includes(_run_setup(bringup, mode="localization", rviz="true"))
+    bare_rviz = [a for name, a in bare if name == "rviz.launch.py"]
+    nav_rviz = [a for name, a in nav if name == "rviz.launch.py"]
+    assert len(bare_rviz) == 1 and len(nav_rviz) == 1
+    assert bare_rviz[0]["rviz_config"].endswith("g1_bringup/config/g1_sensors.rviz")
+    assert nav_rviz[0]["rviz_config"].endswith("g1_navigation/config/g1_navigation.rviz")
+
+
+def test_no_rviz_include_when_not_asked(bringup):
+    for mode in ("none", "localization"):
+        names = [name for name, _ in _includes(_run_setup(bringup, mode=mode, rviz="false"))]
+        assert "rviz.launch.py" not in names, mode
+
+
+# --- boundary 2: the value keeps its meaning all the way down to sim.launch.py --------
+
+
+def test_world_and_delay_survive_the_second_boundary(bringup, nav_sim):
+    """The end-to-end claim: what an operator types reaches the simulator."""
+    forwarded = _includes(
+        _run_setup(bringup, mode="localization", world="perception", sim_start_delay_s="9.5")
+    )[0][1]
+
+    # nav_sim.launch.py starts from exactly what bringup handed it, plus its own defaults.
+    downstream = _includes(_run_setup(nav_sim, **forwarded))
+    sim = [a for name, a in downstream if name == "sim.launch.py"]
+    assert len(sim) == 1, f"expected one sim.launch.py include, got {downstream}"
+
+    assert sim[0]["world"] == "perception"
+    assert sim[0]["sim_start_delay_s"] == "9.5"
+    assert sim[0]["rviz"] == "false"
+    # nav_sim forces this on regardless of what came from above, and must keep doing so.
+    assert sim[0]["sensors"] == "true"
+
+
+# --- the guards ----------------------------------------------------------------------
+
+
+def test_nav_without_localization_is_refused(bringup):
+    for mode in ("none", "mapping"):
+        with pytest.raises(RuntimeError, match="needs mode:=localization"):
+            _run_setup(bringup, mode=mode, nav="true")
+
+
+def test_pin_pelvis_with_navigation_is_refused(bringup):
+    with pytest.raises(RuntimeError, match="cannot drive anywhere"):
+        _run_setup(bringup, mode="mapping", pin_pelvis="true")
+
+
+def test_an_unknown_mode_is_refused(bringup):
+    with pytest.raises(RuntimeError, match="is not a mode"):
+        _run_setup(bringup, mode="slam")

--- a/workspace/src/g1_navigation/test/test_rviz_configs.py
+++ b/workspace/src/g1_navigation/test/test_rviz_configs.py
@@ -1,0 +1,102 @@
+"""The sensor display group is duplicated across two packages and must not drift.
+
+g1_bringup/config/g1_sensors.rviz and g1_navigation/config/g1_navigation.rviz are two static
+files rather than one generated at launch, because they differ in Fixed Frame as well as in
+which groups exist -- and because rewriting config at launch time has already cost this stack
+a debugging session (g1_navigation/launch/nav2.launch.py's docstring).
+
+The price of static files is drift. Neither package's own tests can see the pair, which is
+the same situation test_gait_coupling exists for.
+"""
+
+import os
+
+import pytest
+import yaml
+
+BRINGUP_CONFIG_DIR = os.environ["G1_BRINGUP_CONFIG_DIR"]
+NAVIGATION_CONFIG_DIR = os.environ["G1_NAVIGATION_CONFIG_DIR"]
+
+# nav2_rviz_plugins is the only non-default plugin either config may use, and only the
+# navigation one may use it -- g1_bringup shipping it would mean a Nav2 dependency.
+NAV2_PLUGIN_PREFIX = "nav2_rviz_plugins/"
+
+
+def _displays(path):
+    with open(path) as handle:
+        return yaml.safe_load(handle)["Visualization Manager"]
+
+
+def _group(displays, name):
+    for item in displays["Displays"]:
+        if item.get("Class") == "rviz_common/Group" and item.get("Name") == name:
+            return item
+    return None
+
+
+@pytest.fixture(scope="module")
+def sensors():
+    return _displays(os.path.join(BRINGUP_CONFIG_DIR, "g1_sensors.rviz"))
+
+
+@pytest.fixture(scope="module")
+def navigation():
+    return _displays(os.path.join(NAVIGATION_CONFIG_DIR, "g1_navigation.rviz"))
+
+
+def test_both_configs_carry_a_sensor_group(sensors, navigation):
+    assert _group(sensors, "Sensors") is not None
+    assert _group(navigation, "Sensors") is not None
+
+
+def test_the_sensor_group_contents_are_identical(sensors, navigation):
+    """Everything except the group's own Enabled flag, which is the point of the split."""
+    a = _group(sensors, "Sensors")["Displays"]
+    b = _group(navigation, "Sensors")["Displays"]
+    assert a == b, (
+        "the Sensors group has drifted between g1_bringup and g1_navigation; "
+        "edit both or neither"
+    )
+
+
+def test_the_two_configs_disagree_only_where_intended(sensors, navigation):
+    # Enabled differs by design: navigation starts with sensors folded away.
+    assert _group(sensors, "Sensors")["Enabled"] is True
+    assert _group(navigation, "Sensors")["Enabled"] is False
+
+
+def test_only_the_navigation_config_has_a_nav2_group(sensors, navigation):
+    assert _group(navigation, "Nav2") is not None
+    assert _group(sensors, "Nav2") is None
+
+
+def test_fixed_frames_match_what_each_mode_actually_publishes(sensors, navigation):
+    # There is no map frame without SLAM or AMCL, so the bare config cannot use one.
+    assert sensors["Global Options"]["Fixed Frame"] == "odom"
+    assert navigation["Global Options"]["Fixed Frame"] == "map"
+
+
+def test_g1_bringup_ships_no_nav2_plugin_classes(sensors):
+    """The constraint that put the merged config in g1_navigation in the first place."""
+
+    def classes(node):
+        if isinstance(node, dict):
+            if "Class" in node and isinstance(node["Class"], str):
+                yield node["Class"]
+            for value in node.values():
+                yield from classes(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from classes(value)
+
+    offenders = [c for c in classes(sensors) if c.startswith(NAV2_PLUGIN_PREFIX)]
+    assert not offenders, (
+        f"g1_bringup's RViz config uses {offenders}, which would give the bring-up package a "
+        "runtime dependency on nav2_rviz_plugins"
+    )
+
+
+def test_the_navigation_config_actually_uses_the_amcl_swarm(navigation):
+    # The display that forced the split; if it is gone, the split has no reason to exist.
+    nav2 = _group(navigation, "Nav2")
+    assert any(d.get("Class", "").startswith(NAV2_PLUGIN_PREFIX) for d in nav2["Displays"])


### PR DESCRIPTION
The command an operator types now lives in `g1_bringup`, matching `nav2_bringup`. One entry point covers every mode:

```bash
ros2 launch g1_bringup bringup.launch.py                                      # simulator only
ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
```

`sim.launch.py` and `control.launch.py` are untouched and still work standalone.

## g1_navigation is referenced but not declared

Deliberate, and it cannot be otherwise. `g1_navigation` already declares `<exec_depend>g1_bringup</exec_depend>`, and adding the reciprocal does not merely look untidy, colcon refuses to order the workspace:

```
ERROR:colcon:colcon list: Unable to order packages topologically:
g1_bringup: ['g1_navigation']
g1_navigation: ['g1_bringup']
```

So it is a launch-time path lookup. Verified by stripping `g1_navigation` from `AMENT_PREFIX_PATH`: `mode:=none` launches clean and never names the package, and the navigation modes fail with an actionable message rather than a raw ament search-path dump.

The composition direction is unchanged. The navigation branch includes `g1_navigation`'s `nav_sim.launch.py`, which includes `sim.launch.py` itself. `bringup.launch.py` routes, it does not orchestrate navigation.

Nothing warns if `g1_navigation` renames a launch file, which is why `test_launch_threading` exists.

## RViz

One config per mode instead of two unrelated ones. Each has a `Sensors` group with identical contents; the navigation config adds a `Nav2` group with the official displays we actually publish, including the AMCL particle swarm, which was missing.

Two static files rather than one rewritten at launch: they differ in Fixed Frame as well as in which groups exist, and there is no `map` frame without SLAM or AMCL. The nav config lives in `g1_navigation` because the particle swarm is a `nav2_rviz_plugins` class, and shipping it from `g1_bringup` would give the bringup package a Nav2 dependency.

Displays deliberately left out because nothing publishes them: `Bumper Hit`, `/waypoints`, DWB trajectories, the Smac downsampled costmap, and the global voxel grid.

## Tests

`test_launch_threading` walks `bringup` to `nav_sim` to `sim` without launching anything. Both prior bugs in that family looked like successful launches: nothing crashed, the wrong value just arrived. Mutation-checked, dropping the explicit `rviz:=false` and the per-branch start delay each fail exactly the tests that name them.

`test_rviz_configs` pins the duplicated sensor group and asserts `g1_bringup` ships no Nav2 plugin class.

Both live in `g1_navigation` because they read both packages' files, and a `test_depend` the other way re-creates the cycle above.
