### PR TITLE
Build at C++20 and apply the C++ review findings

### DIFF
--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(g1_arm_sdk_system PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(g1_arm_sdk_system PUBLIC cxx_std_17)
+target_compile_features(g1_arm_sdk_system PUBLIC cxx_std_20)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(g1_arm_sdk_system PRIVATE -Wall -Wextra)
 endif()

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/arm_ramp_engine.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/arm_ramp_engine.hpp
@@ -89,7 +89,7 @@ public:
      * anything until the ramp-up has actually started.
      * @param measured_positions  Just-measured joint positions to seed the published targets with.
      */
-    void seedFromMeasured(const std::array<double, kNumArmJoints>& measured_positions);
+    void seedFromMeasured(const std::array<double, kNumArmJoints>& measured_positions) noexcept;
 
     /**
      * @brief One control-loop tick: advances the blend weight and slews the published targets.
@@ -119,8 +119,9 @@ public:
      *   pathologically large values.
      * @return The resulting blend weight.
      */
-    double
-    step(BlendMode mode, const std::array<double, kNumArmJoints>& commanded_positions, double dt_s);
+    double step(
+        BlendMode mode, const std::array<double, kNumArmJoints>& commanded_positions,
+        double dt_s) noexcept;
 
     /**
      * @brief Current blend weight in [0, 1]; set by seedFromMeasured(), advanced by step().
@@ -137,7 +138,7 @@ public:
     }
 
 private:
-    double rampDurationFor(BlendMode mode) const;
+    double rampDurationFor(BlendMode mode) const noexcept;
 
     RampConfig                        config_;
     double                            weight_{ 0.0 };

--- a/workspace/src/g1_hardware_interface/src/arm_ramp_engine.cpp
+++ b/workspace/src/g1_hardware_interface/src/arm_ramp_engine.cpp
@@ -27,13 +27,14 @@ ArmRampEngine::ArmRampEngine(const RampConfig& config)
   : config_(config)
 {}
 
-void ArmRampEngine::seedFromMeasured(const std::array<double, kNumArmJoints>& measured_positions)
+void ArmRampEngine::seedFromMeasured(
+    const std::array<double, kNumArmJoints>& measured_positions) noexcept
 {
     published_positions_ = measured_positions;
     weight_              = 0.0;
 }
 
-double ArmRampEngine::rampDurationFor(BlendMode mode) const
+double ArmRampEngine::rampDurationFor(BlendMode mode) const noexcept
 {
     /* Exhaustive switch — no default, so new BlendMode values trigger -Wswitch. */
     switch (mode)
@@ -53,7 +54,8 @@ double ArmRampEngine::rampDurationFor(BlendMode mode) const
 }
 
 double ArmRampEngine::step(
-    BlendMode mode, const std::array<double, kNumArmJoints>& commanded_positions, double dt_s)
+    BlendMode mode, const std::array<double, kNumArmJoints>& commanded_positions,
+    double dt_s) noexcept
 {
     if (dt_s <= 0.0)
     {

--- a/workspace/src/g1_locomotion/CMakeLists.txt
+++ b/workspace/src/g1_locomotion/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(g1_loco_bridge_core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(g1_loco_bridge_core PUBLIC cxx_std_17)
+target_compile_features(g1_loco_bridge_core PUBLIC cxx_std_20)
 target_link_libraries(g1_loco_bridge_core PUBLIC nlohmann_json::nlohmann_json)
 ament_target_dependencies(g1_loco_bridge_core PUBLIC unitree_api)
 
@@ -36,7 +36,7 @@ target_include_directories(g1_loco_bridge_node_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(g1_loco_bridge_node_lib PUBLIC cxx_std_17)
+target_compile_features(g1_loco_bridge_node_lib PUBLIC cxx_std_20)
 target_link_libraries(g1_loco_bridge_node_lib PUBLIC g1_loco_bridge_core)
 ament_target_dependencies(g1_loco_bridge_node_lib PUBLIC
   rclcpp
@@ -55,7 +55,7 @@ add_executable(g1_gait_shaper src/g1_gait_shaper_node.cpp src/gait_shaper.cpp)
 target_include_directories(g1_gait_shaper PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_compile_features(g1_gait_shaper PUBLIC cxx_std_17)
+target_compile_features(g1_gait_shaper PUBLIC cxx_std_20)
 ament_target_dependencies(g1_gait_shaper rclcpp geometry_msgs)
 
 # Client of this package's own action, so no new dependency. Its own executable rather than a
@@ -65,11 +65,11 @@ add_executable(g1_loco_authority src/g1_loco_authority_node.cpp)
 target_include_directories(g1_loco_authority PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_compile_features(g1_loco_authority PUBLIC cxx_std_17)
+target_compile_features(g1_loco_authority PUBLIC cxx_std_20)
 ament_target_dependencies(g1_loco_authority rclcpp rclcpp_action rclcpp_lifecycle g1_msgs)
 
 add_executable(g1_loco_bridge src/g1_loco_bridge_main.cpp)
-target_compile_features(g1_loco_bridge PUBLIC cxx_std_17)
+target_compile_features(g1_loco_bridge PUBLIC cxx_std_20)
 target_link_libraries(g1_loco_bridge g1_loco_bridge_node_lib)
 ament_target_dependencies(g1_loco_bridge rclcpp)
 
@@ -110,6 +110,10 @@ if(BUILD_TESTING)
   target_include_directories(test_gait_shaper PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
+  # Stated explicitly because this target compiles gait_shaper.cpp itself and links no library
+  # carrying PUBLIC cxx_std_20, so it would otherwise inherit nothing and build at the compiler
+  # default -- testing GaitShaper under a different dialect than g1_gait_shaper ships it under.
+  target_compile_features(test_gait_shaper PRIVATE cxx_std_20)
 
   # G1LocoBridge itself, in-process against a fake /api/sport/* responder on an isolated
   # ROS_DOMAIN_ID (no sim, no launch_testing) -- lifecycle-transition/authority races the pure

--- a/workspace/src/g1_locomotion/include/g1_locomotion/gait_shaper.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/gait_shaper.hpp
@@ -82,7 +82,7 @@ public:
      * Non-finite inputs need no special case: NaN fails both comparisons and falls through to
      * a stop, and an infinite yaw clamps.
      */
-    Command shape(const Command& in) const;
+    [[nodiscard]] Command shape(const Command& in) const;
 
 private:
     Config config_;

--- a/workspace/src/g1_locomotion/include/g1_locomotion/loco_request_correlator.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/loco_request_correlator.hpp
@@ -61,7 +61,7 @@ public:
      * @return The Request to publish, or nullopt if max_pending is already reached -- nothing is
      *   tracked in that case, and the caller sends nothing this call.
      */
-    std::optional<unitree_api::msg::Request> send(
+    [[nodiscard]] std::optional<unitree_api::msg::Request> send(
         std::int64_t api_id, const std::string& parameter,
         std::chrono::steady_clock::time_point now, ResponseCallback on_done);
 

--- a/workspace/src/g1_locomotion/include/g1_locomotion/velocity_gate.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/velocity_gate.hpp
@@ -93,7 +93,7 @@ public:
      * @param now  Current time.
      * @return The velocity to send this tick, or nullopt if nothing should be sent.
      */
-    std::optional<Intent> tick(std::chrono::steady_clock::time_point now);
+    [[nodiscard]] std::optional<Intent> tick(std::chrono::steady_clock::time_point now);
 
     /**
      * @brief Feeds back the outcome of the SetVelocity request tick() most recently produced.

--- a/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
@@ -383,8 +383,13 @@ private:
 
 namespace
 {
-std::atomic<bool>                         g_stopping{ false };
-rclcpp::executors::MultiThreadedExecutor* g_executor = nullptr;
+std::atomic<bool> g_stopping{ false };
+// The handler below only stores to this. That is async-signal-safe if and only if the store
+// is lock-free; if it were not, the "just a flag" argument would smuggle a lock into the
+// handler, which is the exact hazard the comment below is defending against.
+static_assert(
+    std::atomic<bool>::is_always_lock_free,
+    "the signal handler stores to g_stopping and needs it lock-free");
 
 /// Ctrl-C is the ordinary way a navigation session ends, and it must not leak authority.
 ///
@@ -417,7 +422,6 @@ int main(int argc, char** argv)
     auto node = std::make_shared<g1_locomotion::G1LocoAuthority>(rclcpp::NodeOptions());
     executor.add_node(node->get_node_base_interface());
 
-    g_executor = &executor;
     std::signal(SIGINT, onSignal);
     std::signal(SIGTERM, onSignal);
 
@@ -451,7 +455,6 @@ int main(int argc, char** argv)
     }
     releaser.join();
 
-    g_executor = nullptr;
     rclcpp::shutdown();
     return 0;
 }

--- a/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
@@ -98,7 +98,11 @@ public:
 
     CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override
     {
-        LifecycleNode::on_activate(previous_state);
+        const auto base_result = LifecycleNode::on_activate(previous_state);
+        if (base_result != CallbackReturn::SUCCESS)
+        {
+            return base_result;
+        }
         RCLCPP_INFO(
             get_logger(),
             "acquiring locomotion authority (from %s)",

--- a/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
@@ -255,7 +255,7 @@ private:
             RCLCPP_ERROR(get_logger(), "%s goal was never acknowledged", label);
             return Attempt::kFatal;
         }
-        auto handle = pending.get();
+        const auto& handle = pending.get();
         if (!handle)
         {
             // A goal rejection carries no code, so this cannot be classified from the wire. Of
@@ -276,7 +276,7 @@ private:
             RCLCPP_ERROR(get_logger(), "%s goal produced no result", label);
             return Attempt::kFatal;
         }
-        const auto wrapped = result.get();
+        const auto& wrapped = result.get();
         if (wrapped.code == rclcpp_action::ResultCode::SUCCEEDED && wrapped.result->success)
         {
             return Attempt::kOk;

--- a/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
+++ b/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
@@ -137,9 +137,13 @@ TEST(LocoRequestCorrelator, SweepTimeoutCallbackMaySendANewRequestWithoutCorrupt
             [&correlator, &now, &reissued](std::int32_t, const std::string&) {
                 ++reissued;
                 // Reentrant insert from inside sweep()'s own callback loop -- exactly the
-                // precondition documented as safe on the class's sweep() declaration.
-                correlator.send(kApiIdSetVelocity, "{}", now, [](std::int32_t, const std::string&) {
-                });
+                // precondition documented as safe on the class's sweep() declaration. The
+                // request itself is not the subject here, so the discard is explicit.
+                static_cast<void>(correlator.send(
+                    kApiIdSetVelocity,
+                    "{}",
+                    now,
+                    [](std::int32_t, const std::string&) {}));
             });
         ASSERT_TRUE(request.has_value());
     }

--- a/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
+++ b/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
@@ -123,9 +123,11 @@ TEST(LocoRequestCorrelator, NeverArrivingResponseTimesOutViaSweep)
 TEST(LocoRequestCorrelator, SweepTimeoutCallbackMaySendANewRequestWithoutCorruptingIteration)
 {
     // Enough entries to trigger rehash during reentrant insert.
-    constexpr int kCount  = 20;
-    auto       correlator = makeCorrelator(/*request_timeout_s=*/1.0, /*max_pending=*/kCount * 2);
-    const auto now        = std::chrono::steady_clock::now();
+    constexpr int kCount     = 20;
+    auto          correlator = makeCorrelator(
+        /*request_timeout_s=*/1.0,
+        /*max_pending=*/static_cast<std::size_t>(kCount) * 2);
+    const auto now = std::chrono::steady_clock::now();
 
     int reissued = 0;
     for (int i = 0; i < kCount; ++i)

--- a/workspace/src/g1_motion_service_sim/CMakeLists.txt
+++ b/workspace/src/g1_motion_service_sim/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(blend_math PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(blend_math PUBLIC cxx_std_17)
+target_compile_features(blend_math PUBLIC cxx_std_20)
 ament_target_dependencies(blend_math PUBLIC unitree_hg)
 
 # Walking policy observation/action math — pure C++, no ROS or ONNX.
@@ -36,7 +36,7 @@ target_include_directories(walk_policy PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(walk_policy PUBLIC cxx_std_17)
+target_compile_features(walk_policy PUBLIC cxx_std_20)
 ament_target_dependencies(walk_policy PUBLIC unitree_hg)
 
 # ONNX Runtime session wrapper, separate from math for testability.
@@ -46,7 +46,7 @@ target_include_directories(walk_policy_session PUBLIC
   $<INSTALL_INTERFACE:include>
   ${ONNXRUNTIME_INCLUDE_DIR}
 )
-target_compile_features(walk_policy_session PUBLIC cxx_std_17)
+target_compile_features(walk_policy_session PUBLIC cxx_std_20)
 target_link_libraries(walk_policy_session walk_policy ${ONNXRUNTIME_LIBRARY})
 
 # Sim-only FSM legality table for /api/sport/request.
@@ -55,7 +55,7 @@ target_include_directories(loco_fsm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(loco_fsm PUBLIC cxx_std_17)
+target_compile_features(loco_fsm PUBLIC cxx_std_20)
 
 add_executable(motion_service_sim
   src/motion_service_sim_node.cpp
@@ -65,7 +65,7 @@ target_include_directories(motion_service_sim PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(motion_service_sim PUBLIC cxx_std_17)
+target_compile_features(motion_service_sim PUBLIC cxx_std_20)
 target_link_libraries(motion_service_sim
   blend_math
   loco_fsm

--- a/workspace/src/g1_motion_service_sim/CMakeLists.txt
+++ b/workspace/src/g1_motion_service_sim/CMakeLists.txt
@@ -80,6 +80,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(motion_service_sim PRIVATE -Wall -Wextra)
   target_compile_options(blend_math PRIVATE -Wall -Wextra)
   target_compile_options(loco_fsm PRIVATE -Wall -Wextra)
+  target_compile_options(walk_policy PRIVATE -Wall -Wextra)
+  target_compile_options(walk_policy_session PRIVATE -Wall -Wextra)
 endif()
 
 # blend_math is internal (statically linked) — no install rule.

--- a/workspace/src/g1_motion_service_sim/CMakeLists.txt
+++ b/workspace/src/g1_motion_service_sim/CMakeLists.txt
@@ -114,6 +114,11 @@ if(BUILD_TESTING)
   ament_add_gmock(test_walk_policy test/test_walk_policy.cpp)
   target_link_libraries(test_walk_policy walk_policy)
 
+  # The wire constants this package duplicates from g1_hardware_interface. Only the test
+  # links that package, so blend_math keeps its lean dependency footprint.
+  ament_add_gmock(test_wire_constants test/test_wire_constants.cpp)
+  target_link_libraries(test_wire_constants blend_math g1_hardware_interface::g1_arm_sdk_system)
+
   # ONNX Runtime session tests.
   ament_add_gmock(test_walk_policy_session test/test_walk_policy_session.cpp)
   target_link_libraries(test_walk_policy_session walk_policy_session)

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/blend_math.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/blend_math.hpp
@@ -45,7 +45,7 @@ inline constexpr std::size_t kWeightMotorIndex = 29;
  * @param weight           Blend weight, clamped to [0, 1].
  * @return The blended value.
  */
-inline double blend(double hold_value, double commanded_value, double weight)
+inline double blend(double hold_value, double commanded_value, double weight) noexcept
 {
     weight = std::clamp(weight, 0.0, 1.0);
     return hold_value * (1.0 - weight) + commanded_value * weight;
@@ -69,9 +69,9 @@ inline double blend(double hold_value, double commanded_value, double weight)
  * @param dt_s                       Elapsed time since the previous tick, in seconds.
  * @return The new effective weight for this tick.
  */
-double stepEffectiveWeight(
+[[nodiscard]] double stepEffectiveWeight(
     double previous_effective_weight, double raw_weight, bool arm_sdk_stale,
-    double timeout_ramp_down_s, double dt_s);
+    double timeout_ramp_down_s, double dt_s) noexcept;
 
 /**
  * @brief Assembles a full-body /lowcmd from the frozen hold pose and the latest /arm_sdk command.
@@ -107,7 +107,7 @@ unitree_hg::msg::LowCmd assembleSimLowCmd(
     const std::array<double, kNumArmMotors>&  arm_cmd_q,
     const std::array<double, kNumArmMotors>&  arm_cmd_kp,
     const std::array<double, kNumArmMotors>& arm_cmd_kd, double weight, double arm_hold_kp,
-    double arm_hold_kd);
+    double arm_hold_kd) noexcept;
 
 }  // namespace g1_motion_service_sim
 

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/walk_policy_session.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/walk_policy_session.hpp
@@ -64,6 +64,11 @@ private:
     std::string                   input_name_;
     std::string                   output_name_;
     double                        warmup_s_{ 0.0 };
+
+    /// Output storage bound once at construction. The Run() overload that returns its outputs
+    /// allocates a std::vector every call, which this path cannot afford at 50 Hz.
+    std::array<float, kActionDim> output_buffer_{};
+    Ort::Value                    output_tensor_{ nullptr };
 };
 
 }  // namespace g1_motion_service_sim

--- a/workspace/src/g1_motion_service_sim/src/blend_math.cpp
+++ b/workspace/src/g1_motion_service_sim/src/blend_math.cpp
@@ -11,7 +11,7 @@ namespace g1_motion_service_sim
 
 double stepEffectiveWeight(
     double previous_effective_weight, double raw_weight, bool arm_sdk_stale,
-    double timeout_ramp_down_s, double dt_s)
+    double timeout_ramp_down_s, double dt_s) noexcept
 {
     const double target   = arm_sdk_stale ? 0.0 : std::clamp(raw_weight, 0.0, 1.0);
     const double max_step = dt_s / timeout_ramp_down_s;
@@ -36,7 +36,7 @@ unitree_hg::msg::LowCmd assembleSimLowCmd(
     const std::array<double, kNumArmMotors>&  arm_cmd_q,
     const std::array<double, kNumArmMotors>&  arm_cmd_kp,
     const std::array<double, kNumArmMotors>& arm_cmd_kd, double weight, double arm_hold_kp,
-    double arm_hold_kd)
+    double arm_hold_kd) noexcept
 {
     // rosidl-generated: zero-initialized, including reserved slots and mode/mode_pr/mode_machine
     // -- deliberately left untouched (see motion_service_sim_node's README).

--- a/workspace/src/g1_motion_service_sim/src/walk_policy_session.cpp
+++ b/workspace/src/g1_motion_service_sim/src/walk_policy_session.cpp
@@ -56,6 +56,17 @@ WalkPolicySession::WalkPolicySession(const std::string& model_path)
         kActionDim,
         "output");
 
+    // Bind the output tensor over our own buffer once, so run() allocates nothing.
+    static constexpr std::array<std::int64_t, 2> kOutputShape{ 1,
+                                                               static_cast<std::int64_t>(
+                                                                   kActionDim) };
+    output_tensor_ = Ort::Value::CreateTensor<float>(
+        memory_info_,
+        output_buffer_.data(),
+        output_buffer_.size(),
+        kOutputShape.data(),
+        kOutputShape.size());
+
     // The first inference builds ORT's execution plan and is far slower than steady state; do it
     // here so the 50 Hz timer's first real tick isn't the one that pays for it.
     const auto start = std::chrono::steady_clock::now();
@@ -80,13 +91,19 @@ std::array<float, kActionDim> WalkPolicySession::run(const std::array<float, kOb
     const char* input_names[]  = { input_name_.c_str() };
     const char* output_names[] = { output_name_.c_str() };
 
-    auto outputs =
-        session_->Run(Ort::RunOptions{ nullptr }, input_names, &input_tensor, 1, output_names, 1);
+    // In-place overload: fills output_buffer_ through the tensor bound at construction. The
+    // returning overload allocates a std::vector<Ort::Value> per call, which this path runs
+    // 50 times a second alongside a 500 Hz publish loop.
+    session_->Run(
+        Ort::RunOptions{ nullptr },
+        input_names,
+        &input_tensor,
+        1,
+        output_names,
+        &output_tensor_,
+        1);
 
-    std::array<float, kActionDim> action{};
-    const float*                  data = outputs.front().GetTensorData<float>();
-    std::copy(data, data + kActionDim, action.begin());
-    return action;
+    return output_buffer_;
 }
 
 }  // namespace g1_motion_service_sim

--- a/workspace/src/g1_motion_service_sim/test/test_walk_policy_session.cpp
+++ b/workspace/src/g1_motion_service_sim/test/test_walk_policy_session.cpp
@@ -58,6 +58,39 @@ TEST(WalkPolicySessionTest, IsDeterministicForAFixedObservation)
     EXPECT_EQ(first, second);
 }
 
+TEST(WalkPolicySessionTest, MatchesTheGoldenActionForAZeroObservation)
+{
+    // IsDeterministicForAFixedObservation above compares two runs of the SAME build, so it
+    // cannot see a change introduced by an edit to run(). These literals were captured from
+    // the implementation before run() was switched to ORT's in-place Run() overload, and pin
+    // the output across any future change to how inference is invoked.
+    //
+    // Hex float literals, and compared exactly: the point is bit-identity, and a tolerance
+    // would let a real numerical change through. walker.onnx is vendored and pinned, so the
+    // expected values only move if the model does.
+    static constexpr std::array<float, kActionDim> kGoldenForZeros{
+        0x1.36d39ep-3F,  0x1.4d967cp-2F,  -0x1.a9e434p-3F, -0x1.9bcb1ep-6F, 0x1.cebfdep-2F,
+        -0x1.16305p-3F,  -0x1.e3930cp-3F, -0x1.57ba5ap-2F, 0x1.daa4a6p-5F,  -0x1.87a886p-2F,
+        0x1.2936fcp-2F,  -0x1.00117cp-3F, -0x1.bdfe04p-5F, -0x1.368c24p-3F, -0x1.242b52p-5F,
+        -0x1.b55166p-2F, 0x1.43c3ccp-2F,  0x1.95b334p-3F,  -0x1.83b4dcp-3F, 0x1.ab0618p-3F,
+        0x1.1b57fcp-3F,  0x1.417ep-1F,    0x1.e8fb6p-8F,   -0x1.b82274p-2F, -0x1.211434p-3F,
+        -0x1.268fa4p-2F, 0x1.f47108p-3F,  0x1.3149acp-1F,  0x1.b249b6p-2F
+    };
+
+    WalkPolicySession session(modelPath());
+    const auto        action = session.run({});
+    ASSERT_EQ(action.size(), kGoldenForZeros.size());
+    for (std::size_t i = 0; i < action.size(); ++i)
+    {
+        EXPECT_EQ(action[i], kGoldenForZeros[i]) << "action[" << i << "] moved";
+    }
+
+    // The buffer the in-place overload writes into is reused across calls, so a second run
+    // must not see the first one's values leak through.
+    const auto again = session.run({});
+    EXPECT_EQ(action, again);
+}
+
 TEST(WalkPolicySessionTest, NormalisationIsBakedIntoTheGraph)
 {
     // A zero observation is far from the training mean, so if the graph did NOT normalise

--- a/workspace/src/g1_motion_service_sim/test/test_wire_constants.cpp
+++ b/workspace/src/g1_motion_service_sim/test/test_wire_constants.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file test_wire_constants.cpp
+ * @brief Pins the Unitree wire-layout constants this package duplicates from
+ * g1_hardware_interface.
+ *
+ * Both packages independently encode the same vendor facts: the weight slot lives at motor
+ * index 29, and there are 14 arm joints. They are duplicated rather than shared on purpose --
+ * blend_math links only unitree_hg, and pulling in g1_hardware_interface to reach a constant
+ * would drag the ros2_control plugin's headers into a pure math library.
+ *
+ * The cost of that choice is drift, so it is checked here instead. Same arrangement as
+ * g1_navigation's test_gait_coupling, which exists because two numbers in different packages
+ * had already silently disagreed once. This is a test target, so the heavier include stays
+ * out of the shipped library.
+ */
+#include <gmock/gmock.h>
+
+#include <cstddef>
+
+#include "g1_hardware_interface/arm_ramp_engine.hpp"
+#include "g1_hardware_interface/g1_arm_sdk_system.hpp"
+#include "g1_motion_service_sim/blend_math.hpp"
+
+namespace
+{
+
+// Compile-time, so a mismatch fails the build rather than waiting for the suite to run.
+static_assert(
+    g1_motion_service_sim::kWeightMotorIndex == g1_hardware_interface::kWeightMotorIndex,
+    "the /lowcmd weight slot index disagrees between g1_motion_service_sim and "
+    "g1_hardware_interface -- one of them is writing the weight to the wrong motor");
+
+static_assert(
+    static_cast<std::size_t>(g1_motion_service_sim::kNumArmMotors) ==
+        g1_hardware_interface::kNumArmJoints,
+    "the arm joint count disagrees between g1_motion_service_sim (kNumArmMotors) and "
+    "g1_hardware_interface (kNumArmJoints)");
+
+TEST(WireConstants, TheWeightSlotIndexAgreesAcrossPackages)
+{
+    EXPECT_EQ(g1_motion_service_sim::kWeightMotorIndex, g1_hardware_interface::kWeightMotorIndex);
+}
+
+TEST(WireConstants, TheArmJointCountAgreesAcrossPackages)
+{
+    // Deliberately compared through a cast: the two spellings also disagree on type, int here
+    // and std::size_t there, which is the part most likely to bite in a mixed comparison.
+    EXPECT_EQ(
+        static_cast<std::size_t>(g1_motion_service_sim::kNumArmMotors),
+        g1_hardware_interface::kNumArmJoints);
+}
+
+TEST(WireConstants, TheArmSliceEndsWhereTheWeightSlotBegins)
+{
+    // Not a duplication check but the invariant that makes both constants meaningful: arms
+    // occupy [kFirstArmMotor, kFirstArmMotor + kNumArmMotors) and the weight slot sits just
+    // past them. If this ever fails, the blend is writing over the weight or vice versa.
+    EXPECT_EQ(
+        static_cast<std::size_t>(g1_motion_service_sim::kNumBodyMotors),
+        g1_motion_service_sim::kWeightMotorIndex);
+}
+
+}  // namespace

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -19,6 +19,13 @@ add_executable(g1_sensor_relay src/g1_sensor_relay_node.cpp)
 target_link_libraries(g1_sensor_relay PUBLIC frame_reader)
 ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs geometry_msgs)
 
+# This package parses length-prefixed binary frames off a socket, so -Wsign-compare and the
+# unused-result warnings earn their keep here more than anywhere else in the workspace.
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(frame_reader PRIVATE -Wall -Wextra)
+  target_compile_options(g1_sensor_relay PRIVATE -Wall -Wextra)
+endif()
+
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS frame_reader EXPORT export_${PROJECT_NAME} DESTINATION lib)
 install(TARGETS g1_sensor_relay DESTINATION lib/${PROJECT_NAME})

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(frame_reader PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(frame_reader PUBLIC cxx_std_17)
+target_compile_features(frame_reader PUBLIC cxx_std_20)
 
 add_executable(g1_sensor_relay src/g1_sensor_relay_node.cpp)
 target_link_libraries(g1_sensor_relay PUBLIC frame_reader)

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -252,6 +252,11 @@ private:
         info.r          = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
         info.p          = { f, 0, cx, 0, 0, f, cy, 0, 0, 0, 1, 0 };
 
+        // Captured before the move: the colour image below is stamped from it, and reading it
+        // back off a moved-from message would put the shared-timestamp guarantee at the mercy
+        // of how Image happens to move its header.
+        const auto render_stamp = img.header.stamp;
+
         depth_pub_->publish(std::move(img));
         depth_info_pub_->publish(info);
 
@@ -263,7 +268,7 @@ private:
         if (!frame.rgb.empty())
         {
             sensor_msgs::msg::Image color;
-            color.header.stamp    = img.header.stamp;
+            color.header.stamp    = render_stamp;
             color.header.frame_id = color_frame_id_;
             color.height          = frame.height;
             color.width           = frame.width;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -192,9 +192,12 @@ private:
             return;
         }
 
+        // Hoisted out of the loop deliberately: tryReadFrame fills via resize(), so reusing
+        // one frame reuses its capacity while draining a burst. A cloud can reach tens of MB
+        // and, as above, several can be queued behind one poll().
+        CloudFrame frame;
         for (;;)
         {
-            CloudFrame        frame;
             const FrameStatus status = tryReadFrame(buffer_, frame);
             if (status == FrameStatus::Incomplete)
             {

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -35,6 +35,12 @@ ament_target_dependencies(g1_odometry_publisher_node PUBLIC
 add_executable(g1_odometry_publisher src/g1_odometry_publisher_main.cpp)
 target_link_libraries(g1_odometry_publisher PUBLIC g1_odometry_publisher_node)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(odom_math PRIVATE -Wall -Wextra)
+  target_compile_options(g1_odometry_publisher_node PRIVATE -Wall -Wextra)
+  target_compile_options(g1_odometry_publisher PRIVATE -Wall -Wextra)
+endif()
+
 install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(TARGETS odom_math g1_odometry_publisher_node

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -19,14 +19,14 @@ target_include_directories(odom_math PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(odom_math PUBLIC cxx_std_17)
+target_compile_features(odom_math PUBLIC cxx_std_20)
 
 add_library(g1_odometry_publisher_node src/g1_odometry_publisher_node.cpp)
 target_include_directories(g1_odometry_publisher_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(g1_odometry_publisher_node PUBLIC cxx_std_17)
+target_compile_features(g1_odometry_publisher_node PUBLIC cxx_std_20)
 target_link_libraries(g1_odometry_publisher_node PUBLIC odom_math)
 ament_target_dependencies(g1_odometry_publisher_node PUBLIC
   rclcpp rclcpp_lifecycle lifecycle_msgs nav_msgs sensor_msgs geometry_msgs tf2_ros tf2_msgs

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -1,6 +1,7 @@
 #include "g1_state_estimation/g1_odometry_publisher_node.hpp"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <memory>
@@ -232,9 +233,9 @@ void G1OdometryPublisher::onBaseState(const sensor_msgs::msg::JointState::Shared
     // Look joints up by name every message: joint_state_broadcaster does not promise a
     // stable ordering, and indexing by position would silently swap x and yaw the day it
     // changes.
-    double     values[3]     = { 0.0, 0.0, 0.0 };
-    double     velocities[3] = { 0.0, 0.0, 0.0 };
-    const bool have_velocity = msg->velocity.size() == msg->name.size();
+    std::array<double, 3> values{};
+    std::array<double, 3> velocities{};
+    const bool            have_velocity = msg->velocity.size() == msg->name.size();
 
     for (std::size_t axis = 0; axis < base_joint_names_.size(); ++axis)
     {

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -194,7 +194,13 @@ G1OdometryPublisher::on_cleanup(const rclcpp_lifecycle::State&)
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 G1OdometryPublisher::on_activate(const rclcpp_lifecycle::State& previous_state)
 {
-    LifecycleNode::on_activate(previous_state);
+    // Checked, not discarded: this is what activates odom_pub_. Ignoring it starts the timer
+    // and reports SUCCESS against a publisher that never came up, and TF still goes out.
+    const auto base_result = LifecycleNode::on_activate(previous_state);
+    if (base_result != CallbackReturn::SUCCESS)
+    {
+        return base_result;
+    }
     const auto period = std::chrono::duration<double>(1.0 / publish_rate_hz_);
     timer_            = create_wall_timer(
         std::chrono::duration_cast<std::chrono::nanoseconds>(period),
@@ -206,8 +212,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 G1OdometryPublisher::on_deactivate(const rclcpp_lifecycle::State& previous_state)
 {
     timer_.reset();
-    LifecycleNode::on_deactivate(previous_state);
-    return CallbackReturn::SUCCESS;
+    return LifecycleNode::on_deactivate(previous_state);
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn


### PR DESCRIPTION
C++20 first, so every fix after it is built and verified against one settled baseline.

## The bump

Fourteen `cxx_std_17` declarations across the five packages that contain C++. GCC 11.4 gives concepts, ranges, `std::span`, `std::jthread`, `std::bit_cast` and constexpr algorithms. `std::format` needs GCC 13 and modules are unusable, so neither is available.

The edit count was not the coverage. Verifying the actual flag on all 32 targets found one gap: `test_gait_shaper` compiles `gait_shaper.cpp` itself and links nothing carrying `PUBLIC cxx_std_*`, so it inherited nothing and sat at the compiler default. Harmless while both were 17; after the bump it would have tested `GaitShaper` under a different dialect than the executable ships it under.

Behaviour-neutrality proved by exact output, not timing, which spreads 2.9x run to run here: policy inference over four fixed observations and both CRC vectors are bit-identical between the C++17 and C++20 builds. Live rates match within the ~2% drift measured in a vendored binary neither build recompiles.

## Fixes

Warnings were off entirely in `g1_state_estimation` and `g1_sensor_relay`, and skipped `walk_policy` and `walk_policy_session`. A forced full recompile of all six newly covered targets produces zero warnings, so this changes no code. The source was clean, it just was not being checked.

The lifecycle base-class activation result was discarded in two nodes while a third checked it correctly. The odometry node owns a real `LifecyclePublisher`; ignoring the result starts its timer and reports SUCCESS against a publisher that never came up, and TF still goes out.

`WalkPolicySession::run` used ORT's `Run` overload that returns a `std::vector<Ort::Value>`, allocating on the 50 Hz path every call. Now bound to a member buffer via the in-place overload. Pinned by a golden test written and passing against the pre-refactor implementation first, so it is a real baseline.

`CloudFrame` was reconstructed inside the burst-drain loop, throwing away its capacity each iteration on clouds that reach tens of MB.

`noexcept` on the pure RT arithmetic, and deliberately **not** on `SystemInterface::read`/`write`. `hardware_interface` reports failures as `return_type::ERROR` and `controller_manager` handles them, so `noexcept` there would convert a recoverable error into `std::terminate()` of the control process.

`[[nodiscard]]` on `GaitShaper::shape`, `VelocityGate::tick` and `Correlator::send`. It immediately found an ignored return in `test_loco_correlator`, a deliberate reentrant insert now made explicit.

The duplicated `kWeightMotorIndex` and arm-joint-count constants are cross-checked by `static_assert` rather than shared through a header, which would drag `ros2_control`'s headers into `blend_math`. Mutation-checked by flipping the index.

## clang-tidy

Scoped to the files this branch modified. One real bug: `bugprone-use-after-move` in `g1_sensor_relay`, where the colour image was stamped from a moved-from depth message. It survives only because `Time` is two scalars, and the package's documented claim is that both streams share one timestamp by construction.

`performance-unnecessary-value-param` was applied and reverted: rclcpp's `AnySubscriptionCallback` has no overload for `const shared_ptr<T>&`, so it does not compile. The linter was right about the copy and wrong that the fix was free.

Everything else rejected is recorded with reasons in local notes, including `bugprone-exception-escape` on the authority node's `main`, which is genuine but touches the release-on-exit path and deserves its own change.

## Not fixed

The CRC strict-aliasing violation stays. Vendored, byte-exact, pinned by `static_assert(sizeof(RawLowCmd)==1004)`, and it computes what the robot validates against.
