### PR TITLE
Rewrite the READMEs around what a user needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,180 @@
-# ROS 2 Compose-First Development Template
+# Grove-G1
 
-This template is a Compose-first ROS 2 development environment with VS Code Dev Containers on top.
+An autonomy stack for the [Unitree G1](https://www.unitree.com/g1) humanoid, built on ROS 2 Humble
+and developed simulation-first against `unitree_mujoco`.
 
-- Docker Compose is the runtime source of truth.
-- `.devcontainer/devcontainer.json` is the VS Code experience layer.
-- Privileged/host-style access is intentionally enabled for local robotics development.
+The simulator speaks the same DDS topics as the real robot, so the bridge layer, the navigation
+stack and the control-authority logic all carry over to hardware without code changes. Moving to
+the physical G1 is a domain-ID and interface change, not a rewrite.
 
-## What This Gives You
+## What it does today
 
-- Stable in-container paths:
-  - Workspace: `/root/workspace`
-  - Shared data: `/root/data`
-- Small custom Dockerfile layer for project-specific dependencies.
-- GPU + GUI support (NVIDIA + X11).
-- Root-level, single-source tooling config for clangd, clang-format, and Ruff.
+The robot maps a facility with SLAM Toolbox, localizes against the saved map, and drives itself to
+a goal pose under Nav2. Arm trajectories run through `ros2_control` onto Unitree's weight-blended
+`rt/arm_sdk` interface, so the vendor's onboard controller keeps the legs balanced throughout.
 
-## Prerequisites
+Manipulation is the next milestone and is not built yet.
 
-- Docker Engine and Docker Compose
-- (Optional for GPU) NVIDIA Container Toolkit
-- VS Code with Dev Containers extension
+## Architecture
 
-## Single-Point Runtime Config (`.env`)
+```mermaid
+flowchart TB
+    OP(["ros2 launch g1_bringup bringup.launch.py"])
 
-Copy once, then edit only `.env` for distro/image/container naming knobs:
+    subgraph NAVL["Navigation"]
+        SCAN["pointcloud_to_laserscan"]
+        SLAM["slam_toolbox<br/>or map_server + AMCL"]
+        NAV2["Nav2<br/>planner, controller, BT"]
+        SHAPE["g1_gait_shaper"]
+        AUTH["g1_loco_authority"]
+    end
+
+    subgraph STATE["State estimation"]
+        ODOM["g1_odometry_publisher"]
+    end
+
+    subgraph CTRL["Bridging and control"]
+        BRIDGE["g1_loco_bridge"]
+        ARMSYS["G1ArmSdkSystem<br/>ros2_control plugin"]
+    end
+
+    subgraph SIMONLY["Simulation only"]
+        MSS["motion_service_sim<br/>stands in for the<br/>onboard motion service"]
+        RELAY["g1_sensor_relay"]
+        MJ["unitree_mujoco"]
+    end
+
+    OP --> NAVL
+    OP --> CTRL
+    OP --> SIMONLY
+
+    RELAY -- "/livox/lidar" --> SCAN
+    SCAN -- "/scan" --> SLAM
+    SLAM -- "map to odom" --> NAV2
+    ODOM -- "odom to base_footprint" --> NAV2
+    NAV2 -- "/cmd_vel" --> SHAPE
+    SHAPE --> BRIDGE
+    AUTH -. "acquires authority<br/>before any motion" .-> BRIDGE
+    BRIDGE -- "/api/sport/request" --> MSS
+    ARMSYS -- "/arm_sdk" --> MSS
+    MSS -- "/lowcmd" --> MJ
+    MJ -- "/lowstate, /sportmodestate" --> MSS
+    MJ --> RELAY
+    MJ -- "/sportmodestate" --> ODOM
+```
+
+On hardware the whole "simulation only" group disappears, and the vendor's onboard motion service
+answers `/api/sport/*` and `/arm_sdk` instead. Nothing above that line changes.
+
+Two rules shape most of the design, and both apply in simulation so the habits transfer:
+
+- Only one publisher ever commands a low-level channel. Control-mode ownership is explicit.
+- Arm and locomotion motion goes through `rt/arm_sdk`, which blends against the onboard balance
+  controller. Commanding raw `/lowcmd` means owning balance yourself.
+
+## Packages
+
+| Package | What it does |
+|---|---|
+| [`g1_bringup`](workspace/src/g1_bringup) | The entry point. Launch files, scenes and config that compose everything below. |
+| [`g1_description`](workspace/src/g1_description) | Vendored G1 URDF plus the `ros2_control` xacro wrapper. |
+| [`g1_hardware_interface`](workspace/src/g1_hardware_interface) | `ros2_control` plugin bridging the 14 arm joints onto `rt/arm_sdk`. |
+| [`g1_locomotion`](workspace/src/g1_locomotion) | LocoClient bridge, gait shaper and the locomotion-authority bracket. |
+| [`g1_motion_service_sim`](workspace/src/g1_motion_service_sim) | Simulation stand-in for the robot's onboard motion service. |
+| [`g1_msgs`](workspace/src/g1_msgs) | The `SetLocoMode` action and `LocoStatus` message. |
+| [`g1_navigation`](workspace/src/g1_navigation) | SLAM Toolbox mapping, AMCL localization and Nav2. |
+| [`g1_sensor_relay`](workspace/src/g1_sensor_relay) | Publishes LiDAR and depth frames sampled inside the simulator. |
+| [`g1_sim`](workspace/src/g1_sim) | A separate planar perception sandbox. Not the main track. |
+| [`g1_state_estimation`](workspace/src/g1_state_estimation) | Publishes `odom` to `base_footprint` and the TF chain Nav2 needs. |
+
+## Quick start
+
+Everything runs inside the dev container. The host is Ubuntu 24.04; the container provides the
+Ubuntu 22.04 and ROS 2 Humble combination the Unitree SDK needs.
 
 ```bash
 cp .env.example .env
-```
-
-Main variables:
-
-- `ROS_DISTRO` (for example: `jazzy`, `humble`)
-- `BASE_IMAGE_REPO`
-- `BASE_IMAGE_TAG_SUFFIX`
-- `DEV_IMAGE_REPO`
-- `CONTAINER_PREFIX`
-- `COMPOSE_PROJECT_NAME`
-
-## Source Repositories (`.repos`)
-
-This template keeps real ROS packages in separate repos and assembles them into `workspace/src` using a manifest file.
-
-1) Edit `workspace.repos` with your repo URLs and branches.
-2) Import sources (run on host or inside the container):
-
-```bash
-vcs import workspace/src < workspace.repos
-```
-
-To update to the latest branch tips later:
-
-```bash
-cd workspace/src
-vcs pull
-```
-
-Commits happen inside each repo under `workspace/src`. The template repo only tracks the manifest.
-
-If `vcs` is missing, install once:
-
-```bash
-sudo apt-get install -y python3-vcstool
-```
-
-## Daily Workflow (Recommended)
-
-### 1) Start the environment
-
-```bash
 ./scripts/manage.sh start
-```
-
-After startup, the script prints `docker compose ps` so the resolved container name is immediately visible.
-
-### 2) Open in VS Code container
-
-1. Open this repository in VS Code.
-2. Run `Dev Containers: Reopen in Container`.
-3. Work inside `/root/workspace`.
-
-This is the primary flow for consistent extensions and settings.
-
-Fallback: if the service is already running and you prefer attach mode, use `Dev Containers: Attach to Running Container...` and select the container shown by `docker compose ps`.
-
-### 3) Use multiple ROS terminals
-
-Open as many integrated terminals as you need (`Terminal -> New Terminal`), then run:
-
-```bash
-source /opt/ros/${ROS_DISTRO}/setup.bash
-[ -f /root/workspace/install/setup.bash ] && source /root/workspace/install/setup.bash
-```
-
-Now each terminal is ready for ROS commands, nodes, launch files, bag tools, and debugging.
-
-### 4) Build
-
-Use `Ctrl+Shift+B` (task: `colcon build (R)`) or run:
-
-```bash
-source /opt/ros/${ROS_DISTRO}/setup.bash
-cd /root/workspace
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-```
-
-## Compose Runtime Contract
-
-`docker-compose.yml` keeps host-oriented robotics access enabled by default:
-
-- `privileged: true`
-- `network_mode: host`
-- `ipc: host`
-- `pid: host`
-- `/dev` bind mount
-- `/tmp/.X11-unix` bind mount
-- NVIDIA GPU reservation
-
-### Base vs Derived Image
-
-- Base image (upstream): `${BASE_IMAGE_REPO}:${ROS_DISTRO}${BASE_IMAGE_TAG_SUFFIX}`
-- Derived dev image (this repo build): `${DEV_IMAGE_REPO}:${ROS_DISTRO}`
-
-The derived image is built using `.devcontainer/Dockerfile` and is where you add project-specific dependencies.
-
-## Mounts
-
-| Host Path | Container Path | Purpose |
-|---|---|---|
-| `./workspace` | `/root/workspace` | ROS 2 workspace |
-| `./data` | `/root/data` | Shared files (bags, datasets, configs) |
-| `./.vscode` | `/root/workspace/.vscode` | VS Code workspace config |
-| `./.clangd` | `/root/workspace/.clangd` | clangd config |
-| `./.clang-format` | `/root/workspace/.clang-format` | C/C++ format style |
-| `./ruff.toml` | `/root/workspace/ruff.toml` | Ruff lint/format config |
-| `${HOME}/.ssh` | `/root/.ssh` (ro) | SSH credentials |
-| `/dev` | `/dev` | Hardware device access |
-| `/tmp/.X11-unix` | `/tmp/.X11-unix` | GUI socket |
-
-## Dev Container Behavior
-
-`.devcontainer/devcontainer.json` is configured to:
-
-- Use Compose service `ros-dev`
-- Open `/root/workspace`
-- Start required service(s)
-- Keep container running when VS Code closes (`"shutdownAction": "none"`)
-- Auto-install recommended extensions in the container
-
-## Tooling Setup
-
-### C++
-
-- `clangd` is the primary language server.
-- `C_Cpp.intelliSenseEngine` is disabled to avoid dual-diagnostics conflicts.
-- C/C++ formatting uses the `xaver.clang-format` VS Code extension + `.clang-format`.
-- Format-on-save is intentionally disabled.
-- Manual formatting: `Format Document` (`Ctrl+Shift+I` on Linux).
-- Build task exports `compile_commands.json` for accurate indexing.
-
-### Python
-
-- Ruff is the default formatter.
-- Format-on-save is intentionally disabled.
-- Manual formatting: `Format Document` (`Ctrl+Shift+I` on Linux).
-- Ruff fix/import actions are available manually from code actions / command palette.
-- `ruff.toml` uses `src`-based detection for first-party import resolution:
-  - `src = ["workspace/src", "src"]`
-
-## Management Script
-
-Use `scripts/manage.sh` for lifecycle operations:
-
-```bash
-./scripts/manage.sh start
-./scripts/manage.sh stop
-./scripts/manage.sh restart
-./scripts/manage.sh recreate
-./scripts/manage.sh logs
 ./scripts/manage.sh exec
 ```
 
-`exec` uses Compose service targeting (`docker compose exec ros-dev bash`), so it stays consistent across ROS distro changes via environment or `.env`.
-`start` and `recreate` also print `docker compose ps` to show the active container name and state.
-
-## Dockerfile Customization
-
-Add project dependencies to `.devcontainer/Dockerfile` (this derived layer), then rebuild:
+Inside the container:
 
 ```bash
-./scripts/manage.sh recreate
+cd /root/workspace
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+source install/setup.bash
 ```
 
-## Data Folder Usage
-
-Anything in `./data` on host is available at `/root/data` in container.
-
-Example:
+Then bring up the robot. One command covers every mode:
 
 ```bash
-cp ~/Downloads/my_recording.db3 ./data/
+# Simulator only
+ros2 launch g1_bringup bringup.launch.py
+
+# Build a map, with RViz
+ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
+
+# Localize against the committed map and navigate
+ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
 ```
 
-Inside container:
+Send it somewhere:
 
 ```bash
-ros2 bag play /root/data/my_recording.db3
+ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
+  "{pose: {header: {frame_id: map}, pose: {position: {x: 2.5, y: -2.5}, orientation: {w: 1.0}}}}"
 ```
 
-## Debug Launch Template
+## Development environment
 
-`.vscode/launch.json` includes a template launch entry. Replace:
+Docker Compose is the runtime source of truth; `.devcontainer/devcontainer.json` is the VS Code
+layer on top. In VS Code, use `Dev Containers: Reopen in Container`.
 
-- `src/<your_package>/launch/<your_launch_file>.launch.py`
+| Setting | Value |
+|---|---|
+| ROS distro | Humble, pinned. Unitree tests only Foxy and Humble. |
+| Middleware | CycloneDDS, pinned to loopback |
+| `ROS_DOMAIN_ID` | 1 |
+| C++ standard | C++20 on GCC 11.4 |
+| Workspace | `/root/workspace` |
+| Shared data | `/root/data` |
 
-with your package-specific launch file path.
+The container runs `privileged` with `network_mode: host` and a `/dev` bind mount. That is
+deliberate for local robotics development: DDS discovery between the bare-DDS simulator and the
+ROS graph happens over loopback, and device access has to work.
 
-## Troubleshooting
-
-### GUI apps do not open
+Lifecycle:
 
 ```bash
-xhost +local:docker
+./scripts/manage.sh start | stop | restart | recreate | logs | exec
 ```
 
-### GPU not visible
+Use `exec-as-me` instead of `exec` for anything that rewrites source files in place, such as
+`clang-tidy --fix` or `clang-format -i`. It runs as your host user, so the files do not come back
+owned by root.
+
+Project dependencies belong in `.devcontainer/Dockerfile`, followed by
+`./scripts/manage.sh recreate`. Do not install into a running container and forget about it.
+
+## Tests
 
 ```bash
-docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
+colcon test --packages-select g1_description g1_locomotion g1_navigation
+colcon test-result --all
 ```
 
-### Validate Compose config
+Suites that launch a simulator are timing-sensitive and serialize on a shared ctest resource lock.
+On a loaded machine the walking suites can fail without anything being wrong, so re-run a failing
+suite alone before treating it as a regression. Each package README says which of its tests need a
+simulator.
 
-```bash
-docker compose config
+## Repository layout
+
+```
+.devcontainer/     derived dev image
+workspace/src/     ROS 2 packages
+workspace/patches/ patches applied to vendored sources at image build
+workspace/vendor/  our source compiled into the vendored simulator
+scripts/           container lifecycle
 ```

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -1,101 +1,70 @@
 # g1_bringup
 
-Sim bring-up for the G1 stack. Launches `unitree_mujoco` alongside the `ros2_control` stack
-(`g1_description` + `g1_hardware_interface`), `g1_locomotion`'s bridge, and
-`g1_motion_service_sim`'s sim-only stand-in for the robot's onboard motion service.
+The entry point for the whole stack. Launch files, scenes, config and two ordering scripts. No
+compiled code of its own.
 
-Launch files, config, scenes and scripts only -- no compiled code of its own. `ament_cmake`,
-with Python launch files and integration tests.
+`ament_cmake`, Python launch files and integration tests.
 
-## Launch files and nodes
+```mermaid
+flowchart LR
+    B["bringup.launch.py"]
+    B -->|"mode:=none"| S["sim.launch.py"]
+    B -->|"mode:=mapping<br/>mode:=localization"| N["g1_navigation<br/>nav_sim.launch.py"]
+    B -->|"rviz:=true"| R["rviz.launch.py"]
+    N --> S
+    S --> C["control.launch.py"]
+    S --> L["loco.launch.py"]
+    S --> MJ["unitree_mujoco +<br/>motion_service_sim"]
+```
+
+## Launch files
 
 | File | Purpose |
 |---|---|
-| `launch/bringup.launch.py` | **The operator entry point.** Routes to bare sim or, via `mode:`, to the navigation stack. Args: `mode` (`none`/`mapping`/`localization`), `nav`, `rviz`, `sensors`, `world`, `headless`, `pin_pelvis`, `sim_start_delay_s`. |
-| `launch/sim.launch.py` | Checks the DDS environment, then starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Still works standalone. Args: `headless` (default `true`), `sensors` (default `false`), `pin_pelvis` (default `false`), `sim_start_delay_s` (default `2.0`). |
-| `launch/rviz.launch.py` | Starts RViz on a caller-supplied `rviz_config` path. Knows nothing about navigation. |
-| `launch/control.launch.py` | `robot_state_publisher`, `ros2_control_node` and spawners. No sim, no bridge, so it carries over to hardware unchanged. |
-| `launch/loco.launch.py` | Starts `g1_loco_bridge` and drives it configure to active off its own lifecycle events. |
-| `launch/activate_arm.launch.py` | Runs `scripts/activate_arm`, the ordered acquire step. |
-| `launch/deactivate_arm.launch.py` | Runs `scripts/deactivate_arm`, the ordered release step. |
+| `bringup.launch.py` | What an operator runs. Routes to bare simulator or the navigation stack. |
+| `sim.launch.py` | Starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Checks the DDS environment first. Works standalone. |
+| `control.launch.py` | `robot_state_publisher`, `ros2_control_node` and the spawners. No simulator, so it carries to hardware unchanged. |
+| `loco.launch.py` | Starts `g1_loco_bridge` and drives it from configure to active. |
+| `rviz.launch.py` | Starts RViz on a caller-supplied `rviz_config` path. |
+| `activate_arm.launch.py` | Runs `scripts/activate_arm`, the ordered acquire step. |
+| `deactivate_arm.launch.py` | Runs `scripts/deactivate_arm`, the ordered release step. |
 
-This package starts nodes it does not own. `motion_service_sim` is
-`g1_motion_service_sim`'s, `g1_loco_bridge` is `g1_locomotion`'s, and the sensor and odometry
-nodes belong to `g1_sensor_relay` and `g1_state_estimation`.
+## Arguments
 
-### Topics
+All of these belong to `bringup.launch.py`.
 
-`g1_hardware_interface`'s README covers `/lowstate` and `/arm_sdk`;
-`g1_motion_service_sim`'s covers `/lowcmd`, `/api/sport/*` and the lower-body `/joint_states`.
-What this package's own launch graph adds on top:
-
-| Topic | Direction | Type | QoS |
-|---|---|---|---|
-| `/robot_description` | out | `std_msgs/msg/String` | transient-local |
-| `/livox/lidar` | out | `sensor_msgs/msg/PointCloud2` | sensor data, `sensors:=true` only |
-| `/g1_sensor_relay/sensor_pose` | out | `geometry_msgs/msg/PoseStamped` | sensor data, diagnostics |
-| `/tf` (`odom` -> `pelvis`) | out | `tf2_msgs/msg/TFMessage` | `sensors:=true` only |
-
-## `g1_navigation` is referenced but deliberately not depended on
-
-`bringup.launch.py` includes launch files and an RViz config from `g1_navigation`, and
-`package.xml` says nothing about it. That is not an oversight.
-
-`g1_navigation` already declares `<exec_depend>g1_bringup</exec_depend>`, because navigation
-composes bring-up and not the reverse. Adding the reciprocal dependency here does not merely
-look untidy, it **does not build** — colcon refuses to order the workspace at all:
-
-```
-ERROR:colcon:colcon list: Unable to order packages topologically:
-g1_bringup: ['g1_navigation']
-g1_navigation: ['g1_bringup']
-```
-
-So the reference is a launch-time path lookup and nothing more. What follows from that:
-
-- This package builds, installs and runs with `g1_navigation` absent. Only `mode:=mapping`
-  and `mode:=localization` name it, and their absence is reported as an actionable message
-  rather than a raw ament search-path dump.
-- **colcon and rosdep cannot see this edge.** Nothing warns you if `g1_navigation` renames a
-  launch file; `mode:=mapping` fails at runtime instead. `test_launch_threading` in
-  `g1_navigation` is the compensating check — it lives there because a `test_depend` pointing
-  the other way would re-create the same cycle.
-- Do not "fix" this by adding the dependency. Its absence is load-bearing.
-
-The composition direction is unchanged: on the navigation branch this package includes
-`g1_navigation`'s `nav_sim.launch.py`, which includes `sim.launch.py` itself.
-`bringup.launch.py` routes; it does not orchestrate navigation.
+| Argument | Default | Meaning |
+|---|---|---|
+| `mode` | `none` | `none` is the simulator alone. `mapping` adds the scan pipeline and slam_toolbox. `localization` adds `map_server` and AMCL. |
+| `nav` | `false` | Start Nav2, the gait shaper and the authority bracket. Needs `mode:=localization`. |
+| `rviz` | `false` | Open RViz on the config that matches the mode. |
+| `sensors` | `false` | LiDAR, the relay and the `odom` to `base_footprint` chain. The navigation modes turn this on themselves. |
+| `world` | `navigation` | Which scene to stage. `navigation` is the facility the committed map was built from. |
+| `headless` | `true` | `false` shows the MuJoCo viewer. |
+| `pin_pelvis` | `false` | Welds the pelvis and disables the walking policy, for exercising the arm bridge alone. `mode:=none` only. |
+| `sim_start_delay_s` | branch default | Seconds to delay the simulator. Empty means 2.0 for `mode:=none`, 4.0 for the navigation modes. |
 
 ## Running
 
 ```bash
-# Bare simulator.
-ros2 launch g1_bringup bringup.launch.py
-
-# Build a map, with RViz.
-ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
-
-# Localize against the committed map and navigate.
+ros2 launch g1_bringup bringup.launch.py                                      # simulator only
+ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true             # build a map
 ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
 ```
 
-`mode:=none` is the default and never touches `g1_navigation`. The arm procedure below uses
-`sim.launch.py` directly, which is equivalent to `bringup.launch.py` with the default mode:
+Arms, in order. The order is mandatory: Humble ties command-interface availability to hardware
+component state, so activating the controller before the component can fail the switch.
 
 ```bash
-# 1. Bring up sim + bridge + control stack (headless by default).
-ros2 launch g1_bringup sim.launch.py
-
-# 2. Once settled, acquire arm control authority (component, then controller).
 ros2 launch g1_bringup activate_arm.launch.py
-
-# 3. Command the arms, e.g. a FollowJointTrajectory goal to arm_trajectory_controller.
-
-# 4. Release in reverse order before tearing down.
+# send a FollowJointTrajectory goal to arm_trajectory_controller
 ros2 launch g1_bringup deactivate_arm.launch.py
 ```
 
-To walk the robot, reach FSM `Start` first, then publish velocity:
+`deactivate_arm.launch.py` blocks for about two seconds while the blend weight ramps to zero. That
+is the ramp, not a hang. Ctrl-C is also safe.
+
+Walking by hand needs FSM `Start` first:
 
 ```bash
 ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 4}"
@@ -104,207 +73,58 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args \
   -r /cmd_vel:=/g1_loco_bridge/cmd_vel -p speed:=0.6 -p turn:=1.57
 ```
 
-Both teleop overrides matter. The package defaults are `speed=0.5`, which only just clears the
-0.40 m/s threshold, and `turn=1.0`, which does not clear the 1.50 rad/s in-place yaw threshold at
-all, so the robot will not turn on the spot with it. `1.57` is the bridge's yaw ceiling. Note that
-`q` and `z` scale both speeds by 10%, so a few `z` presses drop you back under threshold and the
-gait stops.
+Both teleop overrides matter. The defaults sit inside the gait's dead zone and the robot will not
+move. See `g1_motion_service_sim` for the measured thresholds.
 
-### Ordering rules
+## g1_navigation is referenced but not depended on
 
-Acquire and release order is mandatory. Humble ties command-interface availability to hardware
-component state, so activating the controller before the component (or deactivating the component
-first) can fail the switch or strand a controller claiming interfaces. `activate_arm` and
-`deactivate_arm` encode the correct order.
+`bringup.launch.py` includes launch files and an RViz config from `g1_navigation`, and
+`package.xml` says nothing about it. That is deliberate. `g1_navigation` already depends on
+`g1_bringup`, so declaring the reverse makes colcon refuse to order the workspace at all.
 
-Deactivating before killing the launch is the documented clean stop. `deactivate_arm.launch.py`
-blocks for about `blend_ramp_down_s` (2.0 s) while the blend weight ramps to zero synchronously.
-That is by design, not a hang. Ctrl-C is also safe: `controller_manager` runs the component's
-`on_deactivate` before `on_shutdown`, and a dead sim tears down the whole launch rather than
-leaving controllers commanding nothing.
-
-## Domain and DDS
-
-The container runs on `ROS_DOMAIN_ID=1` with CycloneDDS pinned to `lo`, a dedicated local domain so
-a real robot on the network is never at risk of crosstalk. `unitree_mujoco`'s own `config.yaml`
-defaults to the same values, so its bare-DDS layer and the ROS graph see each other. Moving to
-hardware is a domain and interface change, not a code change. `sim.launch.py` asserts
-`RMW_IMPLEMENTATION`, `CYCLONEDDS_URI` and `ROS_DOMAIN_ID` up front and fails with an actionable
-message rather than leaving you to debug an empty graph.
-
-**Footgun:** `unitree_mujoco` is a native `unitree_sdk2` DDS app that links its own CycloneDDS from
-`/opt/unitree_robotics/lib`. Sourcing a ROS environment puts `/opt/ros/humble/lib` ahead of that on
-`LD_LIBRARY_PATH`, and because the binary uses `RUNPATH` (resolved after `LD_LIBRARY_PATH`), ROS's
-ABI-incompatible `libddsc.so.0` wins and the sim aborts on its first DDS write. `sim.launch.py`
-prepends the correct directory back for the sim process only.
-
-## The sim-only motion service
-
-`motion_service_sim` fills the three gaps `unitree_mujoco` leaves: it serves the weight-blended
-`/arm_sdk` interface, answers the `/api/sport/*` LocoClient protocol, and runs the walking policy
-that balances the robot. **Never launch it near real hardware.** `sim.launch.py` is the only thing
-that starts it.
-
-It lives in **`g1_motion_service_sim`**, whose README carries the arm blend and staleness policy,
-the FSM legality table and API dispatch, the walking policy's contract and provenance, and the
-measured gait deadband to read before commanding any velocity.
-
-## Sensors on the converged track: SIM-ONLY
-
-`sensors:=true` stages a room with known geometry, runs a LiDAR sweep **inside** the patched
-`unitree_mujoco`, and starts `g1_sensor_relay` to publish it as `PointCloud2` on `/livox/lidar`.
-`odom -> pelvis` comes from `g1_state_estimation` reading `/sportmodestate`.
-
-**It is off by default, provisionally.** With sensors on the walking suites pass, alone and under
-combined load, but `test_arm_command` misses its slew-limited convergence window. That was measured
-on a machine whose CPU was pinned at roughly 14% of peak clock (`powersave` governor, `quiet`
-platform profile), and the test is timing-sensitive, so the result is **unproven rather than a
-property of the sensor stack**. Re-measure on an unthrottled machine before drawing a conclusion.
-
-Keeping the default off in the meantime costs nothing: `test_lidar_geometry` enables sensors
-explicitly and passes, so the sensor path stays covered either way.
-
-**Why the sweep lives inside the simulator.** It needs the scene: geometry, meshes and current pose,
-all of which live in `mjData` inside that process. No DDS topic carries it, so no companion process
-can compute it. The finished cloud is what crosses the boundary, over a local socket.
-
-**Why a separate node publishes it.** `unitree_sdk2` and `rmw_cyclonedds` both call
-`dds_create_domain` unconditionally, and CycloneDDS allows exactly one explicit domain creation per
-domain id per process. They cannot coexist, in either order. So the simulator links no ROS at all and
-the relay owns the ROS side.
-
-**Frame is `mid360_link`, not `livox_frame`.** `g1_sim`, the planar sandbox, publishes in
-`livox_frame` because that is `livox_ros_driver2`'s own default, so swapping sim for hardware is a
-driver launch rather than a pile of remaps. The converged track cannot do the same: the frame is not
-ours to name. It comes from Unitree's vendored URDF, which calls the link `mid360_link`, and
-renaming it means patching a description we otherwise consume verbatim. Adding a second link as an
-alias would put two frames on one physical sensor, which is worse.
-
-So the portability principle moves **one layer up**. The real driver's frame id is a launch
-parameter, so hardware bring-up sets `livox_ros_driver2`'s `frame_id` to `mid360_link` (or remaps at
-launch) instead of the sim contorting to match a default. Same guarantee at the swap, enforced at
-launch rather than in the model.
-
-**What is not validated here:** the Mid360's non-repetitive scan pattern (this is a uniform
-azimuth/elevation grid), intensity, per-point timestamps, noise, dropout and motion distortion.
-
-### Known limitation: the viewer's Reload button is fatal with `sensors:=true`
-
-**Clicking Reload (or dragging a model onto the window) while sensors are running kills the
-simulator with SIGSEGV. Relaunch instead.** Drag-and-drop takes the same code path and is
-equally unsafe.
-
-The sampler reads the model outside `sim.mtx` on purpose: a ~4.5 ms render or ~32 ms sweep
-under the lock would stall physics. The reload path frees the model on the main thread, so
-no lock-based check can make it safe. The reload hook therefore stops the sampler with a
-blocking join before `mj_deleteModel` and never restarts it, logging `SENSORS DISABLED`.
-That much is verified: the first reload after launch is survivable and stops sensors
-cleanly.
-
-**A second reload still crashes**, after the sampler is already stopped and none of this
-code runs. The cause was not identified. Restarting the sampler against the new model was
-tried and also faulted intermittently, so it was removed rather than shipped.
-
-Accepted rather than fixed: Reload is a debugging-only button, the workaround is to
-relaunch, and sensors do not survive a reload either way.
-
-### D435i
-
-Depth and colour come from **one** `mjr_render` of the `d435i` fixed camera, so they share a pose,
-a timestamp and intrinsics by construction. A real D435i only gets that alignment from its
-`align_depth_to_color` step, which is why the depth topic is named as if it had run.
-
-| Topic | Type | Notes |
-|---|---|---|
-| `/camera/aligned_depth_to_color/image_raw` | `Image` `32FC1` | metres; misses are NaN, not 0 |
-| `/camera/color/image_raw` | `Image` `rgb8` | |
-| `/camera/aligned_depth_to_color/camera_info`, `/camera/color/camera_info` | `CameraInfo` | same intrinsics; `fovy` is carried in the frame so they cannot drift from the MJCF |
-
-Published in `camera_depth_optical_frame` / `camera_color_optical_frame`, the REP-145 optical frames
-added by `g1_description`. **Not `d435_link`:** that is a body frame (x forward, y left, z up) and
-every depth consumer assumes the optical convention (z forward, x right, y down), so publishing in
-the link projects the cloud rotated 90 degrees.
-
-**What is not validated here:** depth noise, stereo dropout on textureless surfaces, IR projector
-behaviour, auto-exposure and colour response. One MuJoCo camera carries one set of intrinsics, so
-the colour stream matches the *depth* FOV rather than a real D435i's wider colour FOV.
-
-## Pelvis pin: debugging aid
-
-`pin_pelvis` defaults `false`. Setting it true welds the pelvis to the world **and** disables the
-walking policy: the weld and the policy are the two possible owners of the legs and are never both
-active. Keep it for exercising the arm bridge with nothing else driving the legs.
-
-The weld is a `weld` equality constraint (not `connect`, which would still allow toppling rotation)
-in `mjcf/g1_pinned_scene.xml`, an overlay that composes the vendored G1 model via `<include>`. The
-vendored files are not modified. It constrains the pelvis body only, so all 29 actuated joints stay
-driven via `/lowcmd`. The overlay is copied next to the vendored model at launch and removed on
-shutdown, because MuJoCo 3.3.6 does not reliably resolve the model's relative `meshdir` when the
-including file lives elsewhere.
+The reference is a launch-time path lookup. This package builds and runs with `g1_navigation`
+absent; only the two navigation modes name it, and their absence is reported as an actionable
+message. Nothing will warn you if `g1_navigation` renames a launch file, so `test_launch_threading`
+in that package is the compensating check.
 
 ## Configuration
 
-`motion_service_sim.yaml` and `walk_policy.yaml` moved to `g1_motion_service_sim` with the node
-that reads them; `sim.launch.py` still passes both. The three files here are the ones this
-package's own launch graph owns.
+| File | Contents |
+|---|---|
+| `config/controllers.yaml` | `controller_manager` at 200 Hz. `G1ArmSdkSystem` starts inactive, `joint_state_broadcaster` active. |
+| `config/sim_sensors.yaml` | LiDAR and camera parameters read by the patched simulator. |
+| `config/g1_sensors.rviz` | RViz for `mode:=none`. Fixed frame `odom`. |
+| `mjcf/*.xml` | Six scene overlays. Staged next to the vendored model at launch and removed on shutdown. |
 
-`config/controllers.yaml`: `controller_manager` at 200 Hz. `G1ArmSdkSystem` starts inactive.
-`joint_state_broadcaster` is spawned active, `arm_trajectory_controller` inactive, covering the 14
-arm joints with relaxed sim tolerances. Re-tighten those against real hardware dynamics.
-
-Hand joints stay inert. `g1_description`'s URDF includes the DEX3 joints for kinematic structure,
-but they get no `ros2_control` interfaces and `unitree_mujoco`'s MJCF has no hand joints at all.
+Hand joints stay inert. The URDF includes the DEX3 joints for kinematic structure, but they get no
+`ros2_control` interfaces and the simulator's model has no hand joints.
 
 ## Tests
 
-| Test | Kind | Covers |
+| Test | Needs a simulator | Covers |
 |---|---|---|
-| `test_sim_bringup` | launch | Bring-up topics, rates, controller and component states (welded). |
-| `test_arm_command` | launch | Ordered activation, weight ramp, closed-loop trajectory, slew clamp, rogue-publisher guard (welded). |
-| `test_loco` | launch | LocoClient protocol end to end over DDS (welded). |
-| `test_walk_stand` | launch | The policy stands the robot up unwelded and holds it. Entry transient bounded, single `/lowcmd` writer. |
-| `test_walk_teleop` | launch | The real authority path: `7301` before `Start`, dead-man, Damp release, randomized and whiplash sequences. |
-| `test_walk_and_arm` | launch | Acceptance: walking under `cmd_vel` while an arm trajectory converges, one session. |
-| `sim_settle_gap` | ctest | A 5 s sleep holding the sim resource lock so each DDS graph drains. |
-| `ruff_check_g1_bringup` | ctest | Python lint and import order. |
-
-Every suite here launches `sim.launch.py`, which is why they stay in this package rather than
-following `motion_service_sim`'s source: `g1_bringup` depends on `g1_motion_service_sim`, so
-hosting them there would be a dependency cycle. They also share one `RESOURCE_LOCK`, and ctest
-only honours that within a single invocation. The pure unit tests that need no simulator went
-with their source.
+| `test_sim_bringup` | yes | Bring-up topics, rates, controller and component states. |
+| `test_arm_command` | yes | Ordered activation, weight ramp, closed-loop trajectory, slew clamp. |
+| `test_loco` | yes | LocoClient protocol end to end over DDS. |
+| `test_walk_stand` | yes | The policy stands the robot up unwelded and holds it. |
+| `test_walk_teleop` | yes | Rejection before `Start`, the dead-man, Damp release, randomized sequences. |
+| `test_walk_and_arm` | yes | Walking under `cmd_vel` while an arm trajectory converges. |
+| `test_lidar_geometry` | yes | The LiDAR measures the room it is in. |
+| `ruff_check_g1_bringup` | no | Python lint and import order. |
 
 ```bash
-colcon build --symlink-install --packages-select g1_bringup
 colcon test --packages-select g1_bringup
 colcon test-result --verbose
 ```
 
-### Load sensitivity: read before trusting a red full-suite run
-
-Every launch suite starts a real `unitree_mujoco`. The sim syncs its clock to CPU time and re-syncs
-when it falls behind, while the walking policy is paced on a wall timer, so on a loaded machine the
-two drift apart and the robot can topple. The leading hypothesis is a harness limitation rather than
-a policy defect, stated as a hypothesis deliberately, since inspection on this path has already
-produced two real defects.
-
-**A full sweep does not reliably pass.** Suites that fail inside
-`colcon test --packages-select g1_bringup` pass every time they are run alone. The isolated pass is
-the current evidence of correctness, alongside hand-verified walking, teleop and arm motion in the
-GUI. Do not treat a green full sweep as a precondition for trusting this package.
-
-Mitigations are deliberately lightweight: `RESOURCE_LOCK` serialises the suites, a settle gap lets
-each DDS graph drain, and `COST` ordering puts `test_walk_stand` last so the core balance claim runs
-on the quietest machine. Real isolation belongs with the deferred CI work. Re-run a failing suite
-alone before treating it as a regression:
+Every suite here starts a real `unitree_mujoco` and they serialize on a shared resource lock. The
+simulator syncs to CPU time while the walking policy runs on a wall timer, so on a loaded machine
+the two drift and the robot can topple. Re-run a failing suite alone before calling it a
+regression:
 
 ```bash
 colcon test --packages-select g1_bringup --ctest-args -R test_walk_stand
 ```
 
-## Language
-
-All Python, and no C++ at all since `motion_service_sim` moved out. ROS 2 provides no C++ path for
-launch or `launch_testing`, and the `activate_arm`/`deactivate_arm` scripts are one-shot sequencing
-tools rather than control loops. Nothing here runs at control rate; the packages this one launches
-carry that.
+The launch suites live here rather than with the node sources they exercise because they all
+include this package's `sim.launch.py`, and hosting them elsewhere would be a dependency cycle.

--- a/workspace/src/g1_description/README.md
+++ b/workspace/src/g1_description/README.md
@@ -1,164 +1,68 @@
 # g1_description
 
-Unitree G1 robot description: a vendored, kinematics-only URDF plus a xacro wrapper that adds the
-`ros2_control` block for the 14 arm joints. No compiled code. `ament_cmake`, install-only.
+The Unitree G1 robot description: a vendored, kinematics-only URDF plus a xacro wrapper that adds
+the `ros2_control` block for the arms.
+
+`ament_cmake`, no compiled code.
+
+```mermaid
+flowchart LR
+    V["g1_29dof_with_hand_rev_1_0.urdf<br/>vendored, unmodified"] --> X
+    P["arm_sdk_params.yaml"] -- "xacro.load_yaml" --> X
+    X["g1_arm_sdk.urdf.xacro"] --> RSP["robot_state_publisher"]
+    X --> CM["controller_manager"]
+```
 
 ## Contents
 
-| Path | Purpose |
+| File | Purpose |
 |---|---|
 | `urdf/g1_29dof_with_hand_rev_1_0.urdf` | The vendored upstream description, unmodified. |
-| `urdf/g1_arm_sdk.urdf.xacro` | Wraps the vendored URDF via `xacro:include` and appends a `<ros2_control>` block for the arms only. |
-| `config/arm_sdk_params.yaml` | Every hardware-plugin tunable. Loaded with `xacro.load_yaml` and expanded into `<param>` tags, because Humble hardware plugins only receive parameters that way. |
-| `test/test_arm_sdk_xacro.py` | Expands the xacro, validates with `check_urdf`, asserts the `<ros2_control>` block holds exactly the 14 arm joints. |
+| `urdf/g1_arm_sdk.urdf.xacro` | Includes the vendored URDF and appends a `<ros2_control>` block for the arms only. |
+| `config/arm_sdk_params.yaml` | Every hardware-plugin tunable. |
+| `meshes/` | Vendored visual meshes, installed at configure time so the model renders in RViz. |
 
-## Inspecting the model
-
-```bash
-colcon build --symlink-install --packages-select g1_description
-source install/setup.bash
-
-xacro $(ros2 pkg prefix g1_description)/share/g1_description/urdf/g1_arm_sdk.urdf.xacro \
-  -o /tmp/g1_arm_sdk.urdf
-check_urdf /tmp/g1_arm_sdk.urdf
-```
-
-`check_urdf` prints the link tree and confirms the document parses. It does not need meshes. To
-look at actual geometry, use the MuJoCo GUI once `g1_bringup` launches the sim; that view loads
-`unitree_mujoco`'s own MJCF, independent of this package.
-
-```bash
-colcon test --packages-select g1_description
-colcon test-result --verbose
-```
+Parameters are loaded with `xacro.load_yaml` and expanded into `<param>` tags because Humble
+hardware plugins only receive parameters that way.
 
 ## Scope: arms only
 
-The `<ros2_control name="G1ArmSdkSystem" type="system">` block exports command and state interfaces
-for exactly the 14 arm joints (7 per arm: shoulder pitch/roll/yaw, elbow, wrist roll/pitch/yaw).
-Waist, legs and hands are deliberately absent and stay under the onboard controller.
+The `<ros2_control>` block covers the 14 arm joints and nothing else. Legs and waist belong to the
+onboard controller, which is what keeps the robot balanced; claiming them here would mean owning
+balance. The hand joints are present for kinematic structure but get no interfaces, and the
+simulated model has no finger degrees of freedom at all.
 
-`rt/arm_sdk` is a weight-blended channel that lets an external command drive the arms while the
-onboard controller keeps the legs balanced. Commanding waist, legs or hands through the same system
-would either do nothing or fight the balance controller. One `ros2_control` System per low-level
-channel, one publisher per channel, is the invariant this scope preserves.
+## Parameters
 
-**Hand joints are present but inert.** The DEX3 joints stay in the model for correct TF structure
-ahead of the hand-control milestone, but get no `ros2_control` interfaces: the hand has its own
-command API on the real robot. `unitree_mujoco`'s G1 MJCF has no hand joints and reports no hand
-feedback, so those TF frames have no live source until that milestone.
+`config/arm_sdk_params.yaml`:
 
-**No meshes.** The vendored URDF references meshes as plain relative paths, and they are not
-vendored here. This description exists for `robot_state_publisher`, `controller_manager` and TF,
-which need only link and joint kinematics. Meshes arrive when a later milestone needs them for
-RViz or MoveIt planning-scene collision checking. Until then any tool that tries to resolve those
-paths will fail to find them, which is expected.
-
-## Parameters (`config/arm_sdk_params.yaml`)
-
-| Param | Default | Meaning |
+| Parameter | Default | Meaning |
 |---|---|---|
-| `command_publish_rate` | 100.0 Hz | `/arm_sdk` publish rate, independent of the `controller_manager` update rate. |
+| `command_publish_rate` | 100.0 Hz | `/arm_sdk` publish rate, independent of the controller manager's update rate. |
 | `blend_ramp_up_s` | 2.0 s | Weight eases 0 to 1 on activate. |
 | `blend_ramp_down_s` | 2.0 s | Weight eases 1 to 0 on a clean deactivate. |
 | `emergency_ramp_down_s` | 0.5 s | Faster ramp on stale feedback or shutdown. Must fit inside the launch stack's SIGTERM window. |
 | `max_joint_velocity_rad_s` | 1.0 rad/s | Slew clamp on every commanded joint. |
 | `lowstate_timeout_ms` | 100 ms | `/lowstate` age beyond this trips the emergency ramp. |
 
-Per-joint motor indices come from Unitree's `G1Arm7JointIndex`: legs 0-11, waist 12-14, left arm
-15-21, right arm 22-28. The gains are Unitree's example-conservative values, a sim-safe starting
-point.
+The file also carries the per-joint motor index and gains. Motor indices are the Unitree DDS wire
+order and are not ours to renumber.
 
-| Joint | motor_index | kp | kd |
-|---|---|---|---|
-| `left_shoulder_pitch_joint` | 15 | 40 | 1 |
-| `left_shoulder_roll_joint` | 16 | 40 | 1 |
-| `left_shoulder_yaw_joint` | 17 | 40 | 1 |
-| `left_elbow_joint` | 18 | 40 | 1 |
-| `left_wrist_roll_joint` | 19 | 25 | 1 |
-| `left_wrist_pitch_joint` | 20 | 25 | 1 |
-| `left_wrist_yaw_joint` | 21 | 25 | 1 |
-| `right_shoulder_pitch_joint` | 22 | 40 | 1 |
-| `right_shoulder_roll_joint` | 23 | 40 | 1 |
-| `right_shoulder_yaw_joint` | 24 | 40 | 1 |
-| `right_elbow_joint` | 25 | 40 | 1 |
-| `right_wrist_roll_joint` | 26 | 25 | 1 |
-| `right_wrist_pitch_joint` | 27 | 25 | 1 |
-| `right_wrist_yaw_joint` | 28 | 25 | 1 |
+## Inspecting the model
 
-These are tunable in the YAML only, never hardcoded in the xacro or in plugin code.
-
-## Vendored URDF provenance
-
-- **Upstream:** https://github.com/unitreerobotics/unitree_ros, path `robots/g1_description/`
-- **Commit:** `d96d8f63ae17a7108d4f7229c00ef875ba7129c9`
-- **Variant:** `g1_29dof_with_hand_rev_1_0.urdf`
-
-Unitree ships several hand-equipped G1 variants. This one was chosen because
-`g1_29dof_lock_waist_with_hand_rev_1_0.urdf` fixes `waist_roll` and `waist_pitch`, giving only 27
-mobile joints; `g1_29dof_with_hand.urdf` carries an extra `waist_support_joint` not present in the
-`_rev_1_0` line; and the hand joints here are Unitree's DEX3 three-finger hand rather than the
-separate Inspire-hand URDFs also present upstream. All 3 waist joints are `revolute`, so this is
-the full 29-DoF body plus DEX3 hands.
-
-### Licence
-
-Upstream `unitree_ros` is BSD-3-Clause:
-
-```
-BSD 3-Clause License
-
-Copyright (c) 2016-2022 HangZhou YuShu TECHNOLOGY CO.,LTD. ("Unitree Robotics")
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```bash
+xacro workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro > /tmp/g1.urdf
+check_urdf /tmp/g1.urdf
 ```
 
-This package's own files (xacro wrapper, YAML, build files) are BSD-3-Clause to match.
+For actual geometry, use the MuJoCo viewer once `g1_bringup` launches the simulator, or RViz with
+`rviz:=true`.
 
-## Meshes
+## Tests
 
-The URDF names its visual meshes `package://g1_description/meshes/...`, but the STLs are **not
-vendored in this repo**. They ship with `unitree_mujoco`, which the container image installs, and
-`CMakeLists.txt` copies them into the package share at configure time.
+```bash
+colcon test --packages-select g1_description
+```
 
-Copied rather than committed: 32 MB of binary STL does not belong here when the image already
-carries it. If that directory is absent — a machine without the simulator installed — nothing is
-installed, the build still succeeds, and RViz simply draws no robot.
-
-Three links (`torso_link`, `waist_roll_link`, `waist_yaw_link`) are named `*_rev_1_0` in this
-revision of the description but ship unsuffixed in the vendored set, so they are aliased. Same
-links, adjacent revision; for a visualisation mesh that is fine.
-
-Before this, the URDF used relative paths (`filename="meshes/pelvis.STL"`), which RViz resolves as
-a **URL host**: about 174 lines of `Could not resolve host: meshes` per session and no robot drawn
-at all, even with the display disabled, because the display still fetches the description.
-
-**The fingers still do not render, and cannot.** The palms do, by fixed joints off the wrists, but
-the finger links need joint states and nothing publishes them: the simulated model has 30 joints
-and zero finger DoF. The URDF describes a robot with hands; the sim simulates one without.
-Publishing zeroed finger joints would put fabricated state on `/tf`, which is exactly what
-`g1_state_estimation` refuses to do with odometry.
+`test_arm_sdk_xacro` expands the xacro, validates it with `check_urdf`, and asserts the
+`<ros2_control>` block holds exactly the 14 arm joints. No simulator needed.

--- a/workspace/src/g1_hardware_interface/README.md
+++ b/workspace/src/g1_hardware_interface/README.md
@@ -1,184 +1,109 @@
 # g1_hardware_interface
 
-`ros2_control` `SystemInterface` plugin bridging standard joint command and state interfaces onto
-the Unitree G1's weight-blended `rt/arm_sdk` DDS channel, for the 14 arm joints only. Legs, waist
-and hands stay under the onboard controller at all times. This component never touches them and
-never publishes on raw `/lowcmd`.
+A `ros2_control` `SystemInterface` plugin that bridges standard joint command and state interfaces
+onto Unitree's weight-blended `rt/arm_sdk` DDS topic. Covers the 14 arm joints.
 
-`ament_cmake`, C++17.
+`ament_cmake`, C++20. This is real hardware code and runs unchanged against the physical G1.
 
-## Why this exists
+```mermaid
+flowchart LR
+    JTC["arm_trajectory_controller"] -- "position commands" --> P
+    subgraph P["G1ArmSdkSystem"]
+        RAMP["ArmRampEngine<br/>blend ramp + slew clamp"]
+    end
+    P -- "/arm_sdk<br/>weight in slot 29" --> MS["onboard motion service"]
+    MS -- "/lowstate" --> P
+```
 
-The G1's arms can be driven two ways: raw `/lowcmd`, where you become the whole-body balance
-controller, or `rt/arm_sdk`, which weight-blends your arm targets with the onboard controller's own
-arm behaviour while that controller keeps the legs balancing. This plugin exports standard
-`position` command and state interfaces for the 14 arm joints and translates them onto `/arm_sdk`,
-so a `joint_trajectory_controller` (or MoveIt Servo later) drives the arms like any other
-`ros2_control` manipulator without touching the balance loop.
+Commanding `rt/arm_sdk` rather than raw `/lowcmd` is what keeps the onboard controller balancing
+the legs. The weight in motor slot 29 tells it how much of the arm command to honour.
 
 ## Layout
 
-| Path | Contents |
+| File | Contents |
 |---|---|
-| `arm_ramp_engine.{hpp,cpp}` | Pure, ROS-free ramp and slew safety logic: blend-weight ramping, per-joint slew clamping, motor-index validation, stale-feedback escalation. Directly unit-testable. |
-| `g1_arm_sdk_system.{hpp,cpp}` | The plugin itself: parameters, lifecycle, DDS I/O, `LowCmd` assembly, threading contract. |
-| `motor_crc_hg.{hpp,cpp}` | Vendored CRC. See below. |
-| `g1_hardware_interface.xml` | pluginlib export description. |
+| `arm_ramp_engine.{hpp,cpp}` | Blend-weight ramping, per-joint slew clamping, motor-index validation, stale-feedback escalation. Pure and ROS-free, so it unit-tests directly. |
+| `g1_arm_sdk_system.{hpp,cpp}` | The plugin: parameters, lifecycle, DDS I/O, `LowCmd` assembly, threading. |
+| `motor_crc_hg.{hpp,cpp}` | Vendored CRC, byte-exact against Unitree's. |
+| `g1_hardware_interface.xml` | pluginlib export. |
 
-## Exported plugin and interfaces
+## Interfaces
 
-`g1_hardware_interface/G1ArmSdkSystem`, declared `type="system"` in the URDF.
-`g1_description`'s `g1_arm_sdk.urdf.xacro` wires it up including every `<param>`.
-
-Per arm joint (shoulder pitch/roll/yaw, elbow, wrist roll/pitch/yaw, both sides):
-
-| Interface | Direction | Source |
+| Interface | Kind | Source |
 |---|---|---|
-| `position` | command | Position-only. Mode switching is reserved for a later Servo velocity mode. |
-| `position` | state | `motor_state[motor_index].q` |
-| `velocity` | state | `motor_state[motor_index].dq` |
-| `effort` | state | `motor_state[motor_index].tau_est` |
-
-## Topics
+| `position` | command | Position only. Velocity mode is reserved for a later Servo path. |
+| `position` | state | `motor_state[i].q` |
+| `velocity` | state | `motor_state[i].dq` |
+| `effort` | state | `motor_state[i].tau_est` |
 
 | Topic | Direction | Type | QoS |
 |---|---|---|---|
 | `/lowstate` | in | `unitree_hg/msg/LowState` | best-effort, keep-last(1), volatile |
 | `/arm_sdk` | out | `unitree_hg/msg/LowCmd` | reliable, keep-last(1), volatile |
 
-`/lowstate` is best-effort so it matches either a best-effort or reliable publisher (the sim
-publishes reliable; hardware may differ), and only the newest of the 500 to 900 Hz stream matters.
-`/arm_sdk` is reliable because this component is the sole writer, so a dropped command should be
-retried rather than swallowed. Depth 1 because only the newest ramp tick matters.
-
-Nothing in sim subscribes `/arm_sdk`: `unitree_mujoco` emulates only the low-level device. Testing
-against the sim proves this plugin's own output (ramp shape, hold accuracy, rate, CRC, safety
-behaviour); `g1_motion_service_sim`'s node closes the loop kinematically for end-to-end tests.
-
 ## Parameters
 
-All parameters come from the URDF's `<ros2_control><hardware><param>` tags, routed from
-`g1_description/config/arm_sdk_params.yaml`. Humble hardware plugins only receive parameters parsed
-from `HardwareInfo`; `controller_manager`'s YAML never reaches them. `on_init` validates that every
-one is present, parseable and strictly positive, failing the component with a clear message
-otherwise.
-
-| Param | Meaning |
+| Parameter | Meaning |
 |---|---|
-| `command_publish_rate` | `/arm_sdk` publish rate, independent of `controller_manager`'s `update_rate`. |
-| `blend_ramp_up_s` | Weight eases 0 to 1 over this long on activate. |
-| `blend_ramp_down_s` | Weight eases 1 to 0 over this long on a clean deactivate. |
-| `emergency_ramp_down_s` | Faster ramp on stale feedback, error, or shutdown. |
-| `max_joint_velocity_rad_s` | Slew clamp on every commanded joint, independent of the weight ramp. |
-| `lowstate_timeout_ms` | `/lowstate` age beyond this is stale: blocks activation, and while active triggers the emergency ramp. |
+| `command_publish_rate` | `/arm_sdk` publish rate, independent of `controller_manager`'s update rate. |
+| `blend_ramp_up_s` | Weight eases 0 to 1 on activate. |
+| `blend_ramp_down_s` | Weight eases 1 to 0 on a clean deactivate. |
+| `emergency_ramp_down_s` | Faster ramp on stale feedback, error or shutdown. |
+| `max_joint_velocity_rad_s` | Slew clamp per joint, independent of the weight ramp. |
+| `lowstate_timeout_ms` | `/lowstate` age beyond this counts as stale. Blocks activation, and while active triggers the emergency ramp. |
 
-Per joint: `motor_index` (unique, within `[15, 28]`, the arm range of Unitree's
-`G1Arm7JointIndex`), `kp`, `kd`.
+Values live in `g1_description/config/arm_sdk_params.yaml`.
 
-## Safety and authority model
+## Running
 
-**Single writer by construction.** One `<ros2_control>` System means one `G1ArmSdkSystem`, the only
-thing here that publishes `/arm_sdk`. While active, a 1 Hz advisory timer counts publishers; a
-second one is logged and escalates the shared `mode_` atomic from `ACTIVE` to
-`EMERGENCY_RAMP_DOWN`, so the still-ticking `write()` drives the ramp itself. The timer never
-touches the ramp engine or publisher directly. Advisory only; real cross-process arbitration is a
-future behavior-tree concern.
+The plugin loads through `controller_manager`, so it comes up with the stack:
 
-**Self-gated, not framework-gated.** `write()` publishes only while the internal mode atomic says
-so. Humble's `controller_manager` still calls `write()` on an inactive component, so "commands only
-flow while active" is enforced here rather than assumed.
+```bash
+ros2 launch g1_bringup bringup.launch.py
+ros2 launch g1_bringup activate_arm.launch.py
+```
 
-**Ramp, never snap.** The blend weight (`motor_cmd[29].q`) eases 0 to 1 on activate and 1 to 0 on
-deactivate, error, shutdown or stale feedback, at a rate that is purely a function of the current
-mode each tick. A deactivate mid-ramp-up just changes direction from wherever the weight is,
-monotonically, with no special case. Every commanded position is independently slew-clamped from
-wherever it was last published.
+Acquire and release order is mandatory. Humble ties command-interface availability to hardware
+component state, so activating the controller before the component can fail the switch or strand a
+controller claiming interfaces. The `activate_arm` and `deactivate_arm` scripts encode the order.
 
-**Hold in place on activate.** `on_activate` requires a `/lowstate` sample fresher than
-`lowstate_timeout_ms` or fails with `ERROR` and publishes nothing. On success the measured arm
-position is written into the command interfaces, so `write()` always has a valid hold target before
-any controller sends a command.
+## Safety model
 
-**Stale feedback is self-protecting.** `write()` checks `/lowstate` age every tick and escalates to
-the emergency ramp on its own initiative, without waiting for `read()`'s `ERROR` or for `on_error`.
-`read()` still returns `ERROR` as belt and braces.
+The component starts inactive and never commands anything until something activates it. Weight
+ramps rather than snapping, in both directions, and a mid-ramp reversal is handled rather than
+restarted. Every commanded joint is slew-clamped independently of the weight, so a large trajectory
+step cannot become a large motion.
 
-**Lifecycle transitions own the ramp.** `on_deactivate`, `on_error` and `on_shutdown` run the
-ramp-down themselves, synchronously, via `rampDownSynchronously()`, which is reachable only from
-those three transitions. This is deliberate: `resource_manager` serialises a component's lifecycle
-transitions against its own `read()`/`write()` calls, so whichever holds the floor is unambiguously
-the sole writer for that window. The original design had the transition request a ramp via the
-shared atomic and block waiting for `write()`; that deadlocks in practice. The function also never
-de-escalates: if `write()` already escalated to the emergency ramp, a clean deactivate continues
-the faster ramp rather than downgrading it.
+Stale `/lowstate` blocks activation outright, and while active it escalates to the emergency ramp.
+The escalation is idempotent, so a flapping feedback stream cannot restart the ramp repeatedly.
 
-Consequence worth flagging: because transitions serialise against the whole read/write loop, a 2 s
-clean deactivate blocks the `controller_manager` cycle for that duration. Fine with one active
-component; re-examine when several exist.
-
-**Ordering.** Activate this component before `arm_trajectory_controller`, and deactivate the
-controller first. Humble ties command-interface availability to component state, so the reverse
-order can fail the switch. `g1_bringup`'s `activate_arm` and `deactivate_arm` enforce this.
-
-**Stopping.** Deactivate before killing the launch is the normal path. Killing the process while
-active still ramps down safely: `controller_manager` runs `on_deactivate` before `on_shutdown` on
-SIGINT/SIGTERM, so Ctrl-C exercises the clean ramp. `on_shutdown`'s emergency ramp is the fallback
-for a kill path that skips deactivate.
-
-**RT constraints.** `read()` and `write()` do no allocation (fixed-size arrays, a preallocated
-`LowCmd`), take no blocking locks (`trylock()`), throw nothing, and log nothing on the hot path.
-The lifecycle ramp deliberately runs off the RT path, so it may block and log.
+The CRC is vendored to match Unitree's implementation bit for bit, pinned by a `static_assert` on
+the message size. It computes exactly what the robot validates against, so it is not a place to
+tidy up.
 
 ## Threading
 
 | Thread | Does |
 |---|---|
-| `controller_manager` RT thread | `read()` and `write()` only. `read()` drains the `/lowstate` buffer via `readFromRT()`. `write()` throttles to `command_publish_rate` with a period-guard accumulator, while ramp and slew state advance every tick from the real elapsed period. |
-| Component's hidden node + `SingleThreadedExecutor` | Services the `/lowstate` subscription and the advisory timer. Started in `on_configure`, never added to `controller_manager`'s executor. `on_configure` bounded-waits for `is_spinning()` first, because Humble's `cancel()` and `spin()` write the same flag with no ordering guarantee and losing that race deadlocks the join. |
-| `RealtimePublisher`'s internal thread | The actual DDS publish, decoupled by trylock-copy-publish. |
-| Lifecycle callbacks | Whatever thread `resource_manager` uses, serialised against the RT thread. The deactivate paths block it for the ramp duration. |
+| `controller_manager` real-time thread | `read()` and `write()` only. `read()` drains the `/lowstate` buffer; `write()` throttles to `command_publish_rate` while ramp and slew state advance every tick from the real elapsed period. |
+| Node executor thread | The `/lowstate` subscription. |
+| `RealtimePublisher` thread | The DDS publish, decoupled by trylock, copy, publish. |
 
-## CRC
-
-Every outgoing `LowCmd` gets a CRC computed in `write()` using a vendored, unmodified copy of
-Unitree's routine (`unitreerobotics/unitree_ros2`, commit `668d1ec5`, BSD-3-Clause), wrapped in
-this package's namespace so a pluginlib-loaded `.so` cannot collide with another's global symbols.
-Unitree's own `g1_arm_sdk_dds_example` does not actually call this CRC on its `/arm_sdk` publishes.
-We compute it anyway since it costs nothing on the write path.
-
-`assembleLowCmd()` touches only the 14 arm slots and the weight slot; every other slot stays at its
-constructed zero. It does not set `mode_pr`, `mode_machine`, or any motor `mode` field, mirroring
-what Unitree's own arm_sdk example touches.
+The real-time path does not allocate, block or throw.
 
 ## Tests
 
-```bash
-colcon build --symlink-install --packages-select g1_hardware_interface
-colcon test --packages-select g1_hardware_interface
-colcon test-result --verbose
-```
+None of these need a simulator.
 
 | Test | Covers |
 |---|---|
 | `test_pluginlib_loading` | pluginlib discovery. |
-| `test_arm_ramp_engine` | Weight monotonicity and slope in both directions including a reversal mid-ramp, emergency ramp duration, slew clamp (exact at the boundary, independent per joint), seed-from-measured, motor-index validation, idempotent staleness escalation. |
-| `test_assemble_low_cmd` | Every non-arm, non-weight slot stays zero; arm slots get exactly `q`/`kp`/`kd`; the weight lands on `motor_cmd[29]`; mode fields untouched. |
+| `test_arm_ramp_engine` | Weight monotonicity and slope both directions including a mid-ramp reversal, emergency ramp duration, slew clamp at the boundary, seed-from-measured, motor-index validation, idempotent staleness escalation. |
+| `test_assemble_low_cmd` | Non-arm slots stay zero, arm slots get exactly `q`/`kp`/`kd`, the weight lands on slot 29, mode fields untouched. |
 
-No sim required. Plus `clang-format`, `ament_lint_cmake` and `xmllint`.
+```bash
+colcon test --packages-select g1_hardware_interface
+```
 
-End-to-end validation lives in `g1_bringup`'s `test_sim_bringup.launch.py` and
-`test_arm_command.launch.py`.
-
-### Measured against the sim
-
-Captured during manual validation against a headless `unitree_mujoco`:
-
-- `/lowstate` at about 900 Hz; `/joint_states` at the configured 200 Hz with real measured
-  positions.
-- Ramp-up 0 to 1 in about 1.99 s against a configured 2.0 s, at about 100.04 Hz publish rate
-  against a configured 100 Hz, with the commanded position held constant throughout.
-- Deactivate 1 to 0 in about 2.01 s, monotonic, publishing stopped immediately at zero.
-- Killing the sim while active: staleness past 100 ms triggered the autonomous emergency ramp on
-  `write()`'s own initiative, 1 to 0 in about 0.49 s against a configured 0.5 s.
-- A clean deactivate blocked for about 2.02 s end to end; `SIGTERM` while active ran
-  `on_deactivate` then `on_shutdown` with a clean exit.
+End-to-end validation against a live simulator lives in `g1_bringup`'s `test_sim_bringup` and
+`test_arm_command`.

--- a/workspace/src/g1_locomotion/README.md
+++ b/workspace/src/g1_locomotion/README.md
@@ -1,297 +1,128 @@
 # g1_locomotion
 
-The G1's `LocoClient` bridge. Translates `geometry_msgs/Twist` and `g1_msgs/SetLocoMode` goals into
-Unitree's `LocoClient` wire contract, two plain topics (`/api/sport/request` and
-`/api/sport/response`) carrying JSON-encoded `unitree_api::msg::Request`/`Response`, without ever
-blocking an executor callback on the DDS round trip.
+The G1's LocoClient bridge, plus the two nodes that make a planner's velocity output usable by the
+real gait. Everything here carries to hardware unchanged.
 
-`ament_cmake`, C++17 throughout.
+`ament_cmake`, C++20.
 
-Kept out of `g1_hardware_interface` deliberately: that package is the pluginlib `.so` loaded into
-`ros2_control_node`, and folding `unitree_api`, `nlohmann_json` and `rclcpp_action` in there would
-push those dependencies onto every consumer of the arm hardware interface.
-
-## Running
-
-Normally this comes up as part of the sim stack rather than standalone:
-
-```bash
-ros2 launch g1_bringup sim.launch.py
+```mermaid
+flowchart LR
+    NAV["Nav2"] -- "/cmd_vel" --> GS["g1_gait_shaper"]
+    GS -- "/g1_loco_bridge/cmd_vel" --> BR["g1_loco_bridge"]
+    LM["lifecycle manager"] --> AU["g1_loco_authority"]
+    AU -- "SetLocoMode<br/>StandUp then Start" --> BR
+    BR -- "/api/sport/request" --> RS["onboard motion service<br/>(motion_service_sim in sim)"]
+    RS -- "/api/sport/response" --> BR
+    BR -- "~/status" --> AU
 ```
 
-That includes this package's `loco.launch.py`, which starts `g1_loco_bridge` and drives it
-configure to active off the node's own lifecycle events. Once up:
+## Nodes
 
-```bash
-# Drive the FSM to Start. StandUp is a required intermediate hop.
-ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 4}"
-ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 500}"
-
-# Watch status. Transient-local, so this prints the latest immediately.
-ros2 topic echo /g1_loco_bridge/status
-
-# Drive forward once authority is HELD.
-ros2 topic pub -r 10 /g1_loco_bridge/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.6}}"
-
-# Release authority.
-ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 1}"
-```
-
-In sim the responder is `g1_motion_service_sim`'s `motion_service_sim`, and an accepted
-`SET_VELOCITY` feeds
-the walking policy that drives motors 0-14. See `g1_bringup`'s README for the dispatch table and
-for the policy's measured velocity thresholds, which matter when choosing a `cmd_vel` value.
-
-### Standalone
-
-For developing this package in isolation:
-
-```bash
-ros2 run g1_locomotion g1_loco_bridge --ros-args \
-  --params-file install/g1_locomotion/share/g1_locomotion/config/g1_loco_bridge.yaml
-
-ros2 lifecycle set /g1_loco_bridge configure
-ros2 lifecycle set /g1_loco_bridge activate
-```
-
-Not while `sim.launch.py` is running. Two bridges on the same names in one domain trips this
-bridge's single-writer guard on `/api/sport/request` and force-releases velocity authority. With no
-responder running at all, every request times out after `request_timeout_s`, so `~/status.authority`
-shows `ACQUIRING` then falls back to `RELEASED` with `last_error_code` set to `-1`. Expected in that
-configuration, not a bug.
+| Node | Kind | Purpose |
+|---|---|---|
+| `g1_loco_bridge` | lifecycle | Turns `Twist` and `SetLocoMode` goals into vendor JSON requests, correlates the async responses, and re-issues velocity so the robot keeps moving. |
+| `g1_gait_shaper` | plain | Collapses a planner's continuous velocity onto the three motions this gait can actually produce. |
+| `g1_loco_authority` | lifecycle | Acquires locomotion authority on activate and releases it on the way out. |
 
 ## Interfaces
 
-| Interface | Direction | Type | QoS |
-|---|---|---|---|
-| `~/cmd_vel` | in | `geometry_msgs/Twist` | reliable, keep-last(1), volatile |
-| `~/status` | out | `g1_msgs/LocoStatus` | reliable, transient-local, keep-last(1) |
-| `~/set_mode` | action | `g1_msgs/SetLocoMode` | n/a |
-| `/api/sport/request` | out | `unitree_api/Request` | `QoS(1)` reliable, volatile |
-| `/api/sport/response` | in | `unitree_api/Response` | `QoS(10)` reliable, volatile |
-
-**Reliability and durability on `/api/sport/*` are vendor-matched. Do not deviate.** They are the
-exact policies `BaseClient` uses, and hardware endpoint compatibility depends on them matching.
-History depth is not RxO-matched, so the response reader goes deeper than the vendor's depth-1
-default: a response landing in the same DDS batch as another read must not overwrite an unread
-result. Measured about 20% `SET_VELOCITY` loss before this and the heartbeat phase offset below.
-
-`~/cmd_vel` is node-relative, not bare `/cmd_vel`. Arbitrating multiple command sources (Nav2,
-teleop, a behavior tree) belongs to a future orchestration layer. It maps `linear.x` to `vx`,
-`linear.y` to `vy`, `angular.z` to `vyaw`, multiplied by `axis_sign` then clamped to
-`max_velocity`.
-
-`~/status` publishes on change plus a 1 Hz heartbeat. Transient-local so a monitor attaching after
-activation sees current state immediately.
-
-## Configuration (`config/g1_loco_bridge.yaml`)
-
-| Param | Default | Meaning |
+| Name | Direction | Type |
 |---|---|---|
-| `request_timeout_s` | 5.0 | Correlator sweep timeout. Matches `BaseClient`'s own blocking timeout. |
-| `max_pending` | 16 | Bound on requests tracked at once. |
-| `velocity_reissue_hz` | 5.0 | `SetVelocity` re-issue rate. Must be `> 1.0`. |
-| `cmd_vel_timeout_ms` | 500.0 | `~/cmd_vel` age beyond this is stale. |
-| `failure_streak_limit` | 3 | Consecutive non-zero codes before releasing authority. |
-| `max_velocity` | `[0.8, 0.5, 1.57]` | `[vx, vy, vyaw]` clamp. See below. |
-| `axis_sign` | `[1.0, 1.0, 1.0]` | Sign flip applied before clamping. |
+| `/g1_loco_bridge/cmd_vel` | in | `geometry_msgs/msg/Twist` |
+| `/g1_loco_bridge/set_mode` | action | `g1_msgs/action/SetLocoMode` |
+| `/g1_loco_bridge/status` | out | `g1_msgs/msg/LocoStatus`, reliable and transient-local |
+| `/api/sport/request` | out | `unitree_api/msg/Request` |
+| `/api/sport/response` | in | `unitree_api/msg/Response` |
+| `/cmd_vel` | in | `geometry_msgs/msg/Twist`, the shaper's input |
 
-`max_velocity` is a **sim bring-up value**, chosen to clear the sim walking policy's measured
-gait-initiation thresholds `[0.40, 0.50, 1.50]` with headroom. The earlier `[0.3, 0.2, 0.5]`
-clamped every axis below its own threshold, so the robot could never step. The conservative
-slow-by-default ceiling hardware wants is a separate decision to make at hardware bring-up against
-the real controller's limits, not back-derived from these numbers.
+## Running
 
-`axis_sign` is the calibration knob hardware bring-up will need: the vendor's frame convention
-relative to `Twist` is undocumented and not derivable in sim.
+The bridge comes up with the rest of the stack:
 
-## Design notes
-
-### Why not the vendored `BaseClient`
-
-`unitree_ros2`'s `BaseClient::Call()` is unusable from inside an executor callback:
-
-1. It blocks until its response arrives or 5 s elapse, so only one request can be in flight.
-2. It creates a fresh `/api/sport/response` subscription per call and drops it on return. At 5 Hz
-   that is DDS endpoint churn five times a second.
-3. Its subscription callback captures a stack-local `std::promise` by reference and calls
-   `set_value()` with no coordination against the caller's timeout, so a late response can write to
-   a promise that has gone out of scope.
-4. It deadlocks a single-threaded executor outright: the per-call subscription can never be
-   serviced while the callback holds the executor. Unitree's own example avoids this only by
-   running `LocoClient` on a separate thread.
-
-`LocoRequestCorrelator` replaces it with a map from request id to pending callback, serviced by the
-node's own subscription and timers. No blocking, no per-call churn, any number of requests in
-flight.
-
-### Thread ownership
-
-One thread ever touches this node, and the guarantee is two-part. Every callback source this class
-creates goes in one named `MutuallyExclusive` group, **and** `main()` spins on a
-`SingleThreadedExecutor`. The group alone is not enough: `LifecycleNode`'s own transition and
-parameter services are created by the base class, land in Humble's default group, and cannot be
-redirected, so `on_configure`/`on_cleanup`/`on_deactivate` are kept out from under a running
-callback only by the executor being single-threaded.
-
-No locks and no atomics anywhere in `G1LocoBridge`, `LocoRequestCorrelator` or `VelocityGate`.
-Contrast `g1_hardware_interface`'s `G1ArmSdkSystem`, which genuinely needs atomics because its RT
-thread and its executor thread are two independently scheduled threads. Here every correlator
-`send()` is a fire-and-forget publish and every outcome arrives back through the same executor as
-an ordinary callback.
-
-A `MultiThreadedExecutor` migration would need the base class's lifecycle services serialised
-against the named group by some other means.
-
-#### `g1_loco_authority` deviates, and only it
-
-**`g1_loco_authority` runs a `MultiThreadedExecutor` with two threads.** It has to: its
-`on_activate` blocks on a `SetLocoMode` result, and that result arrives as a callback on the same
-node, so a single-threaded executor would deadlock on the transition that is waiting for it. Its
-action client and status subscription sit in one `Reentrant` group; the base class's lifecycle
-services stay in the default `MutuallyExclusive` one.
-
-The deviation is bounded to **one atomic**, `latest_authority_` — written by the status callback,
-read by the transition thread. There is no other shared state and no lock anywhere in the node.
-
-**`G1LocoBridge`, `LocoRequestCorrelator` and `VelocityGate` are unaffected.** They keep the
-single-threaded guarantee above, and the no-locks-no-atomics property with it. Nothing in this
-paragraph loosens anything about the bridge.
-
-The alternative — a non-blocking `on_activate` driven off a timer — avoids the executor entirely,
-but then the lifecycle manager reports the node active while the robot is not yet walk-capable,
-which destroys the only thing the bracket is for.
-
-### Pure, ROS-free classes
-
-The safety-bearing logic lives in plain classes with no node, executor or timer, so it is unit
-tested with no DDS. Same pattern as `g1_hardware_interface`'s `ArmRampEngine`.
-
-**`loco_payloads`** builds the exact JSON the wire contract expects via `nlohmann::json`, the same
-library `BaseClient` uses, so output is byte-for-byte what the vendor's client would send.
-`buildSetVelocityPayload` always uses `kVelocityDurationS` (1.0 s): there is no parameter for a
-different value, so the vendor's 864000 s "continuous move" constant can never appear.
-`duration` is a dead-man switch, and latching a long value defeats it. This bridge re-issues
-continuously instead, so every request including the stop can carry the same short duration.
-
-`7106 SET_ARM_TASK` has no builder, deliberately. `WaveHand`/`ShakeHand` make the onboard
-controller move the arms, fighting whatever blend weight `rt/arm_sdk` currently holds, and no
-arbitration rule between the two paths exists. Not even the numeric api id is defined here.
-
-**`loco_request_correlator`** keys pending requests on `header.identity.id`. Ids are seeded once
-from `steady_clock` at construction then post-incremented, so two sends in the same tick cannot
-collide. `onResponse` matches and erases; an unmatched id is dropped and counted rather than
-treated as an error, since a response can legitimately arrive just after its entry timed out.
-`sweep` expires entries past `request_timeout_s` with code `-1`, two-phase (collect, erase, then
-invoke) so a callback that calls `send()` cannot invalidate the iteration it runs inside.
-`supersede` drops an entry with no callback, for when a fresher command has already replaced it.
-
-**`velocity_gate`** is the authority state machine:
-
-```
-kReleased --beginAcquire()--> kAcquiring --onAcquireResult(true)--> kHeld
-kAcquiring --onAcquireResult(false)--> kReleased
-kHeld --beginRelease()--> kReleasing --onReleaseResult()--> kReleased   (always)
-kHeld --(failure_streak_limit consecutive non-zero codes)--> kReleased
-any state --forceRelease()--> kReleased
+```bash
+ros2 launch g1_bringup bringup.launch.py
 ```
 
-Every path out of `kAcquiring` and `kReleasing` lands in a defined state, satisfying the release
-cleanly on success and failure rule.
+Reach `Start` before commanding any velocity. Outside `Start` the responder rejects velocity and
+nothing reaches the legs:
 
-`cmd_vel` is honoured only in `kHeld`. A stale or exactly-zero command sends exactly one
-`SetVelocity(0,0,0)` then nothing further until a fresh non-zero command arrives. A live non-zero
-command is re-issued every tick, which is what makes the short `duration` safe.
+```bash
+ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 4}"    # StandUp
+ros2 action send_goal /g1_loco_bridge/set_mode g1_msgs/action/SetLocoMode "{fsm_id: 500}"  # Start
+ros2 topic pub /g1_loco_bridge/cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.6}}"
+```
 
-### Authority handling
+Under navigation, `g1_loco_authority` does the two transitions itself and the shaper feeds the
+bridge, so none of the above is needed.
 
-A `START` goal calls `beginAcquire()` before publishing, and only once the correlator confirms a
-request is in flight, so every `kAcquiring` is guaranteed a future callback. Any other accepted
-goal calls `beginRelease()`, but only from `kHeld`: release keys on leaving `Start`, not on the
-literal `DAMP` id, because `Start -> StandUp` is a legal edge and a `STAND_UP` goal from `kHeld`
-means the robot is about to leave the state velocity authority depends on.
+## The gait shaper
 
-The one authority-promoting callback self-gates on `PRIMARY_STATE_ACTIVE`. The primary defence is
-`on_deactivate()` itself, which supersedes the correlator entry for any in-flight goal and aborts
-it before returning, so a late reply can never reach the result handler. The self-gate is a
-backstop.
+The simulated gait has a hard initiation dead zone with no hysteresis, so the usable action set has
+three elements: stop, drive straight, turn in place. `GaitShaper` reduces Nav2's continuous output
+onto exactly those.
 
-`fsm_id` in `~/status` is not inferred from goal outcomes alone: a `GET_FSM_ID` poll rides the 1 Hz
-heartbeat, keeping it confirmed by the robot. That timer's first tick is phase-offset half a
-re-issue period, because two wall timers with harmonically related periods would otherwise fire
-together every second and publish `SET_VELOCITY` and `GET_FSM_ID` back to back on a channel whose
-contract assumes one call in flight.
+It is subtractive only. Every output is the input unchanged, the input clamped smaller, or zero,
+never larger. That invariant is swept as a property test rather than spot-checked, because turning
+a small command into a large motion is what this stack's control-mode rules exist to prevent.
 
-**Single-writer guard:** the same timer checks `count_publishers("/api/sport/request")`. A count
-above 1 is always logged, and if this bridge holds authority it also sends one defensive
-`SetVelocity(0,0,0)` and force-releases. Advisory only; real cross-process arbitration is a future
-behavior-tree concern.
+Yaw is tested first, so a command carrying both becomes a pure turn. Forward is compared signed, so
+any negative `vx` becomes zero at any magnitude; reverse measures well inside the dead zone anyway,
+and this is why a misconfigured recovery behaviour cannot produce a reverse lurch.
 
-**Shutdown has no synchronous ramp,** unlike the arm bridge, because this node never actuates
-directly. If re-issuing stops, including by this process dying, the onboard controller's own 1 s
-dead-man stops the robot. That emergent property is why re-issuing short rather than latching
-864000 s is non-negotiable.
+The dead zone belongs to the simulated walking policy, not the real G1's onboard controller, which
+has no such gap. That is why the shaper lives here and not in Nav2 tuning: hardware bring-up simply
+does not launch it.
 
-**Teardown never wedges a goal.** `resetEntities()` aborts any in-flight goal with a terminal
-result and clears the correlator before destroying the action server and timers. Ordering matters:
-once those are gone nothing could resolve the goal, so skipping it would hang the client forever.
-Most easily reached via `shutdown()` from `PRIMARY_STATE_ACTIVE`, which Humble allows directly,
-bypassing `on_deactivate()`.
+`config/g1_gait_shaper.yaml`:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `fwd_engage` | `0.45` | Forward speeds below this become a stop. |
+| `yaw_engage` | `1.20` | Yaw rates below this become a stop. |
+| `yaw_clamp` | `1.57` | Ceiling on the turn that is passed through. |
+
+The constructor rejects a configuration it cannot honour, including `yaw_clamp` below `yaw_engage`,
+which would make turning unreachable while still reporting a turn.
+
+## The authority bracket
+
+A planner publishes velocity and nothing else. It has no way to send the `SetLocoMode` goals the
+bridge needs first, so `g1_loco_authority` is that missing step, expressed as a lifecycle
+transition: active means the robot is walk-capable, inactive means authority has been handed back.
+
+It releases on deactivate, shutdown, error, a failed activate, and on a process signal. Without it
+the bridge silently discards `cmd_vel`, Nav2 sends no goal, and the whole stack looks healthy while
+the robot never moves.
+
+It deliberately does not auto-acquire on the first `cmd_vel`. That is implicit acquisition, and a
+stray publisher would stand the robot up and walk it.
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `acquire_timeout_s` | `5.0` | Matches the bridge's own request timeout. |
+| `settle_after_start_s` | `2.5` | The gait is not responsive the instant `Start` returns. |
+| `set_mode_action` | `/g1_loco_bridge/set_mode` | A parameter, not a remap. Remapping does not reach the action client on Humble. |
+
+## Configuration
+
+`config/g1_loco_bridge.yaml` carries the velocity re-issue period, the request timeout, the axis
+signs and the per-axis maxima. The axis signs and maxima are simulator properties, in the same way
+the shaper's thresholds are.
 
 ## Tests
 
+| Test | Needs a simulator | Covers |
+|---|---|---|
+| `test_loco_payloads` | no | Exact JSON wire payloads and the parser. |
+| `test_loco_correlator` | no | Overlapping and out-of-order requests, sweep timeouts, the orphaned-response race, the pending bound. |
+| `test_velocity_gate` | no | Re-issue cadence, stale and zero-command idling, the failure-streak release, the authority state machine. |
+| `test_gait_shaper` | no | The dead zone, primitive exclusivity, the signed-forward asymmetry, the never-amplifies invariant, config validation. |
+| `test_loco_bridge_node` | no | The node itself against a fake responder on an isolated domain. |
+| `test_authority_release` | no | An acquire that fails after the bridge already believes authority is held. |
+
 ```bash
-colcon build --symlink-install --packages-select g1_locomotion
 colcon test --packages-select g1_locomotion
-colcon test-result --verbose
 ```
 
-| Test | Covers |
-|---|---|
-| `test_loco_payloads` | Exact JSON for `7101`/`7105`, `duration` always 1.0, response parsing including malformed input. |
-| `test_loco_correlator` | Overlapping requests, out-of-order responses, sweep timeout, an orphaned response arriving after its entry was swept, `supersede()`, reentrant `send()` from a sweep callback, the `max_pending` bound. |
-| `test_velocity_gate` | Re-issue above 1 Hz, the stale/zero single-stop policy, failure-streak release, `cmd_vel` ignored outside `kHeld`, every terminal path landing defined. |
-| `test_loco_bridge_node` | The node itself, in-process against a fake responder on an isolated domain: a late reply after `on_deactivate` must not revive authority, a slow round trip must still advance the failure streak, `STAND_UP` from `kHeld` must release, and a goal in flight at teardown must terminate. |
-
-Plus `clang-format`, `ament_lint_cmake` and `xmllint`.
-
-`g1_bringup/test/test_loco.launch.py` validates the wiring between this bridge and a real
-`/api/sport/*` responder end to end over DDS. It lives there because it needs the sim stack's
-launch files; run it with `colcon test --packages-select g1_bringup`.
-
-## `g1_gait_shaper`
-
-Reduces a planner's `Twist` onto the three motions this gait can actually produce: stop, drive
-straight, turn in place. Subtractive only — every output is the input unchanged, clamped smaller,
-or zero, never larger. That invariant is the safety claim, and it is asserted as a swept property
-rather than spot-checked.
-
-Yaw is tested first, so a command carrying both axes becomes a pure turn: the measured combined
-response is the worst case (a commanded (0.50, 0, 0.50) produced 0.30 m/s of uncommanded lateral).
-Forward compares **signed**, so any negative velocity becomes zero at any magnitude — which is
-independently why a reverse recovery behaviour cannot lurch the robot backwards.
-
-Thresholds live in `config/g1_gait_shaper.yaml` and carry the same sim-only banner
-`max_velocity` does: the deadband is a property of the sim walking policy, not the real G1's
-onboard MPC. Hardware bring-up does not launch this node.
-
-## `g1_loco_authority`
-
-The lifecycle bracket around LocoClient velocity authority: active means the robot is
-walk-capable, inactive means authority has been handed back. Exists because a planner publishes
-`cmd_vel` and nothing else — it has no way to send the `SetLocoMode` goals the bridge requires.
-
-Acquisition is deliberately **not** automatic on first `cmd_vel`. That would be implicit
-acquisition, and a stray publisher would stand the robot up and walk it.
-
-`on_activate` retries while the stack is still coming up, because everything launches at once and
-the bridge can be answering before the simulator has stepped any physics. The retry is selective,
-not blanket: `7301` (controller not in a state that can service the call) and a sweep timeout are
-retried; `7302` (the controller's own transition table refusing) and an unknown error are not,
-because repeating those would hide a real fault behind a timeout. Bounded by `acquire_timeout_s`
-overall.
-
-Release uses `StandUp`, never `Damp` — `Damp` drops the robot. It fires on deactivate, on
-shutdown (Humble allows `shutdown()` straight from active, bypassing `on_deactivate`), and from
-`on_activate`'s own failure path, since returning FAILURE leaves the node inactive and
-`on_deactivate` never runs.
+Nothing here needs a simulator. `g1_bringup`'s `test_loco` validates the wiring between this bridge
+and a real responder over DDS.

--- a/workspace/src/g1_motion_service_sim/README.md
+++ b/workspace/src/g1_motion_service_sim/README.md
@@ -1,98 +1,81 @@
 # g1_motion_service_sim
 
-**SIM-ONLY. Never launch this near real hardware.**
+**Simulation only. Never launch this near real hardware.**
 
-Stand-in for the G1's onboard motion service. On the real robot that service owns `/lowcmd`
-exclusively, provides the weight-blended `/arm_sdk` interface, and answers `/api/sport/*`.
-`unitree_mujoco` emulates only the low-level device, so none of it exists in simulation. This node
-fills all three gaps, sim-side only, and is launched exclusively by `g1_bringup`'s `sim.launch.py`.
+A stand-in for the G1's onboard motion service. On the real robot that service owns `/lowcmd`,
+serves the weight-blended `/arm_sdk` interface, and answers `/api/sport/*`. `unitree_mujoco`
+emulates only the low-level device, so none of it exists in simulation. This node fills all three
+gaps.
 
-`ament_cmake`, C++17.
+`ament_cmake`, C++20. Launched exclusively by `g1_bringup`'s `sim.launch.py`.
 
-## Why this is its own package
+```mermaid
+flowchart LR
+    ARM["G1ArmSdkSystem"] -- "/arm_sdk" --> N
+    BR["g1_loco_bridge"] -- "/api/sport/request" --> N
+    MJ["unitree_mujoco"] -- "/lowstate<br/>/sportmodestate" --> N
+
+    subgraph N["motion_service_sim"]
+        BLEND["arm blend<br/>motors 15-28"]
+        FSM["FSM and API responder"]
+        POL["walking policy<br/>motors 0-14, 50 Hz"]
+    end
+
+    N -- "/lowcmd at 500 Hz" --> MJ2["unitree_mujoco"]
+```
+
+The two halves never contend: they write disjoint slices of one `/lowcmd` message.
+
+## Why it is its own package
 
 Everything here exists only because the simulator stops at the low-level device. That makes it one
 deletion boundary rather than three features: at hardware bring-up you stop launching this package
-and nothing else in the stack changes.
+and nothing else changes.
 
-It is not in `g1_locomotion` because that package is the LocoClient *client* and this is the
-LocoClient *server* — opposite ends of one wire, and `g1_locomotion`'s whole claim is that it
-carries to hardware unchanged. It is not in `g1_sim` because that is the separate
-`mujoco_ros2_control` sandbox track, which is under a sunset clause.
+It is not part of `g1_locomotion` because that package is the LocoClient client and this is the
+server, and `g1_locomotion`'s whole claim is that it carries to hardware unchanged.
 
-The sim-only-ness is structural, not a switch. The walking policy's `base_lin_vel` observation
-comes from `/sportmodestate`, and the real G1 publishes `unitree_hg::SportModeState_`, which
-carries no velocity field at all. See the Contract section.
+The simulation-only property is structural, not a switch. The walking policy's `base_lin_vel`
+observation comes from `/sportmodestate`, and the real G1 publishes a type with no velocity field
+at all.
 
-## Running
+## Topics
 
-Not launched directly. `g1_bringup`'s `sim.launch.py` starts it with both config files and the two
-launch-computed overrides (`publish_lower_joint_states`, `walk_policy.enabled`):
+| Topic | Direction | Type |
+|---|---|---|
+| `/lowcmd` | out | `unitree_hg/msg/LowCmd` |
+| `/lowstate` | in | `unitree_hg/msg/LowState` |
+| `/arm_sdk` | in | `unitree_hg/msg/LowCmd` |
+| `/sportmodestate` | in | `unitree_go/msg/SportModeState` |
+| `/api/sport/request` | in | `unitree_api/msg/Request` |
+| `/api/sport/response` | out | `unitree_api/msg/Response` |
+| `/joint_states` | out | `sensor_msgs/msg/JointState`, lower body only |
 
-```bash
-ros2 launch g1_bringup sim.launch.py
-```
+Reliability and durability on `/api/sport/*` are matched to the vendor's. Do not deviate.
 
-### Topics
-
-| Topic | Direction | Type | QoS |
-|---|---|---|---|
-| `/lowcmd` | out | `unitree_hg/msg/LowCmd` | best-effort, keep-last(1), volatile |
-| `/lowstate` | in | `unitree_hg/msg/LowState` | best-effort, volatile |
-| `/arm_sdk` | in | `unitree_hg/msg/LowCmd` | matches `G1ArmSdkSystem`'s publisher exactly |
-| `/sportmodestate` | in | `unitree_go/msg/SportModeState` | best-effort, volatile |
-| `/api/sport/request` | in | `unitree_api/msg/Request` | `QoS(10)` reliable, volatile |
-| `/api/sport/response` | out | `unitree_api/msg/Response` | `QoS(1)` reliable, volatile |
-| `/joint_states` | out | `sensor_msgs/msg/JointState` | keep-last(1), lower body only, `publish_lower_joint_states` |
-
-It is a plain node rather than lifecycle-managed: it emulates an always-on vendor service that has
-no activate/deactivate concept of its own.
+It is a plain node, not lifecycle-managed, because it emulates an always-on vendor service that has
+no activate concept of its own.
 
 ## Arm path
 
-- Captures a frozen hold pose from the first `/lowstate` sample.
-- Subscribes `/arm_sdk`, matching `G1ArmSdkSystem`'s publisher QoS exactly.
-- Publishes `/lowcmd` at `publish_rate_hz`, blending arms (motors 15-28) between the hold pose and
-  the commanded values on `q`, `kp` and `kd` alike: `published = hold * (1 - w) + commanded * w`.
-  The weight slot (`motor_cmd[29].q`) echoes the effective weight, and the CRC uses
-  `g1_hardware_interface`'s vendored `computeLowCmdCrc()`.
+The node captures a hold pose from the first `/lowstate` sample, then publishes `/lowcmd` at
+`publish_rate_hz`, blending arms between that hold pose and the commanded values on `q`, `kp` and
+`kd` alike. Motor slot 29 echoes the effective weight.
 
-`mode`, `mode_pr` and `mode_machine` are deliberately never set. `unitree_mujoco` computes actuator
-torque purely as `tau_ff + kp * (q_des - q_meas) + kd * (dq_des - dq_meas)` and never reads them.
-That is a sim-specific finding; what the real motion service does with these fields is unverified
-and stays a hardware re-validation item.
+If the newest `/arm_sdk` message is older than `arm_sdk_timeout_ms`, the weight decays toward zero,
+so a silent publisher eases the arms back to the hold pose instead of freezing them. A fresh
+message resumes from wherever the weight sits, never snapping.
 
-**Staleness policy (bridge policy, not vendor semantics):** if the newest `/arm_sdk` message is
-older than `arm_sdk_timeout_ms`, the effective blend weight decays toward zero at
-`1 / timeout_ramp_down_s` per second, so a silent publisher eases the arms back to the hold pose
-instead of freezing them. A fresh message resumes from wherever the weight sits, never snapping.
-What the real controller does when its publisher goes silent at weight 1 is unverified.
-
-## LocoClient wire responder
-
-The same node answers `/api/sport/request`, mirroring the single-service reality on hardware. It
-tracks an FSM state and applies the acceptance rules in `include/g1_motion_service_sim/loco_fsm.hpp`.
-Those rules are load-bearing: an accepted `SET_VELOCITY` latches the command the walking policy
-consumes, so this path drives motors 0-14. It never touches the arm slots and never publishes
-`/lowcmd` itself.
-
-**Reliability and durability on `/api/sport/*` are vendor-matched. Do not deviate.** History depth
-is not RxO-matched, so it is picked per side: the request reader is deeper than the response
-publisher so two requests in one DDS batch cannot overwrite each other in a depth-1 cache.
-
-Every response echoes `header.identity` (both `id` and `api_id`). The correlator matches on `id`
-only, and nothing on either side validates `api_id`, so a colliding `id` from another client on the
-same domain would not be caught.
+## LocoClient responder
 
 | API id | Name | Behaviour |
 |---|---|---|
-| `7001` | `GET_FSM_ID` | Returns `{"data": <fsm_id>}`, code `0`. |
+| `7001` | `GET_FSM_ID` | Returns the current id, code `0`. |
 | `7101` | `SET_FSM_ID` | Applies the legality table below. Code `0` or `7302`. |
 | `7105` | `SET_VELOCITY` | Code `7301` unless the FSM is `Start`, else `0` and the command is latched. |
-| `7106` | `SET_ARM_TASK` | Always rejected with `-2`. `WaveHand`/`ShakeHand` moves hand arm authority to the onboard controller, which would fight this stack's `rt/arm_sdk` blend weight. |
-| anything else, or malformed JSON | | `-2` (`UT_ROBOT_TASK_UNKNOWN_ERROR`). |
+| `7106` | `SET_ARM_TASK` | Always rejected. It would move arm authority to the onboard controller and fight this stack's blend weight. |
 
-FSM state starts at `Damp(1)`, matching the robot's boot state. Legal transitions:
+State starts at `Damp(1)`, matching the robot's boot state:
 
 ```
 Damp(1)    -> StandUp(4)
@@ -100,137 +83,73 @@ StandUp(4) -> Start(500), Damp(1)
 Start(500) -> StandUp(4), Damp(1)
 ```
 
-Every other edge is rejected `7302`. The vendor contract has no code specific to "illegal
-transition", so reusing `7302` is this responder's approximation and stays a hardware
-re-validation item.
+Every other edge is rejected. These rules are load-bearing: an accepted `SET_VELOCITY` latches the
+command the walking policy consumes, and the latch carries the request's own duration as a
+dead-man, so a silent bridge stops the robot within a second.
 
 ## Walking policy
 
-An RL walking policy that owns motors 0-14 (legs and waist) and balances the robot with no pelvis
-weld. `/arm_sdk` keeps motors 15-28, so the two never contend: they are disjoint slices of one
-`/lowcmd` message. The policy's own arm outputs are discarded.
+An RL policy owning motors 0 to 14, running at 50 Hz. It balances the robot with no pelvis weld.
 
-**Provenance:** `policy/walker.onnx` and its external weights `walker.onnx.data` come from
+`policy/walker.onnx` and its external weights come from
 [luckyrobots/g1-manipulation-challenge](https://github.com/luckyrobots/g1-manipulation-challenge),
-which describes the policy as trained with RL in Isaac Lab. That repository publishes no licence
-file and no attribution for the policy's own origin, so its redistribution terms are undeclared.
-Recorded here rather than left implicit. The MJCF, meshes and scene from that repository are not
-vendored and are not needed.
+described there as trained with RL in Isaac Lab. That repository publishes no licence file and no
+attribution for the policy's own origin, so its redistribution terms are undeclared.
 
-### Contract
+### Measured behaviour, read before commanding velocities
 
-- **Observation, 99 elements, fed raw:** `base_lin_vel(3)`, `base_ang_vel(3)`,
-  `projected_gravity(3)`, `joint_pos(29, relative to the default posture)`, `joint_vel(29)`,
-  `last_action(29)`, `command(3)`. The exported graph starts with `Sub(mean)` then `Div(std)`, so
-  normalisation is already inside the model. Applying the `obs_mean`/`obs_std` arrays that ship
-  alongside it would apply it twice.
-- **Action:** `target = default_joint_pos + action * action_scales`, per joint.
-- **Joint order:** identical to the Unitree DDS motor order (0-28), so `motor_state[i]` and
-  `motor_cmd[i]` map straight through. Asserted at startup and in `test_walk_policy`.
-- **Base linear velocity comes from `/sportmodestate`,** not `/lowstate`, which carries no such
-  field. This is why the policy is structurally sim-only, and the reason is stronger than "that
-  service is switched off": **the field does not exist on hardware at all.** `unitree_mujoco`
-  publishes the **go2** `SportModeState` (16 fields, with `position` and `velocity` filled from
-  MuJoCo `framepos`/`framelinvel` on the pelvis `imu` site) regardless of which robot is simulated.
-  The real G1 publishes `unitree_hg::SportModeState_` on the same topic name, and that type carries
-  only `fsm_id`, `fsm_mode`, `task_id` and `task_time`. No pose, no velocity. `rt/odommodestate` does
-  not exist anywhere in Unitree's code. Supplying this observation on hardware needs real state
-  estimation, which is a future milestone (see `g1_state_estimation`).
-- Inference runs at 50 Hz on its own timer, about 0.02 ms per call.
-
-Armature matching turned out not to matter. Ablating armature, frictionloss and damping against
-`unitree_mujoco`'s `g1_29dof.xml` showed the model as shipped (uniform `armature=0.01`) performs
-identically to per-joint values across standing, walking, turning and a 500 N perturbation. No MJCF
-edits and no mesh vendoring are required.
-
-### Measured behaviour: read before commanding velocities
-
-There is a hard gait-initiation deadband with no hysteresis. Below it the robot stands still rather
-than stepping, and kicking above it then dropping back stops the gait outright.
+There is a hard gait-initiation dead zone with no hysteresis. Below it the robot stands still, and
+kicking above it then dropping back stops the gait outright.
 
 | Axis | No motion at or below | Steps from | Measured output |
 |---|---|---|---|
-| `vx` | 0.35 m/s | **0.40 m/s** | 0.5 to 0.35, 0.6 to 0.47, 1.0 to 0.93 m/s |
-| `vy` | 0.30 m/s | **0.50 m/s** | 0.5 to 0.44, 1.0 to 0.93 m/s |
-| `vyaw` (in place) | 0.60 rad/s | **1.50 rad/s** | 1.0 to 0.21, 1.5 to 1.08 rad/s |
+| `vx` | 0.35 m/s | 0.40 m/s | 0.5 gives 0.35, 0.6 gives 0.47, 1.0 gives 0.93 |
+| `vy` | 0.30 m/s | 0.50 m/s | 0.5 gives 0.44, 1.0 gives 0.93 |
+| `vyaw` in place | 0.60 rad/s | 1.50 rad/s | 1.0 gives 0.21, 1.5 gives 1.08 |
 
-Commands below threshold pass through unchanged and are logged, never scaled up. Turning a small
-command into a large motion is exactly what this stack's control-mode rules exist to prevent.
+Combined commands come out badly. A commanded (0.50, 0, 0.50) measured (0.337, 0.299, 0.390), a
+third of a metre per second of lateral nobody asked for. Commands below threshold pass through
+unchanged and are logged, never scaled up.
 
-Also measured:
-
-- About 0.22 to 0.25 m/s of uncommanded lateral drift while walking forward, so straight-line
-  walking curves.
-- Turning collapses forward speed: `vx=0.6` with yaw commanded measures about -0.11 m/s.
-- Balance is solid. The robot survives a 500 N, 50 ms lateral impulse while standing with about
-  2.6 degrees of peak tilt.
-
-Together these make it a teleop-grade locomotion source, not a planner-grade one. `g1_locomotion`'s
-`g1_gait_shaper` is the consumer-side answer to this table.
-
-### Authority
-
-No new authority mechanism exists for the policy. The FSM legality table is the gate:
-`SET_VELOCITY` is latched only when `checkVelocityAllowed()` accepted it, so outside `Start` it is
-rejected `7301` and nothing reaches the policy. A successful transition away from `Start` clears
-the latch, and the latch carries the request's own `duration` as a dead-man, so a silent bridge
-stops the robot within a second.
-
-The policy runs continuously from startup regardless of FSM state. Leg authority is gated on policy
-freshness, not on the FSM, so releasing locomotion authority stops the walking without dropping the
-robot. If inference goes stale the lower-body target freezes at the last policy output rather than
-reverting to the captured spawn pose, which would be a large step away from the stance the robot is
-actually in.
+Walking also drifts sideways about 0.22 to 0.25 m/s, and turning collapses forward speed. Together
+that makes it a teleop-grade locomotion source, not a planner-grade one. `g1_locomotion`'s
+`g1_gait_shaper` is the consumer-side answer.
 
 ## Configuration
 
 `config/motion_service_sim.yaml`:
 
-| Param | Default | Meaning |
+| Parameter | Default | Meaning |
 |---|---|---|
 | `publish_rate_hz` | `500.0` | `/lowcmd` publish rate. |
-| `leg_kp` / `leg_kd` | `100.0` / `1.0` | Stiff-hold gains, motors 0-11. |
-| `waist_kp` / `waist_kd` | `50.0` / `1.0` | Stiff-hold gains, motors 12-14. |
+| `leg_kp` / `leg_kd` | `100.0` / `1.0` | Stiff-hold gains, motors 0 to 11. |
+| `waist_kp` / `waist_kd` | `50.0` / `1.0` | Stiff-hold gains, motors 12 to 14. |
 | `arm_hold_kp` / `arm_hold_kd` | `40.0` / `1.0` | Arm gains at blend weight 0. |
-| `arm_sdk_timeout_ms` | `500.0` | `/arm_sdk` age beyond this is stale. |
+| `arm_sdk_timeout_ms` | `500.0` | `/arm_sdk` age beyond this counts as stale. |
 | `timeout_ramp_down_s` | `1.0` | Weight decay and resume rate. |
 
-Gain provenance: Unitree's `g1_low_level_example.cpp` holds a captured posture with
-`motor_cmd[i].kp = (i < 13) ? 100.0 : 50.0` and `kd = 1.0`. This bridge holds the whole waist group
-at the gentler value, the more conservative choice for locking a static pose. The arm gains match
-`g1_description/config/arm_sdk_params.yaml`.
-
 `config/walk_policy.yaml` holds the policy's joint names, default posture, action scales, per-joint
-gains, rates and limits. The file itself is commented; see it directly.
+gains and limits. The file is commented; read it directly.
 
-Two parameters are set by `sim.launch.py` rather than by either file, because both are launch
-decisions: `publish_lower_joint_states` (on only with `sensors:=true`, since it costs work on the
-1 kHz `/lowstate` path) and `walk_policy.enabled` (off when `pin_pelvis:=true`, since the weld and
-the policy are the two possible owners of the legs and are never both active).
+`sim.launch.py` supplies two more, because both are launch decisions rather than tuning:
+`publish_lower_joint_states` and `walk_policy.enabled`.
 
 ## Tests
 
-| Test | Kind | Covers |
-|---|---|---|
-| `test_blend_math` | gmock | Blend-weight decay and resume, q/kp/kd blend. |
-| `test_assemble_sim_low_cmd` | gmock | `/lowcmd` assembly: lower-body slots and gains, arm blend, weight-slot echo. |
-| `test_loco_fsm` | gmock | FSM legality: every legal and illegal edge, `SET_VELOCITY`'s Start-only gate. |
-| `test_walk_policy` | gmock | Policy contract (joint order, observation layout, un-normalised input, action mapping, dead-man) and the leg-authority fallback. |
-| `test_walk_policy_session` | gmock | ONNX Runtime: shape contract, external-weight resolution, determinism, inference budget. |
-| `clang_format_check_g1_motion_service_sim` | ctest | C++ formatting. |
+None of these need a simulator, DDS or a live graph.
+
+| Test | Covers |
+|---|---|
+| `test_blend_math` | Blend-weight decay and resume, q/kp/kd blend. |
+| `test_assemble_sim_low_cmd` | `/lowcmd` assembly: slots, gains, arm blend, weight echo. |
+| `test_loco_fsm` | Every legal and illegal edge, and the Start-only velocity gate. |
+| `test_walk_policy` | Joint order, observation layout, action mapping, dead-man, leg-authority fallback. |
+| `test_walk_policy_session` | ONNX Runtime shape contract, external weights, determinism, and a golden action vector. |
+| `test_wire_constants` | The motor-index constants this package duplicates from `g1_hardware_interface`. |
 
 ```bash
 colcon build --symlink-install --packages-select g1_motion_service_sim
 colcon test --packages-select g1_motion_service_sim
-colcon test-result --verbose
 ```
 
-None of these need a simulator, DDS or a live graph, so they are fast and deterministic. The
-launch-level suites that exercise this node against a real `unitree_mujoco` live in `g1_bringup`
-(`test_loco`, `test_walk_stand`, `test_walk_teleop`, `test_walk_and_arm`), because they all include
-`g1_bringup/launch/sim.launch.py` and this package cannot depend on `g1_bringup` without a cycle.
-
-## Language
-
-C++17: this is a 500 Hz control-rate loop with 50 Hz inference on it. No Python here at all — the
-launch files and integration suites that drive it live in `g1_bringup`.
+The launch-level suites that drive this node against a real simulator live in `g1_bringup`.

--- a/workspace/src/g1_msgs/README.md
+++ b/workspace/src/g1_msgs/README.md
@@ -1,37 +1,53 @@
 # g1_msgs
 
-Interfaces for the G1 LocoClient bridge (`g1_locomotion`): the `SetLocoMode` action and the
-`LocoStatus` message. `ament_cmake` with `rosidl_default_generators`, no source of its own.
+Interfaces for the LocoClient bridge in `g1_locomotion`: one action and one message.
+
+`ament_cmake` with `rosidl_default_generators`. No source of its own.
+
+```mermaid
+flowchart LR
+    AU["g1_loco_authority"] -- "SetLocoMode goal" --> BR["g1_loco_bridge"]
+    CLI["ros2 action send_goal"] -- "SetLocoMode goal" --> BR
+    BR -- "LocoStatus<br/>fsm_id, authority,<br/>last_error_code" --> AU
+```
 
 ```bash
 colcon build --symlink-install --packages-select g1_msgs
 ```
 
-## `action/SetLocoMode.action`
+## action/SetLocoMode.action
 
 | Field | Meaning |
 |---|---|
-| `fsm_id` (goal) | Target FSM id. Only `DAMP` (1), `STAND_UP` (4) and `START` (500) are accepted; the bridge rejects anything else in `handle_goal` and logs the reason. `Squat` (2), `Sit` (3) and `ZeroTorque` (0) have no constant here: nothing needs them, and their transition legality was never checked against a real onboard controller. |
-| `success`, `error_code` (result) | `error_code` is the raw LocoClient wire status code: `0` on success, otherwise `7301`, `7302`, or a correlator timeout. |
-| `message` (result) | Human-readable context for logs and CLI use. Not meant to be parsed. |
+| `fsm_id` (goal) | Target FSM id. Only `DAMP` (1), `STAND_UP` (4) and `START` (500) are accepted; the bridge rejects anything else and logs why. |
+| `success`, `error_code` (result) | `error_code` is the raw LocoClient wire status: `0` on success, otherwise `7301`, `7302`, or a correlator timeout. |
+| `message` (result) | Context for logs and CLI use. Not meant to be parsed. |
 
-No feedback field: the exchange either completes or times out within a few seconds, with nothing
-meaningful to report mid-flight.
+`Squat`, `Sit` and `ZeroTorque` have no constants here. Nothing needs them, and their transition
+legality was never checked against a real onboard controller.
 
-## `msg/LocoStatus.msg`
+There is no feedback field. The exchange either completes or times out within a few seconds, with
+nothing meaningful to report mid-flight.
+
+## msg/LocoStatus.msg
 
 | Field | Meaning |
 |---|---|
-| `stamp` | When this status was produced. |
+| `stamp` | When the status was produced. |
 | `fsm_id` | Last FSM id the bridge knows to be true. `-1` before it has any information. |
-| `authority` | `RELEASED`, `ACQUIRING`, `HELD` or `RELEASING`: whether the bridge holds velocity-command authority. See `g1_locomotion`'s README for the state machine. |
-| `last_error_code` | Most recent wire status code observed, from `SetLocoMode` or velocity requests alike. |
-| `ignored_cmd_vel` | How many **non-zero** `~/cmd_vel` samples the bridge has discarded because it held no authority. Monotonic, never reset on acquire, so a reader can assert "stopped increasing". Zero commands are not counted: publishers idle at zero routinely, and an idle publisher is not a dropped intent. The counter exists because "the planner is running and the robot is stationary" is otherwise silent. |
+| `authority` | `RELEASED`, `ACQUIRING`, `HELD` or `RELEASING`. Whether the bridge holds velocity-command authority. |
+| `last_error_code` | Most recent wire status code seen, from a mode goal or a velocity request. |
+| `ignored_cmd_vel` | How many non-zero velocity samples the bridge discarded for lack of authority. |
+
+`ignored_cmd_vel` is monotonic and never reset on acquire, so a reader can assert that it stopped
+increasing. Zero commands are not counted, because publishers idle at zero routinely and an idle
+publisher is not a dropped intent. The counter exists because "the planner is running and the robot
+is stationary" is otherwise silent.
 
 ## Why an action rather than a service
 
 Completion is asynchronous. The LocoClient wire exchange is two plain topics: a request published
-now, a response correlated to it later. A Humble service callback must populate its response before
-returning, so waiting there for `/api/sport/response` would block the executor. An action's
-`handle_accepted` returns immediately and reports the outcome later through the goal handle, which
-matches the protocol's own asynchrony.
+now, a response correlated to it later. A Humble service callback has to populate its response
+before returning, so waiting there would block the executor. An action's `handle_accepted` returns
+immediately and reports the outcome later through the goal handle, which matches the protocol's own
+asynchrony.

--- a/workspace/src/g1_navigation/README.md
+++ b/workspace/src/g1_navigation/README.md
@@ -1,261 +1,141 @@
 # g1_navigation
 
-SLAM Toolbox mapping and Nav2 navigation for the G1, on the converged `unitree_mujoco` track.
+SLAM Toolbox mapping, AMCL localization and Nav2 for the G1 on the `unitree_mujoco` track.
+Configuration, launch files and two G1-specific nodes' worth of glue. Nav2 itself is upstream.
 
-Configuration, launch and maps only — every node here is upstream.
+`ament_cmake`, Python launch files.
 
-Nav2's planner, controller, behaviors and BT navigator are configured here; the two G1-specific
-nodes they need — `g1_loco_authority` to acquire locomotion authority and `g1_gait_shaper` to
-reduce Nav2's output onto the gait's three usable motions — live in `g1_locomotion`, so nothing
-Nav2-shaped leaks into the package that has to survive to hardware.
+```mermaid
+flowchart TB
+    RELAY["g1_sensor_relay"] -- "/livox/lidar" --> SCAN["pointcloud_to_laserscan"]
+    SCAN -- "/scan" --> SLAM["slam_toolbox"]
+    SCAN -- "/scan" --> AMCL["map_server + AMCL"]
+    SLAM -- "map to odom" --> NAV2
+    AMCL -- "map to odom" --> NAV2
+    ODOM["g1_odometry_publisher"] -- "odom to base_footprint" --> NAV2
+    NAV2["Nav2"] -- "/cmd_vel" --> SHAPE["g1_gait_shaper"]
+    SHAPE --> BRIDGE["g1_loco_bridge"]
+    AUTH["g1_loco_authority"] -.-> BRIDGE
+```
+
+## Launch files
+
+| File | Purpose |
+|---|---|
+| `nav_sim.launch.py` | This package's orchestrator. Composes the simulator, the scan pipeline, and either SLAM or localization. |
+| `scan.launch.py` | `pointcloud_to_laserscan`, flattening the LiDAR into the 2D scan SLAM and AMCL consume. |
+| `slam.launch.py` | `slam_toolbox` in online async mapping mode. |
+| `localization.launch.py` | `map_server` and AMCL against the committed map. |
+| `nav2.launch.py` | Nav2 itself: planner, controller, behaviours, BT navigator, lifecycle manager. |
+
+The operator entry point is `g1_bringup`'s, matching `nav2_bringup`. `nav_sim.launch.py` still runs
+directly if you want it.
 
 ## Running
-
-Everything here needs `sensors:=true` on `g1_bringup`, which gates the LiDAR, the relay, the
-`odom -> base_footprint -> pelvis` chain and the waist joint states. The top-level launch passes it.
-
-**The operator entry point is `g1_bringup`'s**, matching `nav2_bringup`:
 
 ```bash
 ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
 ```
 
-`mode:=mapping` builds a new map with slam_toolbox. `mode:=localization` runs `map_server` + AMCL
-against `maps/facility` — use that when a goal pose has to mean the same thing twice.
+Drive it around with teleop and watch the map fill in. When it looks right:
 
-To actually navigate, add `nav:=true` (which requires `mode:=localization`):
+```bash
+ros2 run nav2_map_server map_saver_cli -f ~/facility
+```
+
+`maps/facility` is already committed, so that is only for a new scene. To navigate:
 
 ```bash
 ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
-```
 
-`nav_sim.launch.py` is still this package's orchestrator and still runs directly
-(`ros2 launch g1_navigation nav_sim.launch.py mode:=mapping`); `bringup.launch.py` routes to it.
-The composition direction is unchanged — navigation composes bring-up, and `g1_bringup` declares
-no dependency on this package, because the two would form a colcon cycle. See `g1_bringup`'s
-README for why that reference is deliberately undeclared, and `test_launch_threading` for the
-check that compensates.
-
-```bash
 ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
   "{pose: {header: {frame_id: map}, pose: {position: {x: 2.5, y: -2.5}, orientation: {w: 1.0}}}}"
 ```
 
-## What the robot can actually do
+Everything here needs `sensors:=true`, which gates the LiDAR, the relay and the
+`odom` to `base_footprint` chain. The navigation modes pass it for you.
 
-Measured, and it shapes every controller decision here. The gait has a hard initiation deadband
-with no hysteresis: nothing at or below 0.35 m/s forward, steps from 0.40; nothing at or below
-0.60 rad/s yaw, steps from 1.50. Combined commands come out badly — a commanded (0.50, 0, 0.50)
-measured (0.337, **0.299**, 0.390), a third of a metre per second of lateral nobody asked for.
+## What the gait forces
 
-So the usable action set is three elements: **stop, drive straight at ~0.6 m/s, turn in place at
-~1.57 rad/s.** `g1_gait_shaper` collapses Nav2's continuous output onto exactly those, subtractive
-only — it clamps and zeroes, never amplifies.
+The simulated gait has a hard initiation dead zone, so the usable action set is stop, drive
+straight, turn in place. `g1_locomotion`'s `g1_gait_shaper` collapses Nav2's continuous output onto
+those three, subtractively. Full numbers are in `g1_motion_service_sim`'s README.
 
-The consequence worth knowing before tuning: the shaper zeroes any yaw below 1.20, and RPP's
-curvature steering is usually well under that, so it rarely reaches the robot. Effective behaviour
-is bang-bang — drive straight until the heading error is large, then rotate in place. That makes
-**`angular_dist_threshold` the dominant knob, not `lookahead_dist`.**
+Two consequences worth knowing before tuning:
 
-This deadband is a property of the **sim walking policy**, not of the real G1's onboard MPC, which
-has no such dead zone. That is why it lives in `g1_locomotion`'s config and not in Nav2 tuning:
-hardware bring-up simply does not launch the shaper.
+The shaper zeroes any yaw below 1.20 rad/s, and the pure pursuit controller's curvature steering is
+usually well under that. Effective behaviour is bang-bang: drive straight until the heading error
+is large, then rotate in place. That makes `angular_dist_threshold` the dominant knob, not
+`lookahead_dist`.
 
-## RViz
+`behavior_server`'s `max_rotational_vel` is 1.57 rather than upstream's 1.0. At 1.0 it sat below
+the shaper's engage threshold, so every `Spin` was zeroed before reaching the bridge while still
+reporting success. `test_gait_coupling` now fails if that pairing regresses.
 
-`config/g1_navigation.rviz` carries every display in two toggleable groups: **Nav2** (map, scan,
-AMCL particle swarm, global/local plan, both costmaps, footprints, the local voxel grid) and
-**Sensors** (LiDAR, depth cloud, depth and colour images, sensor pose), which starts folded away.
-Fixed frame is `map`. `g1_bringup`'s `config/g1_sensors.rviz` is the counterpart for
-`mode:=none`: same Sensors group, no Nav2 group, fixed frame `odom` — there is no `map` frame
-without SLAM or AMCL, which is why one merged file could not serve both.
+## Decisions that look odd without the reason
 
-Two static files rather than one rewritten at launch: they differ in fixed frame as well as in
-which groups exist, and rewriting config at launch has already cost this stack a debugging session
-(`nav2.launch.py`'s docstring). The price is drift, and `test_rviz_configs` is what stops it.
+Nav2 runs uncomposed while the scan and localization nodes compose. Composed, the costmaps came up
+on `Costmap2DROS` defaults instead of the params file, and `controller_server` then hung forever
+activating against a frame that does not exist. `use_composition:=true` raises with that
+explanation rather than hanging.
+
+Reverse recovery is removed from both behaviour trees and from `behavior_plugins`, so no action
+server exists to invoke. This gait barely reverses at all, and upstream's backup speed sits inside
+the dead zone, so `BackUp` would burn its whole time allowance producing no motion while consuming
+the round-robin slot `Spin` could have used.
+
+`z_voxels` is 40, not upstream's 16. The sensor sits at 1.22 m, outside a 0.8 m voxel column.
+
+## Configuration
+
+| File | Contents |
+|---|---|
+| `config/nav2_params.yaml` | Planner, controller, costmaps, behaviours, BT navigator. |
+| `config/localization.yaml` | `map_server` and AMCL. |
+| `config/scan.yaml` | The point cloud to laser scan flatten, including the height band. |
+| `config/slam_mapping.yaml` | `slam_toolbox` online async. |
+| `config/g1_navigation.rviz` | RViz for the navigation modes. Fixed frame `map`. |
+| `navigate_to_pose.xml`, `navigate_through_poses.xml` | Behaviour trees, with reverse recovery removed. |
+| `maps/facility.{yaml,pgm}` | The committed map of the navigation scene. |
+
+### RViz
+
+`config/g1_navigation.rviz` holds everything in two toggleable groups: Nav2 (map, scan, AMCL
+particle swarm, plans, both costmaps, footprints, the local voxel grid) and Sensors, which starts
+folded away. `g1_bringup`'s `config/g1_sensors.rviz` is the counterpart for `mode:=none`: the same
+Sensors group, no Nav2 group, fixed frame `odom`, because there is no `map` frame without SLAM or
+AMCL.
+
+Two static files rather than one rewritten at launch, since they differ in fixed frame as well as
+in which groups exist. The price is drift, which `test_rviz_configs` catches.
 
 This file lives here rather than in `g1_bringup` because the particle swarm is a
-`nav2_rviz_plugins` display. Shipping it from the bring-up package would give that package a Nav2
-dependency, which is the one thing the layering forbids.
+`nav2_rviz_plugins` display, and shipping it from the bring-up package would give that package a
+Nav2 dependency.
 
-Displays from upstream's `nav2_default_view.rviz` that are deliberately **not** here: `Bumper Hit`
-(turtlebot hardware), `MarkerArray` on `/waypoints` (no `waypoint_follower` in `nav2_params.yaml`),
-`Trajectories` on `/marker` (DWB-only; we run RPP), `Downsampled Costmap` (Smac-only; we run
-NavFn), and the global `VoxelGrid` (the global costmap runs `obstacle_layer`, not `voxel_layer`,
-so `/global_costmap/voxel_marked_cloud` is never published). Each would be a permanently dead row.
+## Tests
 
-## Composition
-
-The navigation nodes load into one `component_container_isolated` named `nav2_container`.
-`nav_sim.launch.py` creates the container; the leaf launches load into it. Set
-`use_composition:=false` for one process per node, which is what you want when a single node is
-crashing and you need to see which.
-
-This shares a process and gives each component its own executor. It is **not** zero-copy — nothing
-sets `use_intra_process_comms`, and neither does `nav2_bringup`, because `/map` is transient-local
-and Humble's intra-process path does not support that durability.
-
-**Nav2 itself runs uncomposed, and that is measured rather than preference.** Composed, the
-costmaps silently come up on `Costmap2DROS`'s built-in defaults —
-`/local_costmap/local_costmap` reported `base_link`, `map` and `robot_radius 0.1` while
-`config/nav2_params.yaml` plainly says `base_footprint`, `odom` and `0.45` — and
-`controller_server` then hangs forever activating against a frame that does not exist. A bare
-path, `RewrittenYaml` and `ParameterFile` all behaved the same. The scan and localization nodes
-still compose and do get their parameters; their sections are flat and named for the node itself,
-which is consistent with the nested sections being the problem.
-
-Structure follows `nav2_bringup`'s own launch files, including which nodes stay out:
-**slam_toolbox runs as a separate process** even though it ships a component. That is what
-`nav2_bringup/launch/slam_launch.py` does, and its 40 MB stack requirement for map serialization is
-not something to hand a shared process.
-
-## Sensor inputs
-
-| Consumer | Input | Why |
+| Test | Needs a simulator | Covers |
 |---|---|---|
-| slam_toolbox | `/scan` (`LaserScan`, `base_footprint`) | It is a 2D scan matcher and takes nothing else. |
-| Nav2 costmaps | `/livox/lidar` (`PointCloud2`, `mid360_link`) raw | The layer accepts it natively and it keeps the low obstacles `/scan` discards. |
+| `test_navigate_to_pose` | yes | The acceptance gate: the robot reaches a goal on its own. |
+| `test_nav_authority` | yes | Authority acquired on activate, released on deactivate, `cmd_vel` discarded before it. |
+| `test_scan_pipeline` | yes | The frame chain and the scan. |
+| `test_slam_map` | yes | slam_toolbox owning `map` to `odom`, and the map's geometry. |
+| `test_gait_coupling` | no | Spin's rotational limits against the shaper's engage threshold. |
+| `test_launch_threading` | no | Arguments surviving `bringup` to `nav_sim` to `sim`. |
+| `test_rviz_configs` | no | The sensor display group not drifting between the two configs. |
+| `test_no_sim_time` | no | No shipped config enables `use_sim_time`. There is no `/clock` on this track. |
 
-The flatten is `pointcloud_to_laserscan` against a gravity-aligned target frame, banded to
-[0.30, 1.50] m above the floor. See `config/scan.yaml` — every value there carries the measurement
-that chose it.
+```bash
+colcon test --packages-select g1_navigation
+```
 
-**The depth camera is not a navigation input.** The D435i is pitched 47.6 degrees down and looks at
-the floor about 1.2 m ahead. It is a manipulation and near-field sensor.
+`test_navigate_to_pose` will fail occasionally without anything being wrong. It drives the real
+gait, which sometimes comes up unresponsive, and the suites are timing-sensitive. Re-run it alone
+before believing a red run:
 
-## What is covered, and how
+```bash
+ctest --test-dir build/g1_navigation -R '^test_navigate_to_pose$'
+```
 
-| | Coverage |
-|---|---|
-| The `odom -> base_footprint -> pelvis` chain and the scan | `test_scan_pipeline`, against a live headless sim |
-| slam_toolbox owning `map -> odom`, and the map's geometry | `test_slam_map`, against a live headless sim |
-| The frame split, the tilt guard, parameter validation | `g1_state_estimation`'s node and math suites |
-| No shipped config enables `use_sim_time` | `test_no_sim_time` |
-| Authority acquired on activate, released on deactivate, and `cmd_vel` discarded before it | `test_nav_authority`, live sim |
-| **The robot reaching a navigation goal on its own** | `test_navigate_to_pose` — the acceptance gate |
-| `localization.launch.py`, `config/localization.yaml`, `map_server` + AMCL | now covered: `test_navigate_to_pose` runs the whole stack in localization mode |
-| `g1_gait_shaper`'s contract, including never amplifying | `g1_locomotion`'s `test_gait_shaper` |
-| Authority released when the acquire *fails* | `g1_locomotion`'s `test_authority_release`, against a stub, no sim |
-| Arguments surviving `bringup.launch.py` -> `nav_sim.launch.py` -> `sim.launch.py` | `test_launch_threading`, no sim |
-| The sensor display group not drifting between the two RViz configs | `test_rviz_configs`, no sim |
-
-PR A shipped with localization deliberately untested; `test_navigate_to_pose` closes that, because
-it runs `map_server` + AMCL exactly as shipped.
-
-**`test_navigate_to_pose` will fail occasionally, for reasons outside this package.** See the two
-failure modes below. Re-run it alone before treating a red run as a regression — that is the same
-policy `g1_bringup`'s `test_walk_stand` carries, and there is deliberately no retry wrapper,
-because a retry would hide the very number that matters.
-
-## What sim validates, and what it does not
-
-Odometry on this track is **exact MuJoCo ground truth** — zero drift, zero noise, zero latency. That
-makes SLAM trivially easy here.
-
-Whether the robot's achievable motion is enough to reach a navigation goal **is** now tested, by
-`test_navigate_to_pose`. `test_scan_pipeline` and `test_slam_map` still pin the pelvis, because
-they are measuring geometry and a wandering robot would move the numbers.
-
-**Not** validated: loop closure under drift, scan-matching robustness, relocalization from a wrong
-initial pose, or any real odometry error model. Anything tuned against this is unvalidated on
-hardware.
-
-## Two failure modes, two separate mitigations
-
-These are unrelated, and only one of them has a mitigation that fires. Do not read the
-`OnProcessExit` handler as covering both — it covers exactly one.
-
-### A — `g1_loco_authority` dies while holding authority
-
-Nav2 and the shaper keep publishing, the bridge keeps re-issuing `SET_VELOCITY`, its 1 s dead-man
-never expires, and **the robot walks on to its goal with nobody supervising authority.**
-
-*Mitigation:* `nav2.launch.py` registers an `OnProcessExit` handler on the authority node that
-stops `g1_gait_shaper`. `cmd_vel` ceases, the bridge's staleness path emits one
-`SetVelocity(0,0,0)`, and the robot stands balanced.
-
-### B — the robot is fully healthy and will not walk
-
-`authority` HELD, `fsm_id` 500, no errors anywhere, and the gait simply does not respond.
-**Measured at 1 of 8 fresh launches.**
-
-**`OnProcessExit` does nothing here.** `g1_loco_authority` is alive and correct; there is no
-process exiting for anything to notice.
-
-*Mitigation:* Nav2's progress checker aborts the goal — and this is confirmed against the measured
-case, not assumed. `SimpleProgressChecker::check()` returns false when the robot has not moved
-more than `required_movement_radius` from its baseline within `movement_time_allowance`, and the
-baseline resets **only** when it does move enough. The recorded frozen case travelled 0.09 m in
-30 s, never within 0.5 m of resetting the baseline, so at `movement_time_allowance: 20.0` the
-checker trips and `controller_server` fails the goal. Observed live as
-`[controller_server]: Failed to make progress`.
-
-What that mitigation does **not** do is recover. It aborts. The robot stays frozen and only
-relaunching the simulator clears it. Nav2's recoveries cannot help either: `Spin` commands motion
-the robot ignores, `Wait` waits, and `ClearCostmap` clears a costmap that was never the problem.
-
-### A caveat on the 1-in-8 figure
-
-That number was measured with **`sensors:=true world:=navigation`**, which is what navigation
-runs. It is 8 samples, so treat it as order-of-magnitude.
-
-It may not transfer to other launch configurations. Three consecutive `sensors:=false` launches
-were frozen while the next `sensors:=true` launch walked immediately — 3 against 1, which at a
-12% base rate is unlikely (~0.2%) but not absurd, and no mechanism is known: `sensors` gates the
-LiDAR, the relay, the odometry publisher and the waist joint states, none of which touch the
-walking policy. Quote the figure for the navigation configuration only, and record the `sensors`
-value if you ever reproduce a frozen robot.
-
-**Unconfirmed, and it may well be higher.** Late in the PR B work, 3 of 4 consecutive
-`sensors:=true world:=navigation` launches came up unable to walk — one confirmed by publishing
-`vyaw` straight to `/g1_loco_bridge/cmd_vel`, bypassing Nav2 and the shaper, for zero motion at
-`authority: 2`, `fsm_id: 500`, `last_error_code: 0`. At a 12% rate, 3 or more in 4 is unlikely
-(~0.7%).
-
-Treat that as an observation, not a measurement. It is 4 samples, gathered incidentally while
-debugging something unrelated rather than from fresh isolated launches, and one of the four was
-degraded (the robot moved, but `Spin` never returned a result) rather than a clean freeze — which
-is a judgement call, not a threshold. It is not evidence the 12% figure is wrong, only that it has
-not been re-checked since it was taken.
-
-**The figure above is deliberately left as measured.** Re-measuring properly is a fast-follow: run
-Step 0's protocol from `docs/notes/milestone6-authority-timing.md` — N ≥ 8 fresh, isolated
-launches, each scored on displacement from the START-result pose rather than on velocity, with
-every non-moving run logged individually. Change the number only from that, never from a tally
-picked up in passing.
-
-Separately, the robot sometimes **falls over** rather than freezing — seen once during acceptance
-testing, at 117 degrees of tilt. The odometry publisher's tilt guard holds the last heading and
-says so, and the progress checker aborts the goal the same way. Three consecutive acceptance runs
-passed afterwards.
-
-## Known limitations
-
-**There is no `/clock`** — the simulator links no ROS. `use_sim_time` is false everywhere, and a
-ctest fails the build if any shipped config sets it true.
-
-**The ramp will map as an obstacle** once the costmaps exist: `slope_ramp`'s surface sits between
-0.08 and 0.24 m, above the floor cut a costmap needs to avoid painting the whole floor. That is the
-right answer for this gait, but it looks like a bug in RViz.
-
-**Mapped free space shows radial spokes at long range.** At 15 m adjacent 1-degree beams are 26 cm
-apart, so raytraced clearing fans out. Cosmetic; shortening the scan's `range_max` would trade real
-far-wall coverage for it.
-
-**The robot's fingers do not render in RViz, and cannot.** The palms do — they hang off the wrists
-by fixed joints — but the finger links need joint states, and nothing publishes them: the
-simulated model has 30 joints and **zero** finger DoF, so there is no hand state to publish. The
-URDF describes a robot with hands; the sim simulates one without. Publishing zeroed finger joints
-would put fabricated state on `/tf`, which is the thing `g1_state_estimation` refuses to do with
-odometry, so it is not done here either.
-
-**Reverse recovery behaviours are removed from both behavior trees.** `BackUp` and
-`DriveOnHeading` command reverse, and this gait reverses at −0.247 m/s for a commanded −0.60 and
-at exactly 0.000 for −0.40. Upstream's `backup_speed` is **0.05 m/s** — squarely inside that dead
-zone — so `BackUp` would command motion the robot cannot produce and burn its full
-`time_allowance` before failing, consuming the round-robin slot `Spin` could have used. Both are
-also dropped from `behavior_plugins`, so no action server exists to invoke. And independently of
-all that, `g1_gait_shaper` compares forward velocity **signed**, so any negative command becomes
-zero at any magnitude: even a hand-edited tree cannot produce a reverse lurch. Raising
-`backup_speed` to 0.6 is the only setting that would make them move the robot; that is an
-uncontrolled reverse lurch as a *recovery*, and it is rejected rather than overlooked.
+There is deliberately no retry wrapper, because a retry would hide the rate.

--- a/workspace/src/g1_navigation/maps/README.md
+++ b/workspace/src/g1_navigation/maps/README.md
@@ -1,29 +1,29 @@
 # maps
 
-`facility` is the `g1_navigation_scene` world, mapped with `slam.launch.py mode:=mapping` while
-the robot was driven around the four rooms. 361 x 359 cells at 5 cm, origin `[-9.05, -8.96]`,
-covering 18.1 x 18.0 m — the facility is 18 x 18 m. All four rooms, the corridor doorways, the
-shelving, the workbench and the pillars are resolved.
+`facility` is the `g1_navigation_scene` world, mapped with `mode:=mapping` while the robot was
+driven around the four rooms. 361 by 359 cells at 5 cm, origin `[-9.05, -8.96]`, covering 18.1 by
+18.0 m against a facility that is 18 by 18 m. All four rooms, the corridor doorways, the shelving,
+the workbench and the pillars are resolved.
 
 ## Only the occupancy grid is committed
 
-`map_saver_cli` produces `facility.pgm` + `facility.yaml`, which is what is here. slam_toolbox can
-also serialize its pose graph, and that is what its `localization` mode loads — but for this map
-those come out at **33 MB (`.posegraph`) and 1.6 MB (`.data`)**, against 130 KB for the grid. A
-33 MB binary that has to be regenerated whenever the scene changes does not belong in git.
+`map_saver_cli` produces `facility.pgm` and `facility.yaml`, which is what is here. slam_toolbox can
+also serialize its pose graph, and that is what its `localization` mode loads, but for this map
+those come out at 33 MB and 1.6 MB against 130 KB for the grid. A 33 MB binary that has to be
+regenerated whenever the scene changes does not belong in git.
 
-The consequence is that localization runs on `nav2_map_server` + AMCL rather than slam_toolbox's
-`localization` mode, which needs the pose graph. The cost is real and worth knowing: AMCL's motion
-model is parameterised on odometry noise, and this track's odometry is exact ground truth, so the
-model is degenerate and its `alpha1..5` cannot be tuned to anything that transfers to hardware.
+The consequence is that localization runs on `nav2_map_server` and AMCL rather than slam_toolbox's
+`localization` mode, which needs the pose graph. The cost is worth knowing: AMCL's motion model is
+parameterised on odometry noise, and this track's odometry is exact ground truth, so the model is
+degenerate and its `alpha1` through `alpha5` cannot be tuned to anything that transfers to hardware.
 
 ## Regenerating
 
 ```bash
-ros2 launch g1_navigation nav_sim.launch.py mode:=mapping
+ros2 launch g1_bringup bringup.launch.py mode:=mapping
 # drive the robot through all four rooms, then:
 ros2 run nav2_map_server map_saver_cli -f facility
 ```
 
 Re-map whenever `g1_bringup`'s `g1_navigation_scene.xml` changes. Nothing checks that the committed
-map still matches the scene — a stale map shows up as Nav2 planning through walls that moved.
+map still matches the scene, and a stale map shows up as Nav2 planning through walls that moved.

--- a/workspace/src/g1_sensor_relay/README.md
+++ b/workspace/src/g1_sensor_relay/README.md
@@ -1,0 +1,87 @@
+# g1_sensor_relay
+
+Publishes the sensor data sampled inside the patched `unitree_mujoco`. The simulator computes the
+LiDAR sweep and the camera render against its own `mjData` and hands finished frames over a local
+socket; this node turns them into ROS 2 messages.
+
+`ament_cmake`, C++20. Simulation only.
+
+```mermaid
+flowchart LR
+    MJ["unitree_mujoco<br/>sweep and render<br/>against mjData"] -- "unix socket<br/>length-prefixed frames" --> R
+    R["g1_sensor_relay"] --> PC["/livox/lidar"]
+    R --> D["/camera/aligned_depth_to_color/image_raw"]
+    R --> C["/camera/color/image_raw"]
+    R --> CI["camera_info"]
+```
+
+## Why the split exists
+
+`unitree_sdk2` and `rmw_cyclonedds` both call `dds_create_domain` unconditionally, and CycloneDDS
+allows exactly one explicit domain creation per domain id per process. They cannot coexist in
+either order. So the simulator links no ROS at all, and this node owns the ROS side.
+
+The sweep itself has to happen inside the simulator because it needs the scene: geometry, meshes
+and current pose all live in `mjData` in that process, and no DDS topic carries them. The finished
+frame is what crosses the boundary.
+
+## Topics
+
+| Topic | Type | Notes |
+|---|---|---|
+| `/livox/lidar` | `sensor_msgs/msg/PointCloud2` | Sensor data QoS, so a reliable subscriber sees nothing. |
+| `/camera/aligned_depth_to_color/image_raw` | `sensor_msgs/msg/Image` | `32FC1`, metres. Misses are NaN, not 0. |
+| `/camera/color/image_raw` | `sensor_msgs/msg/Image` | `rgb8` |
+| `/camera/aligned_depth_to_color/camera_info`, `/camera/color/camera_info` | `sensor_msgs/msg/CameraInfo` | Same intrinsics. |
+| `~/sensor_pose` | `geometry_msgs/msg/PoseStamped` | Where the simulator says the sensor is. Diagnostic. |
+
+Depth and colour come from one render, so they share a pose, a timestamp and intrinsics by
+construction. A real D435i only gets that alignment from its own align-depth-to-colour step, which
+is why the depth topic is named as if it had run.
+
+## Parameters
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `socket_path` | `/tmp/g1_sensors.sock` | Where the relay listens. The simulator connects to it. |
+| `frame_id` | `mid360_link` | Frame for the point cloud. |
+| `depth_frame_id` | `camera_depth_optical_frame` | REP-145 optical frame. |
+| `color_frame_id` | `camera_color_optical_frame` | REP-145 optical frame. |
+| `world_frame_id` | `world` | Frame for the diagnostic sensor pose. |
+
+Start order does not matter. The relay listens whenever it comes up and the simulator retries every
+cycle, so either process can start, die or restart independently.
+
+The optical frames are not `d435_link`. That is a body frame with x forward, and every depth
+consumer assumes the optical convention with z forward, so publishing in the link frame rotates the
+cloud 90 degrees.
+
+## Running
+
+The node starts with `sensors:=true`:
+
+```bash
+ros2 launch g1_bringup bringup.launch.py sensors:=true rviz:=true
+ros2 topic hz /livox/lidar
+```
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `frame_reader.{hpp,cpp}` | Framing and validation, free of ROS and sockets so the wire format tests without a simulator. |
+| `g1_sensor_relay_node.cpp` | The socket, the poll loop and the publishers. |
+| `sensor_frame.h` | The wire struct, duplicated on the simulator side. |
+
+The wire format is untrusted input: every length is validated before it is trusted, including the
+one multiply that could overflow.
+
+## Tests
+
+```bash
+colcon test --packages-select g1_sensor_relay
+```
+
+`test_frame_reader` covers the framing, the bounds checks and a drift check that reads both copies
+of `sensor_frame.h`. No simulator needed. `g1_bringup`'s `test_lidar_geometry` asserts the
+published cloud measures the room it is in.

--- a/workspace/src/g1_sim/README.md
+++ b/workspace/src/g1_sim/README.md
@@ -1,102 +1,96 @@
 # g1_sim
 
-**SIM-ONLY, and now a SANDBOX rather than the perception track.** The LiDAR and depth camera moved
-onto the real G1 in `g1_bringup` (`sensors:=true`), where perception, arms and locomotion share one
-simulation. This package survives because it starts in seconds and needs no walking policy, balance
-or DDS bridge, so a sensor question can be answered without touching the timing-critical track.
+**Simulation only, and a sandbox rather than the main track.**
 
-Three conditions keep it from becoming a second stack: it gains **no new capability** (no Nav2, no
-MoveIt, no manipulation), new work targets the converged track, and if it goes two milestones unused
-it should be deleted.
+A simplified mobile body carrying a 3D LiDAR and an RGB-D camera in MuJoCo, driven through
+`mujoco_ros2_control`. The LiDAR and depth camera moved onto the real G1 model in `g1_bringup`
+(`sensors:=true`), where perception, arms and locomotion share one simulation.
 
-**It also keeps a defect the converged track does not have.** The sandbox uses the vendor
-`mujoco_3d_lidar` plugin, whose raycast lets ~4% of returns through walls (see below). The converged
-track hand-rolls its sweep with `mj_ray` and does not carry that bug forward, so a leak seen here
+This package survives because it starts in seconds and needs no walking policy, balance or DDS
+bridge, so a sensor question can be answered without touching the timing-critical track.
+
+`ament_cmake`, no compiled code.
+
+```mermaid
+flowchart LR
+    MJCF["g1_perception_base.xml<br/>cylinder on 3 planar joints"] --> MRC["mujoco_ros2_control"]
+    MRC --> LID["/livox/lidar"]
+    MRC --> CAM["/camera/*"]
+    MRC --> JS["/joint_states"]
+    JS --> ODOM["g1_odometry_publisher<br/>sim_ground_truth"]
+```
+
+## Three conditions keep it from becoming a second stack
+
+It gains no new capability: no Nav2, no MoveIt, no manipulation. New work targets the converged
+track. If it goes two milestones unused, it should be deleted.
+
+It also keeps a defect the converged track does not have. The sandbox uses the vendor
+`mujoco_3d_lidar` plugin, whose raycast lets a few percent of returns pass through walls. The
+converged track hand-rolls its sweep with `mj_ray` and does not carry that bug, so a leak seen here
 says nothing about the real track, and a sandbox result must never be used to characterise it.
 
-The perception simulation track: a simplified mobile body carrying a 3D LiDAR and an
-RGB-D camera in MuJoCo, run through `mujoco_ros2_control`.
-
-This is a **second, independent simulation track**. `unitree_mujoco` (driven by `g1_bringup`) is
-untouched and remains the source of truth for arm and locomotion fidelity. The two are never run at
-the same time.
+The two tracks share a ROS domain and must never run at the same time.
 
 ## This is not the G1
 
-The body here is a deliberately non-physical mobility stand-in: a cylinder on three planar joints
-(slide-x, slide-y, hinge-z). It cannot topple and is commanded directly through `ros2_control`.
+The body is a deliberately non-physical stand-in: a cylinder on three planar joints, slide-x,
+slide-y and hinge-z. It cannot topple and is commanded directly through `ros2_control`. Early
+perception work does not need bipedal dynamics, and a 29-DoF humanoid with no balance controller
+would only topple or need a weld. Nothing here commands a motor on the G1 model, so no new writer
+appears on any low-level channel.
 
-Early perception work does not need bipedal dynamics to be correct, and a 29-DoF humanoid with no
-balance controller would only topple or need a weld. Nothing here commands a motor on the G1 model,
-so no new writer appears on any low-level control channel.
+What is real is the sensor mount poses. They come from Unitree's own vendored URDF, with
+`torso_link`'s offset from `pelvis` folded in.
 
-**What is real:** the sensor mount poses. They are taken from Unitree's own vendored URDF
-(`g1_description`, joints `mid360_joint` and `d435_joint`), with `torso_link`'s offset from `pelvis`
-folded in, and `base_link` sits at the pelvis spawn height of 0.793 m. So the sensors sit where they
-sit on the robot.
+| Frame | Mount, relative to `base_link` | Note |
+|---|---|---|
+| `livox_frame` | xyz `-0.00368 0.00003 0.472434`, rpy `pi 0.05112069 0` | Roll is exactly pi. The Mid360 is mounted upside down on the real G1, and missing that inverts every cloud relative to hardware. |
+| `camera_link` | xyz `0.05366 0.01753 0.473870`, rpy `0 0.83077672 0` | Pitched 47.6 degrees down, making it a near-ground manipulation camera rather than a forward-looking navigation one. |
+
+`base_link` spawns at 0.793 m, the G1's pelvis height. That number lives in
+`config/sensor_mounts.yaml` and nowhere else, so `odom` is the ground plane rather than a frame
+floating at spawn height.
 
 ## Scene
 
-An 8 x 8 m room, walls with inner faces at +/-4.0 m, floor at z = 0, and three obstacles at known
-poses. The geometry is deliberate: every sensor assertion in the integration tests is a geometric
-fact of `mjcf/g1_perception_base.xml`, so the tests measure something real rather than checking that
-data merely arrives.
+An 8 by 8 m room, walls with inner faces at plus or minus 4.0 m, floor at z = 0, and three
+obstacles at known poses. Every sensor assertion in the tests is a geometric fact of
+`mjcf/g1_perception_base.xml`, so the tests measure something real rather than checking that data
+merely arrives.
 
-## Frames
+## Running
 
-`base_link` spawns at **0.793 m**, the G1's pelvis height, so the sensors sit at realistic heights.
-That number lives in `config/sensor_mounts.yaml` as `base_link.spawn_z` and nowhere else:
-`test_sensor_mount_consistency` pins it to the MJCF, and `perception_sim.launch.py` hands it to
-`g1_odometry_publisher` as `base_height_m`. That makes **`odom` the ground plane** rather than a
-frame floating at the spawn height, so a cloud transformed into `odom` has its floor at z = 0.
+```bash
+ros2 launch g1_sim perception_sim.launch.py
+```
 
-## Sensors
+Do not run this while the `unitree_mujoco` track is up.
 
-| | Mount vs `base_link` | Notes |
+## Contents
+
+| Path | Purpose |
+|---|---|
+| `mjcf/g1_perception_base.xml` | The scene and the body. |
+| `urdf/g1_perception_base.urdf.xacro` | The matching description with the `ros2_control` block. |
+| `config/sensor_mounts.yaml` | Mount poses and the spawn height, in one place. |
+| `config/controllers.yaml` | The planar velocity controller. |
+| `config/mujoco_plugins.yaml` | LiDAR and camera plugin configuration. |
+| `launch/perception_sim.launch.py` | Brings up the simulator, controllers and odometry. |
+
+## Tests
+
+| Test | Needs a simulator | Covers |
 |---|---|---|
-| `livox_frame` | xyz `-0.00368 0.00003 0.472434`, rpy `pi 0.05112069 0` | **Roll is exactly pi: the Mid360 is mounted upside down on the real G1.** Replicated here, because missing it inverts every point cloud relative to hardware. |
-| `camera_link` | xyz `0.05366 0.01753 0.473870`, rpy `0 0.83077672 0` | **Pitched 47.6 degrees downward.** That makes it a manipulation / near-ground camera, not a forward-looking navigation one. |
+| `test_perception_sim_bringup` | yes | The graph comes up and the controllers activate. |
+| `test_lidar_stream` | yes | The scan measures the room's known walls. |
+| `test_camera_stream` | yes | Depth and colour streams, and camera info against the MJCF. |
+| `test_odom_ground_truth` | yes | The odometry chain against MuJoCo ground truth. |
+| `test_sensor_mount_consistency` | no | The mount config against the MJCF, so the two cannot drift. |
 
-LiDAR is configured to the real Mid360 envelope: 360 degrees azimuth, -7 to +52 degrees elevation,
-40 m range, 10 Hz, at 360 x 32 resolution (11,520 rays, about 115k pts/s against the real sensor's
-~200k).
+```bash
+colcon test --packages-select g1_sim
+```
 
-**What this LiDAR is not.** It is a uniform azimuth/elevation grid raycast, not the Mid360's
-non-repetitive rosette scan. Point density is uniform where the real sensor's is time-varying. There
-is no intensity, no per-point timestamps, no ring field, no noise, no dropout, no reflectivity
-dependence, and no motion distortion. Anything whose correctness depends on the real scan pattern,
-such as Livox-tuned LIO feature extraction or de-skewing, is **not** validated here. The real
-driver's `CustomMsg` format is not produced either; this publishes `PointCloud2`.
-
-**Known plugin artifact: rays leak through walls.** Roughly 4% of returns (about 440 of 11,520) pass
-straight through a wall and land on the floor plane outside the room. It is a contiguous band of
-downward rays, grid rows 9 to 13, about 10 to 18 degrees below horizontal, which would strike the
-wall below z ~= 0.55 m. Rays crossing the same wall higher up are blocked correctly, and the camera
-renders those same walls as solid at those same heights, so this is the plugin's raycast rather than
-the scene geometry. Consequence for downstream work: **a costmap fed directly from this cloud will
-see phantom obstacles outside the room.** `test_lidar_stream` asserts only that the great majority of
-returns land inside the room, so a real regression still fails while this artifact does not.
-
-The camera is `848x480 @ fovy 58`, about 87 degrees horizontal, matching the real D435i **depth**
-stream. One MuJoCo camera cannot carry two intrinsics, so the colour stream is wider than a real
-D435i colour stream. Matched to depth, which is what this track is for. No depth noise, no stereo
-dropout on textureless surfaces, no IR projector behaviour.
-
-## MJCF plugin API
-
-The 3D LiDAR is a MuJoCo **engine plugin**, configured in `<extension><instance>` and referenced
-from `<sensor>`. Config keys are `resolution`, `azimuth_range`, `elevation_range`, `max_range`,
-`min_range`, `update_rate`, `async`.
-
-The upstream README documents an older API (`mujoco.sensor.lidar` with `size` and `fov`) that does
-**not** work at the pinned commit. `elevation_range` being an explicit min/max, rather than a
-symmetric field of view, is why the asymmetric Mid360 band needs no compensating sensor pitch.
-
-The plugin registers itself under the ament resource index key `mujoco_plugins`, which the node
-scans at startup. No `MUJOCO_PLUGIN_DIR` is needed, and setting it does not work.
-
-`config/mujoco_plugins.yaml` must be keyed to **`mujoco_ros2_control_node`**, a second node living
-inside the same process as `controller_manager`. Key it to `controller_manager` and the parameters
-reach the wrong node: the log says `No 'mujoco_plugins' parameter found!`, the LiDAR never publishes
-at all, and the camera quietly auto-registers on default topics at the default rate. Key it to `/**`
-and it also matches every controller, shadowing their own sections.
+These share the same ctest resource lock as `g1_bringup`'s suites, because two simulators on one
+DDS graph is what makes them flaky.

--- a/workspace/src/g1_state_estimation/README.md
+++ b/workspace/src/g1_state_estimation/README.md
@@ -1,107 +1,101 @@
 # g1_state_estimation
 
-`odom -> base` state estimation for the G1.
+Publishes `odom` to the robot's base frame, and the TF chain Nav2 and slam_toolbox need.
+
+`ament_cmake`, C++20. One lifecycle node, `g1_odometry_publisher`.
+
+```mermaid
+flowchart LR
+    SM["/sportmodestate<br/>pelvis position"] --> N
+    LS["/lowstate<br/>IMU orientation"] --> N
+    N["g1_odometry_publisher"] --> TF["/tf<br/>odom to base_footprint to pelvis"]
+    N --> OD["~/odom"]
+```
 
 ## Odometry source
 
-The real G1 **publishes no odometry**. On hardware `/sportmodestate` carries
-`unitree_hg::SportModeState_`, which holds only `fsm_id`, `fsm_mode`, `task_id` and `task_time`. There
-is no pose and no velocity, and `rt/odommodestate` does not exist. So this package has three sources
-and only two of them are implemented:
+The real G1 publishes no odometry. On hardware `/sportmodestate` carries a type holding only
+`fsm_id`, `fsm_mode`, `task_id` and `task_time`. No pose, no velocity, and `rt/odommodestate` does
+not exist anywhere in Unitree's code.
 
 | `odometry_source` | Behaviour |
 |---|---|
-| `sim_sportmodestate` | The converged `unitree_mujoco` track. Pelvis position from `/sportmodestate` (which the simulator fills from `framepos`/`framelinvel` on the pelvis imu site) and full orientation from `/lowstate`'s IMU. |
-| `sim_ground_truth` | The `g1_sim` planar sandbox. MuJoCo generalized coordinates read from that track's planar joints. |
-| `hardware` (default) | **Refuses to run.** A real source (leg odometry + IMU EKF, or LiDAR-inertial odometry) is a future milestone. |
+| `sim_sportmodestate` | The `unitree_mujoco` track. Pelvis position from `/sportmodestate`, full orientation from `/lowstate`'s IMU. |
+| `sim_ground_truth` | The `g1_sim` planar sandbox. MuJoCo generalized coordinates from that track's planar joints. |
+| `hardware` (default) | Refuses to configure. A real source, leg odometry with an IMU EKF or LiDAR-inertial odometry, is a future milestone. |
 
 `hardware` is the default deliberately. A misconfigured hardware bring-up must never silently emit
-fabricated odometry, so simulation is the case that opts in.
+fabricated odometry, so simulation is the case that has to opt in.
 
-**Both sim sources are ground truth, not estimates.** Zero drift, zero noise, zero latency. Nothing
-here validates how a real estimator behaves under drift, foot slip, or the suspend/freeze handling
-that goes with it. Treat any tuning done against this as unvalidated on hardware.
+Both simulation sources are ground truth, not estimates: no drift, no noise, no latency. Nothing
+here validates how a real estimator behaves under drift or foot slip, so treat tuning done against
+it as unvalidated on hardware.
 
-No `map -> odom` is published. That is SLAM's, and it comes from `g1_navigation`.
+No `map` to `odom` transform is published. That belongs to SLAM, in `g1_navigation`.
 
 ## Frames
 
-Which chain gets published depends on `pelvis_frame_id`:
+Which chain is published depends on `pelvis_frame_id`:
 
 ```
-pelvis_frame_id: "pelvis"   ->   odom -> base_footprint -> pelvis     (converged track)
-pelvis_frame_id: ""         ->   odom -> base_link                    (planar sandbox)
+pelvis_frame_id: "pelvis"   ->   odom -> base_footprint -> pelvis    (unitree_mujoco track)
+pelvis_frame_id: ""         ->   odom -> base_link                   (planar sandbox)
 ```
 
-The split exists because Nav2 and slam_toolbox both want a gravity-aligned base frame, and a walking
-G1 does not have one: the pelvis rolls and pitches several degrees with the gait, and every sensor
-frame hangs off it. `base_footprint` is the REP-105 ground projection — x, y and heading only, z
-pinned to 0 — and `base_footprint -> pelvis` carries the height and the tilt the projection drops.
+Nav2 and slam_toolbox both want a gravity-aligned base frame, and a walking G1 does not have one:
+the pelvis rolls and pitches several degrees with the gait, and every sensor frame hangs off it.
+`base_footprint` is the REP-105 ground projection, carrying x, y and heading with z pinned to zero,
+and `base_footprint` to `pelvis` carries the height and tilt the projection drops.
 
-Inserted rather than published as a second edge off `odom`. Two sibling edges would make every
-`mid360_link -> base_footprint` lookup compose two independently-published dynamic transforms, which
-agree only if they always carry the identical stamp; one chain cannot be inconsistent even in
-principle. Both edges go out in a single `sendTransform` call for the same reason.
+The pelvis edge is inserted into the chain rather than published as a second edge off `odom`. Two
+sibling edges would make every sensor lookup compose two independently published dynamic
+transforms, which agree only if they always carry an identical stamp. One chain cannot be
+inconsistent even in principle. Both edges go out in a single `sendTransform` call for the same
+reason.
 
 Past `max_tilt_deg` the heading extraction is ill-conditioned, so the last well-conditioned heading
-is held. The attitude keeps being published unchanged — a fallen robot really is tilted.
+is held. Attitude keeps being published unchanged, because a fallen robot really is tilted.
 
-## `g1_odometry_publisher`
+## Parameters
 
-Lifecycle node. Configuration is where the source decision is enforced, so a refusal is externally
-observable: with `odometry_source=hardware` it returns FAILURE from `on_configure` and stays in
-`unconfigured` having created **no publisher and no broadcaster**. Advertising `/tf` and then going
-quiet would be indistinguishable from a healthy node with a stalled source.
+| Parameter | Default | Meaning |
+|---|---|---|
+| `odometry_source` | `hardware` | See the table above. |
+| `odom_frame_id` | `odom` | |
+| `base_frame_id` | `base_footprint` | |
+| `pelvis_frame_id` | `""` | Empty publishes one edge; naming a link splits it in two. |
+| `base_height_m` | `0.0` | Height of the base above the floor, making `odom` the ground plane. |
+| `max_tilt_deg` | `80.0` | Beyond this the heading is held. |
+| `publish_rate_hz` | `50.0` | |
+| `publish_odom_msg` | `true` | |
+| `source_timeout_ms` | `200.0` | Source age beyond this stops publishing. |
 
-| Interface | Dir | Type | Source |
-|---|---|---|---|
-| `~/sport_state` (remap to `/sportmodestate`) | in | `unitree_go/SportModeState` | `sim_sportmodestate` |
-| `~/imu_state` (remap to `/lowstate`) | in | `unitree_hg/LowState` | `sim_sportmodestate` |
-| `~/base_state` (remap to `/base_joint_states`) | in | `sensor_msgs/JointState` | `sim_ground_truth` |
-| `/tf` | out | `tf2_msgs/TFMessage` | both |
-| `~/odom` | out | `nav_msgs/Odometry` | both |
+Shipped configs: `g1_odometry_publisher_converged.yaml` for the `unitree_mujoco` track,
+`g1_odometry_publisher.yaml` for the planar sandbox.
 
-Orientation comes from `/lowstate` rather than `/sportmodestate` because `unitree_mujoco` leaves the
-latter's `imu_state` at all zeros, and tf2 normalises a zero quaternion straight to NaN and then
-silently drops the transform.
+## Running
 
-`~/odom` describes `base_frame_id`, taken from the transform that was just published so the two
-cannot disagree. On a split chain that means the footprint: z and tilt are absent because
-`child_frame_id` says `base_footprint`, and `toBodyTwist()` is yaw-only, which is exactly that frame.
+The node comes up with `sensors:=true`:
 
-Each track has its own file: `config/g1_odometry_publisher.yaml` for the **planar sandbox**, and
-`config/g1_odometry_publisher_converged.yaml` for the **converged track**, which
-`g1_bringup/launch/sim.launch.py` loads. Joints are looked up **by name**, since
-`joint_state_broadcaster` makes no promise about ordering.
+```bash
+ros2 launch g1_bringup bringup.launch.py sensors:=true
+ros2 run tf2_ros tf2_echo odom base_footprint
+```
 
-`base_height_m` applies to the planar track only: its base has no z DoF, so the spawn height comes
-from `g1_sim/config/sensor_mounts.yaml` via the launch. The converged track measures z and leaves
-this at 0.
+It is a lifecycle node, and configuration is where the source decision is enforced, so a refusal is
+visible as a failed transition rather than a silent absence of transforms.
 
-Staleness has two budgets. `source_timeout_ms` bounds the data's age on the source clock;
-`wall_timeout_ms` bounds it on `steady_clock`, measured from the last stamp **change**. The second
-is not redundant: a wedged simulator freezes its own clock too, so a source-clock-only check would
-never fire. Either budget tripping stops the transform rather than re-stamping the last pose. On the
-converged track the orientation gets its own wall budget, because position and attitude arrive on
-different topics and one can die while the other keeps flowing.
+## Tests
 
-## `odom_math`
+None need a simulator.
 
-Frame and staleness math, kept free of ROS so it tests without a node, DDS or a running sim (same
-split as `g1_motion_service_sim`'s `blend_math`). Covers the ground projection and its
-recomposition, the
-world-to-body twist rotation, yaw/quaternion conversion, tilt from vertical, angle wrapping, the
-staleness boundary, and covariance fill.
-
-Two parts worth knowing about:
-
-- `nav_msgs/Odometry` defines `twist` in the **child** frame, while both sources report velocity in
-  the world frame. They agree only at yaw zero.
-- `quaternionToYaw()` is the full ZYX yaw, not `2*atan2(z, w)`. The short form is exact only for a
-  pure +z rotation, which the planar base always is and a walking G1 never is.
-
-## Testing
+| Test | Covers |
+|---|---|
+| `test_odom_math` | Ground projection and its recomposition, heading extraction, the tilt guard. |
+| `test_odometry_publisher_node` | The node itself: source selection, the hardware refusal, frame chains, timeouts. |
 
 ```bash
 colcon test --packages-select g1_state_estimation
 ```
+
+`g1_navigation`'s `test_scan_pipeline` exercises the frame chain against a live simulator.


### PR DESCRIPTION
The root README described the upstream container template, not this project. It never mentioned the G1, the packages or the architecture, and it still documented `pid: host` and the four single-file config mounts removed in the PR below. Rewritten around what Grove-G1 actually is, with a stack diagram and a package map.

Package READMEs are trimmed to what a user of the package needs: purpose, files, interfaces, launch arguments, config, how to run, tests. Each gets a diagram of where it sits.

Design reasoning, measured provenance and abandoned approaches moved to local notes, which are gitignored. Nothing was deleted: all nine previous READMEs are archived verbatim first.

What stayed public is anything an operator needs before touching the robot, including the gait dead-zone table. Commanding 0.5 m/s and watching nothing happen is a support question, not archaeology.

| | Before | After |
|---|---|---|
| `g1_bringup` | 310 | 130 |
| `g1_locomotion` | 297 | 128 |
| `g1_navigation` | 261 | 141 |
| `g1_motion_service_sim` | 236 | 155 |

`g1_sensor_relay` had no README at all and now has one.
