### PR TITLE
Fix AMCL corrections and tighten the costmap sensor window

### DIFF
--- a/workspace/src/g1_navigation/CMakeLists.txt
+++ b/workspace/src/g1_navigation/CMakeLists.txt
@@ -8,6 +8,15 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+# Soak test and its recorder. Same arrangement as g1_bringup's activate_arm: run in-container
+# via `ros2 run g1_navigation nav_soak`, not from the host.
+install(
+  PROGRAMS
+    scripts/nav_soak
+    scripts/nav_diag.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   # Linters that don't conflict with ruff. No pep257, matching g1_bringup and g1_sim, the two
   # other launch-heavy packages: its D213 wants the docstring summary on the second line and
@@ -74,6 +83,7 @@ if(BUILD_TESTING)
       NAME ruff_check_g1_navigation
       COMMAND ${RUFF_EXECUTABLE} check --config ${_ruff_config}
               ${CMAKE_CURRENT_SOURCE_DIR}/launch ${CMAKE_CURRENT_SOURCE_DIR}/test
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts
     )
   else()
     message(WARNING "ruff and/or workspace ruff.toml not found; skipping ruff_check_g1_navigation test")

--- a/workspace/src/g1_navigation/README.md
+++ b/workspace/src/g1_navigation/README.md
@@ -130,6 +130,41 @@ Nav2 dependency.
 colcon test --packages-select g1_navigation
 ```
 
+## Soak test
+
+`nav_soak` brings the stack up, drives a list of goals across the facility one at a time,
+records health, and tears everything down.
+
+```bash
+ros2 run g1_navigation nav_soak                        # default goal list
+ros2 run g1_navigation nav_soak --rviz
+ros2 run g1_navigation nav_soak --goals "3.0 -3.0,-2.5 2.0"
+```
+
+It reports distance driven, how much of Nav2's output falls inside the gait shaper's dead
+band, `map` to `odom` correction sizes, pelvis pitch through the gait, and local costmap
+lethal-cell counts. `nav_diag.py` is the recorder and also runs on its own against a stack
+that is already up:
+
+```bash
+ros2 run g1_navigation nav_diag.py 200
+```
+
+Three details in `nav_soak` are load-bearing, and doing any of them the obvious way produces
+results that look like stack defects. It sends one goal at a time and lets each finish, since
+killing the action client mid-goal lets the next goal preempt the running one and the robot
+falls. It tears down by process group and sweeps `/proc/PID/cmdline` rather than executable
+paths, because anything running as `python3` or the `ros2` CLI otherwise survives as an orphan
+into the next run. And it reads readiness from the launch log, because action and TF discovery
+can exceed any reasonable timeout and AMCL only publishes `/amcl_pose` after a motion-gated
+update, so a stationary robot never emits one.
+
+Verify by hand that nothing survived:
+
+```bash
+ros2 node list --no-daemon | sort | uniq -d    # any output means an orphan is still running
+```
+
 `test_navigate_to_pose` will fail occasionally without anything being wrong. It drives the real
 gait, which sometimes comes up unresponsive, and the suites are timing-sensitive. Re-run it alone
 before believing a red run:

--- a/workspace/src/g1_navigation/config/localization.yaml
+++ b/workspace/src/g1_navigation/config/localization.yaml
@@ -30,11 +30,20 @@ amcl:
     # a poor description of a gait that produces 0.3 m/s of uncommanded lateral motion, which
     # is another reason not to read anything into the alphas.
     robot_model_type: "nav2_amcl::DifferentialMotionModel"
-    alpha1: 0.2
-    alpha2: 0.2
-    alpha3: 0.2
-    alpha4: 0.2
-    alpha5: 0.2
+    # Deliberately an order of magnitude below the usual 0.2. Those values describe wheel slip
+    # on a real differential base; this track's odometry is MuJoCo ground truth, so 0.2 injects
+    # error that is not there. The particle cloud spread on every motion update and the scan
+    # match then pulled it back, which is what produced visible map to odom steps: measured at
+    # 11 corrections in 200 s, up to 10.4 cm and 2.08 deg, against a source that is exact by
+    # construction.
+    #
+    # SIM-ONLY tuning. On hardware, where odometry really does drift, these are far too tight
+    # and the filter would fail to track. See docs/notes for the measurement.
+    alpha1: 0.02
+    alpha2: 0.02
+    alpha3: 0.02
+    alpha4: 0.02
+    alpha5: 0.02
 
     # Matches the scan's own limits, so AMCL weighs exactly the beams that exist.
     laser_max_range: 25.0
@@ -51,10 +60,12 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
 
-    # The robot walks in ~0.5 m bursts between gait initiations, so a tighter update threshold
-    # would resample on noise rather than on motion.
-    update_min_d: 0.25
-    update_min_a: 0.2
+    # Tightened alongside the alphas above. The original reasoning was that a smaller threshold
+    # resamples on noise, but with the alphas cut there is far less injected noise to resample
+    # on, and batching the correction until the robot had moved 0.25 m is what made it land as
+    # one visible step. A 56 s gap between corrections was measured at the old values.
+    update_min_d: 0.10
+    update_min_a: 0.10
 
     sigma_hit: 0.2
     z_hit: 0.5

--- a/workspace/src/g1_navigation/config/nav2_params.yaml
+++ b/workspace/src/g1_navigation/config/nav2_params.yaml
@@ -172,6 +172,8 @@ controller_server:
       rotate_to_heading_angular_accel: 10.0
       lookahead_dist: 0.9                 # GUESS, and mostly inert -- see the note above
       use_velocity_scaled_lookahead_dist: false
+      # Left at 1.0. This is the controller's own pose-transform tolerance, not a costmap's,
+      # and tightening it is a separate question from the sensor-staleness one below.
       transform_tolerance: 1.0
 
 local_costmap:
@@ -181,7 +183,12 @@ local_costmap:
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_footprint
-      transform_tolerance: 1.0
+      # 0.3, upstream's default, not 1.0. One second is longer than a gait cycle, so a
+      # cloud could be transformed with a pelvis attitude from the opposite phase of the
+      # step. The pelvis swings 9.31 deg peak to peak while walking (measured), and at
+      # obstacle_max_range even a fraction of that lifts floor returns above the 0.08 m
+      # cut. If this starts dropping clouds, that is the finding: TF genuinely lags.
+      transform_tolerance: 0.3
       use_sim_time: false
       rolling_window: true
       width: 3
@@ -228,9 +235,18 @@ local_costmap:
           max_obstacle_height: 1.80
           # At 15 m adjacent 1-degree beams are 26 cm apart, so long-range raytracing leaves
           # radial spoke gaps in cleared space. GUESSES.
-          raytrace_max_range: 12.0
+          # Pulled in from 12.0/10.0. Attitude error scales with range: at 10 m, 0.5 deg of
+          # unaccounted pelvis pitch lifts a floor return 8.7 cm, clearing the 0.08 m cut on
+          # its own, and the gait swings 9.31 deg. Beyond about 5 m the sweep cannot be
+          # trusted to stay below the cut while walking. raytrace stays above obstacle so
+          # anything markable is also clearable.
+          #
+          # Inert for the local costmap, which is 3 x 3 m rolling and can only hold returns
+          # within 1.5 m. These matter for the global costmap, where a long-range floor strike
+          # is what persists.
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 10.0
+          obstacle_max_range: 5.0
           obstacle_min_range: 0.0
       always_send_full_costmap: True
 
@@ -241,7 +257,12 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_footprint
-      transform_tolerance: 1.0
+      # 0.3, upstream's default, not 1.0. One second is longer than a gait cycle, so a
+      # cloud could be transformed with a pelvis attitude from the opposite phase of the
+      # step. The pelvis swings 9.31 deg peak to peak while walking (measured), and at
+      # obstacle_max_range even a fraction of that lifts floor returns above the 0.08 m
+      # cut. If this starts dropping clouds, that is the finding: TF genuinely lags.
+      transform_tolerance: 0.3
       use_sim_time: false
       # The standing footprint is smaller, but the gait drifts 0.22-0.30 m/s laterally while
       # walking forward, so the swept corridor is wider than the body. Circular rather than a
@@ -271,9 +292,18 @@ global_costmap:
           max_obstacle_height: 1.80
           # At 15 m adjacent 1-degree beams are 26 cm apart, so long-range raytracing leaves
           # radial spoke gaps in cleared space. GUESSES.
-          raytrace_max_range: 12.0
+          # Pulled in from 12.0/10.0. Attitude error scales with range: at 10 m, 0.5 deg of
+          # unaccounted pelvis pitch lifts a floor return 8.7 cm, clearing the 0.08 m cut on
+          # its own, and the gait swings 9.31 deg. Beyond about 5 m the sweep cannot be
+          # trusted to stay below the cut while walking. raytrace stays above obstacle so
+          # anything markable is also clearable.
+          #
+          # Inert for the local costmap, which is 3 x 3 m rolling and can only hold returns
+          # within 1.5 m. These matter for the global costmap, where a long-range floor strike
+          # is what persists.
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 10.0
+          obstacle_max_range: 5.0
           obstacle_min_range: 0.0
       static_layer:
         plugin: "nav2_costmap_2d::StaticLayer"

--- a/workspace/src/g1_navigation/scripts/nav_diag.py
+++ b/workspace/src/g1_navigation/scripts/nav_diag.py
@@ -1,0 +1,200 @@
+"""Records navigation health while the robot drives.
+
+Started by `nav_soak`, and usable by hand against an already-running stack:
+
+    ros2 run g1_navigation nav_diag.py 200
+
+Prints a snapshot every 20 s so a long run can be watched, and a summary on exit. The
+summary is the output that matters; the snapshots are progress.
+"""
+import math
+import signal
+import statistics as st
+import sys
+
+import rclpy
+import tf2_ros
+from geometry_msgs.msg import Twist
+from nav_msgs.msg import OccupancyGrid
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from rclpy.time import Duration, Time
+from sensor_msgs.msg import PointCloud2
+
+SWEEP_S = 0.032        # measured cost of one full 360x32 sweep
+OBSTACLE_RANGE = 5.0   # obstacle_max_range in config/nav2_params.yaml
+FLOOR_CUT = 0.08       # min_obstacle_height
+FWD_ENGAGE = 0.45      # g1_locomotion/config/g1_gait_shaper.yaml
+YAW_ENGAGE = 1.20
+
+
+def yaw_of(q):
+    return math.atan2(2.0 * (q.w * q.z + q.x * q.y), 1.0 - 2.0 * (q.y * q.y + q.z * q.z))
+
+
+def pitch_of(q):
+    s = 2.0 * (q.w * q.y - q.z * q.x)
+    return math.asin(max(-1.0, min(1.0, s)))
+
+
+class NavDiag(Node):
+    def __init__(self):
+        super().__init__("nav_diag")
+        self.buf = tf2_ros.Buffer(cache_time=Duration(seconds=10))
+        self.lis = tf2_ros.TransformListener(self.buf, self)
+
+        self.tilt_err = []
+        self.map_odom = []
+        self.jumps = []
+        self.pitch = []
+        self.lethal = []
+        self.odom_xy = []
+        self.shaped_nonzero = 0
+        self.nav_cmd = 0
+        self.nav_cmd_in_deadband = 0
+
+        self.create_subscription(PointCloud2, "/livox/lidar", self.on_cloud,
+                                 QoSProfile(depth=5,
+                                            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                                            history=QoSHistoryPolicy.KEEP_LAST))
+        self.create_subscription(
+            OccupancyGrid, "/local_costmap/costmap", self.on_costmap,
+            QoSProfile(depth=1, reliability=QoSReliabilityPolicy.RELIABLE,
+                       durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+                       history=QoSHistoryPolicy.KEEP_LAST))
+        self.create_subscription(Twist, "/g1_loco_bridge/cmd_vel", self.on_shaped, 10)
+        self.create_subscription(Twist, "/cmd_vel", self.on_nav_cmd, 10)
+        self.create_timer(0.05, self.on_tick)
+        self.create_timer(20.0, self.snapshot)
+
+    def on_shaped(self, msg):
+        if abs(msg.linear.x) > 1e-6 or abs(msg.angular.z) > 1e-6:
+            self.shaped_nonzero += 1
+
+    def on_nav_cmd(self, msg):
+        """Nav2's output, before the shaper. Anything inside the deadband becomes a stop."""
+        self.nav_cmd += 1
+        if abs(msg.linear.x) < FWD_ENGAGE and abs(msg.angular.z) < YAW_ENGAGE:
+            self.nav_cmd_in_deadband += 1
+
+    def on_cloud(self, msg):
+        """How far the pelvis tilt moves across one sweep window.
+
+        The cloud is stamped at relay publish time, but the geometry it describes was sampled
+        up to a sweep earlier, so this is the attitude error the costmap transform inherits.
+        """
+        stamp = Time.from_msg(msg.header.stamp)
+        try:
+            a = self.buf.lookup_transform("base_footprint", "pelvis", stamp)
+            b = self.buf.lookup_transform("base_footprint", "pelvis",
+                                          stamp - Duration(seconds=SWEEP_S))
+        except Exception:
+            return
+        self.tilt_err.append(
+            math.degrees(abs(pitch_of(a.transform.rotation) - pitch_of(b.transform.rotation))))
+
+    def on_costmap(self, msg):
+        self.lethal.append(sum(1 for v in msg.data if v >= 253))
+
+    def on_tick(self):
+        t = self.get_clock().now().nanoseconds * 1e-9
+        try:
+            tr = self.buf.lookup_transform("map", "odom", rclpy.time.Time())
+            x, y = tr.transform.translation.x, tr.transform.translation.y
+            yaw = yaw_of(tr.transform.rotation)
+            if self.map_odom:
+                _, px, py, pyaw = self.map_odom[-1]
+                dxy = math.hypot(x - px, y - py)
+                dyaw = abs(math.atan2(math.sin(yaw - pyaw), math.cos(yaw - pyaw)))
+                if dxy > 0.005 or dyaw > 0.005:
+                    self.jumps.append((t, dxy, dyaw))
+            self.map_odom.append((t, x, y, yaw))
+        except Exception:
+            pass
+        try:
+            tr = self.buf.lookup_transform("base_footprint", "pelvis", rclpy.time.Time())
+            self.pitch.append(pitch_of(tr.transform.rotation))
+        except Exception:
+            pass
+        try:
+            tr = self.buf.lookup_transform("odom", "base_footprint", rclpy.time.Time())
+            self.odom_xy.append((tr.transform.translation.x, tr.transform.translation.y))
+        except Exception:
+            pass
+
+    def distance(self):
+        return sum(math.hypot(self.odom_xy[i][0] - self.odom_xy[i - 1][0],
+                              self.odom_xy[i][1] - self.odom_xy[i - 1][1])
+                   for i in range(1, len(self.odom_xy)))
+
+    def snapshot(self):
+        pct = (100.0 * self.nav_cmd_in_deadband / self.nav_cmd) if self.nav_cmd else 0.0
+        print("[snap] driven=%.2fm  nav2_cmds=%d (%.0f%% in deadband)  shaped_nonzero=%d  "
+              "amcl_corrections=%d  lethal_now=%s"
+              % (self.distance(), self.nav_cmd, pct, self.shaped_nonzero, len(self.jumps),
+                 self.lethal[-1] if self.lethal else "n/a"))
+        sys.stdout.flush()
+
+    def report(self):
+        def stats(v, scale=1.0, unit=""):
+            if not v:
+                return "no data"
+            w = sorted(x * scale for x in v)
+            return ("n=%d  min=%.3f  med=%.3f  p95=%.3f  max=%.3f %s"
+                    % (len(w), w[0], st.median(w), w[int(0.95 * (len(w) - 1))], w[-1], unit))
+
+        print("\n================ NAV DIAGNOSTICS ================")
+        print("distance driven       : %.2f m" % self.distance())
+        if self.nav_cmd:
+            print("nav2 cmd_vel          : %d, of which %d (%.0f%%) inside the shaper deadband"
+                  % (self.nav_cmd, self.nav_cmd_in_deadband,
+                     100.0 * self.nav_cmd_in_deadband / self.nav_cmd))
+        print("shaped non-zero       : %d" % self.shaped_nonzero)
+        print("pelvis pitch          :", stats(self.pitch, 180 / math.pi, "deg"))
+        if self.pitch:
+            print("  swing               : %.2f deg peak to peak"
+                  % ((max(self.pitch) - min(self.pitch)) * 180 / math.pi))
+        print("tilt change per sweep :", stats(self.tilt_err, 1.0, "deg"))
+        if self.tilt_err:
+            mx = max(self.tilt_err)
+            print("  vertical error at %.0f m: max %.2f m  (floor cut is %.2f m)"
+                  % (OBSTACLE_RANGE, OBSTACLE_RANGE * math.sin(math.radians(mx)), FLOOR_CUT))
+        print("local costmap lethal  :", stats(self.lethal))
+        span = (self.map_odom[-1][0] - self.map_odom[0][0]) if self.map_odom else 0
+        print("map->odom corrections : %d over %.0f s" % (len(self.jumps), span))
+        if self.jumps:
+            print("  translation         :", stats([j[1] for j in self.jumps], 100, "cm"))
+            print("  rotation            :", stats([j[2] for j in self.jumps], 180 / math.pi, "deg"))
+            if len(self.jumps) > 1:
+                print("  gaps between them   :",
+                      stats([self.jumps[i][0] - self.jumps[i - 1][0]
+                             for i in range(1, len(self.jumps))], 1.0, "s"))
+        print("=================================================\n")
+        sys.stdout.flush()
+
+
+def main():
+    rclpy.init()
+    node = NavDiag()
+
+    # The summary has to survive a signal. KeyboardInterrupt is a BaseException, so an
+    # `except Exception` around the spin loop silently skips report() and the run ends with
+    # no numbers at all.
+    stop = {"now": False}
+    signal.signal(signal.SIGINT, lambda *_: stop.update(now=True))
+    signal.signal(signal.SIGTERM, lambda *_: stop.update(now=True))
+
+    duration = float(sys.argv[1]) if len(sys.argv) > 1 else 200.0
+    end = node.get_clock().now().nanoseconds * 1e-9 + duration
+    try:
+        while rclpy.ok() and not stop["now"]:
+            if node.get_clock().now().nanoseconds * 1e-9 >= end:
+                break
+            rclpy.spin_once(node, timeout_sec=0.1)
+    except BaseException:
+        pass
+    node.report()
+
+
+if __name__ == "__main__":
+    main()

--- a/workspace/src/g1_navigation/scripts/nav_soak
+++ b/workspace/src/g1_navigation/scripts/nav_soak
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Navigation soak test. Brings the stack up, drives a list of goals across the facility one at
+# a time, records health, and tears everything down.
+#
+# Run inside the container:
+#   ros2 run g1_navigation nav_soak
+#   ros2 run g1_navigation nav_soak --rviz
+#   ros2 run g1_navigation nav_soak --goals "3.0 -3.0,-2.5 2.0"
+#
+# Default goals are ones an operator drove interactively in a session that completed all of
+# them with no falls and no recoveries. They cross the facility rather than nudging around the
+# origin, which is where costmap and localization problems actually show up.
+#
+# Three things this gets right, each of which produced a false "stack defect" when done the
+# obvious way. See docs/notes for the measurements.
+#
+#   1. One goal at a time, allowed to finish. Wrapping the action client in a hard timeout
+#      kills it mid-goal and lets the next goal preempt the running one; abrupt replanning
+#      through a bang-bang gait topples the robot.
+#   2. Teardown by process group, then a sweep on /proc/PID/cmdline. Sweeping executable paths
+#      misses everything running as python3 or the ros2 CLI, which survives as an
+#      init-reparented orphan into the next run and puts a second writer on the velocity path.
+#   3. Readiness read from the launch log. Live queries are unreliable here: action and TF
+#      discovery can exceed any sane timeout, and AMCL publishes /amcl_pose only after a
+#      motion-gated update, so a stationary robot never emits one.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIAG="$SCRIPT_DIR/nav_diag.py"
+LOG=/tmp/nav_soak_launch.log
+DIAG_OUT=/tmp/nav_soak_diag.txt
+PGID_FILE=/tmp/nav_soak.pgid
+
+RVIZ=false
+GOALS_RAW="4.15 -6.96,-2.79 -6.69,5.21 1.93,5.37 2.08,-4.67 4.97,-4.46 7.58,6.31 -2.10,6.53 -7.00,-2.51 -6.42,4.13 1.76,2.80 6.92,-7.49 5.23,-2.44 -6.90"
+
+# Above the 4.0 navigation default. The simulator's first physics tick can land before the
+# bridge and controller_manager finish DDS discovery, and the robot topples at spawn when it
+# does. sim.launch.py's own argument documentation says to raise this.
+DELAY="${SIM_START_DELAY_S:-8.0}"
+SETTLE="${SETTLE_S:-100}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --rviz)  RVIZ=true; shift ;;
+        --goals) GOALS_RAW="$2"; shift 2 ;;
+        -h|--help) sed -n '3,27p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+IFS=',' read -r -a GOALS <<< "$GOALS_RAW"
+
+teardown() {
+    if [ -f "$PGID_FILE" ]; then
+        PGID=$(cat "$PGID_FILE")
+        kill -TERM -"$PGID" 2>/dev/null
+        for _ in $(seq 1 15); do pgrep -g "$PGID" >/dev/null 2>&1 || break; sleep 1; done
+        kill -KILL -"$PGID" 2>/dev/null
+        rm -f "$PGID_FILE"
+    fi
+    sleep 3
+    for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+        [ "$p" = "$$" ] && continue
+        cmd=$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null) || continue
+        exe=$(readlink "/proc/$p/exe" 2>/dev/null)
+        case "$cmd$exe" in
+            *nav_diag.py*|*"ros2 launch"*|*"ros2 action"*|*/root/workspace/install/*|*unitree_mujoco*|\
+            *rviz2*|*ros2_control_node*|*robot_state_publisher*|*component_container*|*nav2_*|\
+            *controller_server*|*planner_server*|*bt_navigator*|*amcl*|*map_server*|*lifecycle_manager*)
+                kill -KILL "$p" 2>/dev/null ;;
+        esac
+    done
+    rm -f /opt/unitree_robotics/unitree_robots/g1/*.staged.xml 2>/dev/null
+    ros2 daemon stop >/dev/null 2>&1
+}
+
+verify_clean() {
+    n=0
+    for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+        [ "$p" = "$$" ] && continue
+        cmd=$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null) || continue
+        case "$cmd" in
+            *nav_diag.py*|*/root/workspace/install/*|*unitree_mujoco*|*"ros2 launch"*) n=$((n + 1)) ;;
+        esac
+    done
+    echo "  workspace processes still alive: $n"
+    # --no-daemon deliberately: the daemon caches the graph and will list nodes that died
+    # minutes ago. A duplicate name means an orphan is still running.
+    dup=$(timeout 25 ros2 node list --no-daemon 2>/dev/null | sort | uniq -d)
+    if [ -n "$dup" ]; then
+        echo "  DUPLICATE NODES (orphans alive):"; echo "$dup" | sed 's|^|    |'
+    else
+        echo "  duplicate node names: none"
+    fi
+}
+
+trap 'echo; echo "interrupted, tearing down"; teardown; exit 130' INT TERM
+
+echo "########## teardown before starting ##########"
+teardown
+verify_clean
+
+echo
+echo "########## launch ##########"
+setsid ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true \
+    rviz:="$RVIZ" sim_start_delay_s:="$DELAY" > "$LOG" 2>&1 &
+LEADER=$!
+sleep 2
+ps -o pgid= -p "$LEADER" 2>/dev/null | tr -d ' ' > "$PGID_FILE"
+sleep "$SETTLE"
+
+FELL=$(grep -ac "is falling, not turning" "$LOG")
+READY=NOTREADY
+for _ in $(seq 1 12); do
+    if [ "$(grep -ac 'Managed nodes are active' "$LOG")" -ge 2 ]; then READY=READY; break; fi
+    sleep 5
+done
+
+echo "  fall warnings: ${FELL:-?}   nav2: $READY"
+if [ "${FELL:-1}" != "0" ] || [ "$READY" != "READY" ]; then
+    echo "  NOT HEALTHY. Aborting before any goal is sent."
+    teardown
+    exit 3
+fi
+
+echo
+echo "########## ${#GOALS[@]} goals, one at a time ##########"
+python3 "$DIAG" 100000 > "$DIAG_OUT" 2>&1 &
+DIAG_PID=$!
+sleep 4
+
+i=0
+for g in "${GOALS[@]}"; do
+    i=$((i + 1))
+    read -r gx gy <<< "$g"
+    printf "  goal %2d/%d  (%s, %s)  " "$i" "${#GOALS[@]}" "$gx" "$gy"
+    ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
+        "{pose: {header: {frame_id: map}, pose: {position: {x: $gx, y: $gy}, orientation: {w: 1.0}}}}" 2>&1 \
+        | grep -oE 'SUCCEEDED|ABORTED|CANCELED|REJECTED' | tail -1 | grep . \
+        || echo "NO RESULT (client saw no action server)"
+done
+
+echo
+echo "########## recorded ##########"
+kill -INT "$DIAG_PID" 2>/dev/null
+wait "$DIAG_PID" 2>/dev/null
+grep -vE '^\[snap\]' "$DIAG_OUT" | tail -22
+
+echo
+echo "########## health ##########"
+echo "  falls:              $(grep -ac 'is falling, not turning' "$LOG")"
+echo "  progress failures:  $(grep -ac 'Failed to make progress' "$LOG")"
+echo "  recoveries fired:   $(grep -acE 'Running Spin|Running BackUp|Clearing costmap' "$LOG")"
+
+echo
+echo "########## teardown after ##########"
+teardown
+verify_clean


### PR DESCRIPTION
Two symptoms reported from an interactive session: the map appearing to update late during turns with an oversized correction afterwards, and floor points entering the costmap during gait jerks.

## AMCL

Measured before the change: 11 `map` to `odom` corrections in 200 s, up to 10.4 cm and 2.08 deg, with one 56 s gap followed by a correction. That is the reported symptom exactly.

Those corrections should not exist. Odometry on this track is MuJoCo ground truth, so `map` to `odom` is a constant and every correction is the filter disagreeing with a source that is correct by construction. `alpha1` through `alpha5` at 0.2 describe wheel slip on a real differential base; applied to ground truth they inject error the filter then spends its time undoing. Now 0.02, with the update thresholds tightened so what remains lands continuously rather than batched into one visible step.

SIM-ONLY, and commented as such. On hardware these are far too tight.

## Costmap

`transform_tolerance` was 1.0 in both costmaps, against upstream's 0.3. One second is longer than a gait cycle, so a cloud could be transformed with a pelvis attitude from the opposite phase of the step. The pelvis swings 9.31 deg peak to peak while walking, measured.

Obstacle and raytrace ranges pulled from 10.0/12.0 to 5.0/6.0. Attitude error scales with range: at 10 m, half a degree lifts a floor return 8.7 cm and clears the 0.08 m floor cut on its own.

The floor-strike symptom did not reproduce over 79 m of driving, before or after. Recorded as such rather than claimed as fixed.

## Verification

Operator-driven session, 14 goals, 79 m: no falls, no recoveries, and `Failed to make progress` went from 11 to 0. Scripted soak afterwards: 13/13 goals, same result.

Correction magnitudes after the change are not captured; the operator reports the large jumps are gone with only small corrections during turns that resolve quickly.

## nav_soak

Added to `g1_navigation`, installed to `lib/` like `g1_bringup`'s `activate_arm`.

```bash
ros2 run g1_navigation nav_soak
ros2 run g1_navigation nav_diag.py 200
```

Three details in it are load-bearing, and each produced a false stack defect when done the obvious way. One goal at a time, allowed to finish, because killing the action client mid-goal lets the next goal preempt the running one and the robot falls. Teardown by process group plus a `/proc/PID/cmdline` sweep, because sweeping executable paths misses anything running as `python3` or the `ros2` CLI, which then survives as an orphan and puts a second writer on the velocity path. And readiness read from the launch log, because action and TF discovery outlast any reasonable timeout and AMCL only publishes `/amcl_pose` after a motion-gated update.
