### PR TITLE
Add MoveIt arm planning and Dex3 gripper control

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -194,6 +194,26 @@ RUN apt-get update && apt-get install -y \
         ros-humble-pointcloud-to-laserscan \
     && rm -rf /var/lib/apt/lists/*
 
+# --- Milestone 7: MoveIt 2 (structured manipulation) --------------------------
+
+# Humble's stable line, 2.5.9. The metapackage already covers core, OMPL, the simple
+# controller manager and the RViz MotionPlanning display; the two extras below are named
+# for specific reasons rather than habit. moveit-configs-utils otherwise arrives only as a
+# transitive dependency of moveit-ros-benchmarks, which is not a chain to hang every launch
+# file off. moveit-setup-assistant is the sole way to regenerate g1_moveit_config's
+# self-collision matrix on Humble -- there is no headless collisions_updater -- and upstream
+# has been reshuffling that package across releases.
+#
+# pick-ik replaces the default KDL solver because the arms are 7-DoF against a 6-DoF pose;
+# see g1_moveit_config/config/kinematics.yaml. moveit-servo is deliberately absent: later
+# milestone, and nothing streams to it yet.
+RUN apt-get update && apt-get install -y \
+        ros-humble-moveit \
+        ros-humble-moveit-configs-utils \
+        ros-humble-moveit-setup-assistant \
+        ros-humble-pick-ik \
+    && rm -rf /var/lib/apt/lists/*
+
 # Placed last on purpose. This is the only block that consumes COPYed host files
 # (workspace/patches, workspace/vendor), and cache invalidation flows forward: sitting
 # earlier, a one-line patch or sensor-source edit re-ran every apt block, the ONNX

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -200,18 +200,31 @@ RUN apt-get update && apt-get install -y \
 # controller manager and the RViz MotionPlanning display; the two extras below are named
 # for specific reasons rather than habit. moveit-configs-utils otherwise arrives only as a
 # transitive dependency of moveit-ros-benchmarks, which is not a chain to hang every launch
-# file off. moveit-setup-assistant is the sole way to regenerate g1_moveit_config's
-# self-collision matrix on Humble -- there is no headless collisions_updater -- and upstream
-# has been reshuffling that package across releases.
+# file off. moveit-setup-assistant ships the collisions_updater binary, kept for
+# regenerating g1_moveit_config's self-collision matrix -- though note that tool does not
+# finish on this model at any trial count (g1_moveit_config/README.md), so the shipped matrix
+# came from a different route. Upstream has also been reshuffling that package across releases.
 #
 # pick-ik replaces the default KDL solver because the arms are 7-DoF against a 6-DoF pose;
 # see g1_moveit_config/config/kinematics.yaml. moveit-servo is deliberately absent: later
 # milestone, and nothing streams to it yet.
+#
+# moveit-ros-perception carries BOTH octomap updater plugins, and the moveit metapackage does
+# NOT pull it in -- only the occupancy-map-monitor framework arrives, which is why move_group
+# warns about octomap resolution while having no plugin to load. Without this the sensor config
+# fails as a pluginlib load error rather than anything that names the missing package.
+#
+# realsense2-description is Intel's own D435 model. The vendored G1 URDF leaves d435_link and
+# mid360_link as empty links, so both sensors are invisible; this supplies the camera's real
+# geometry instead of a guessed box. Visual only -- see g1_arm_sdk.urdf.xacro for why nothing
+# here gets collision geometry.
 RUN apt-get update && apt-get install -y \
         ros-humble-moveit \
         ros-humble-moveit-configs-utils \
         ros-humble-moveit-setup-assistant \
         ros-humble-pick-ik \
+        ros-humble-moveit-ros-perception \
+        ros-humble-realsense2-description \
     && rm -rf /var/lib/apt/lists/*
 
 # Placed last on purpose. This is the only block that consumes COPYed host files

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
 
 # Plan for the arms and hands, with the LiDAR octomap in the planning scene
 ros2 launch g1_bringup bringup.launch.py moveit:=true sensors:=true rviz:=true
+
+# Everything at once: localized, navigating, planning, arms acquired, RViz up
+ros2 launch g1_bringup bringup.launch.py \
+  mode:=localization nav:=true moveit:=true rviz:=true activate_arm:=true headless:=false
 ```
 
 Send it somewhere:
@@ -209,8 +213,6 @@ Run them **one package at a time**, and check nothing is left over from a previo
 for a batch of failures that all pass on a clean rerun. Each package README says which of its
 tests need a simulator.
 
-Known failure, unrelated to anything above: `g1_bringup`'s `test_lidar_geometry` test_06 reports
-no returns on one wall. It reproduces on older models too and is not understood yet.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ The robot maps a facility with SLAM Toolbox, localizes against the saved map, an
 a goal pose under Nav2. Arm trajectories run through `ros2_control` onto Unitree's weight-blended
 `rt/arm_sdk` interface, so the vendor's onboard controller keeps the legs balanced throughout.
 
-Manipulation is the next milestone and is not built yet.
+MoveIt plans for either arm or both together, collision-checked against a live octomap built from
+the LiDAR, and each Dex3-1 hand is its own planning group with `open` and `closed` postures. That
+covers pick and place: reach, close, attach the object to the arm in the planning scene, move,
+place, open.
+
+Learned manipulation for unstructured scenes is the next milestone and is not built yet.
 
 ## Nav2 Demo
 
@@ -37,9 +42,14 @@ flowchart TB
         ODOM["g1_odometry_publisher"]
     end
 
+    subgraph MANIP["Manipulation"]
+        MG["move_group<br/>plan + collision check"]
+    end
+
     subgraph CTRL["Bridging and control"]
         BRIDGE["g1_loco_bridge"]
         ARMSYS["G1ArmSdkSystem<br/>ros2_control plugin"]
+        HANDSYS["G1Dex3System<br/>one per hand"]
     end
 
     subgraph SIMONLY["Simulation only"]
@@ -49,10 +59,15 @@ flowchart TB
     end
 
     OP --> NAVL
+    OP --> MANIP
     OP --> CTRL
     OP --> SIMONLY
 
+    MG -- "FollowJointTrajectory" --> ARMSYS
+    MG -- "FollowJointTrajectory" --> HANDSYS
+    HANDSYS -- "/dex3/side/cmd" --> MSS
     RELAY -- "/livox/lidar" --> SCAN
+    RELAY -- "/livox/lidar" --> MG
     SCAN -- "/scan" --> SLAM
     SLAM -- "map to odom" --> NAV2
     ODOM -- "odom to base_footprint" --> NAV2
@@ -82,9 +97,11 @@ Two rules shape most of the design, and both apply in simulation so the habits t
 |---|---|
 | [`g1_bringup`](workspace/src/g1_bringup) | The entry point. Launch files, scenes and config that compose everything below. |
 | [`g1_description`](workspace/src/g1_description) | Vendored G1 URDF plus the `ros2_control` xacro wrapper. |
+| [`g1_hand_interface`](workspace/src/g1_hand_interface) | `ros2_control` plugin for one Dex3-1 hand, over the hand's own DDS topics. |
 | [`g1_hardware_interface`](workspace/src/g1_hardware_interface) | `ros2_control` plugin bridging the 14 arm joints onto `rt/arm_sdk`. |
 | [`g1_locomotion`](workspace/src/g1_locomotion) | LocoClient bridge, gait shaper and the locomotion-authority bracket. |
 | [`g1_motion_service_sim`](workspace/src/g1_motion_service_sim) | Simulation stand-in for the robot's onboard motion service. |
+| [`g1_moveit_config`](workspace/src/g1_moveit_config) | MoveIt config: arm and hand planning groups, kinematics, the octomap. |
 | [`g1_msgs`](workspace/src/g1_msgs) | The `SetLocoMode` action and `LocoStatus` message. |
 | [`g1_navigation`](workspace/src/g1_navigation) | SLAM Toolbox mapping, AMCL localization and Nav2. |
 | [`g1_sensor_relay`](workspace/src/g1_sensor_relay) | Publishes LiDAR and depth frames sampled inside the simulator. |
@@ -121,6 +138,9 @@ ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
 
 # Localize against the committed map and navigate
 ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+
+# Plan for the arms and hands, with the LiDAR octomap in the planning scene
+ros2 launch g1_bringup bringup.launch.py moveit:=true sensors:=true rviz:=true
 ```
 
 Send it somewhere:
@@ -128,6 +148,17 @@ Send it somewhere:
 ```bash
 ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
   "{pose: {header: {frame_id: map}, pose: {position: {x: 2.5, y: -2.5}, orientation: {w: 1.0}}}}"
+```
+
+Moving the arms or hands needs an explicit acquire step first, and a matching release. It takes
+the arm and both hands together; a hand that is absent or unpowered logs and leaves the arm
+usable.
+
+```bash
+ros2 launch g1_bringup activate_arm.launch.py
+# plan from RViz's MotionPlanning panel, or send FollowJointTrajectory goals to
+# arm_trajectory_controller, left_hand_controller or right_hand_controller
+ros2 launch g1_bringup deactivate_arm.launch.py
 ```
 
 ## Development environment
@@ -169,9 +200,13 @@ colcon test-result --all
 ```
 
 Suites that launch a simulator are timing-sensitive and serialize on a shared ctest resource lock.
-On a loaded machine the walking suites can fail without anything being wrong, so re-run a failing
-suite alone before treating it as a regression. Each package README says which of its tests need a
-simulator.
+Run them **one package at a time**, and check nothing is left over from a previous run
+(`pgrep -x unitree_mujoco`) before trusting a result: a stray simulator is the usual explanation
+for a batch of failures that all pass on a clean rerun. Each package README says which of its
+tests need a simulator.
+
+Known failure, unrelated to anything above: `g1_bringup`'s `test_lidar_geometry` test_06 reports
+no returns on one wall. It reproduces on older models too and is not understood yet.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Learned manipulation for unstructured scenes is the next milestone and is not bu
 
 ![Nav2 Demo](docs/media/grove_nav2_demo.gif)
 
+## MoveIt Demo
+
+![MoveIt Demo](docs/media/grove_moveit_demo.gif)
+
 ## Architecture
 
 ```mermaid

--- a/workspace/patches/unitree_mujoco/003-add-dex3-hands.patch
+++ b/workspace/patches/unitree_mujoco/003-add-dex3-hands.patch
@@ -1,0 +1,205 @@
+Gives the simulated G1 the Dex3-1 hands the real robot has.
+
+Generated against unitree_mujoco ae6a8403e272733e9996ef59990880330496177f.
+
+The stock g1_29dof.xml ends each arm in a fixed rubber-hand geom with no joints, so the
+URDF (7 finger joints per side) and the simulator disagreed about what is on the end of
+the wrist. This replaces both geoms with the real 8-body subtree, generated from
+g1_description/urdf/g1_29dof_with_hand_rev_1_0.urdf so the two cannot drift. The meshes
+were already vendored and unused.
+
+NO ACTUATORS AND NO SENSORS, which is not an oversight. RobotBridge sets
+num_motor_ = mj_model_->nu and then indexes lowcmd->msg_.motor_cmd()[i], a fixed
+std::array<MotorCmd_, 35>; it also reads motor state as three contiguous nu-sized blocks
+of sensordata. Adding 14 actuators would take nu to 43 and run both loops off the end of
+those arrays. Keeping nu at 29 leaves the vendored bridge byte-identical and correct, and
+the hand is a separate device on its own DDS topics anyway (docs/CONTROL_MODES.md), so it
+is driven through qfrc_applied by dex3_handler instead.
+
+Each wrist_yaw_link inertial goes back to the URDF's own value. The stock model lumps a
+0.170 kg rubber hand into it, which would double-count against the new palm body. Net
+effect on the model is +1.053 kg, all of it at the ends of the arms: 2 x 0.697 kg of Dex3
+in, 2 x 0.170 kg of rubber hand out. That is the mass the real robot carries, but it is a
+real change to what the walking policy balances.
+
+--- a/unitree_robots/g1/g1_29dof.xml
++++ b/unitree_robots/g1/g1_29dof.xml
+@@ -18,6 +18,24 @@
+       <joint damping="0.05" armature="0.01" frictionloss="0.1"/>
+     </default>
+     
++    <!-- Dex3-1 fingers. No <actuator> and no <sensor> entries on purpose: the SDK bridge
++         sizes itself from nu and indexes a fixed 35-slot LowCmd, so 29 + 14 would run it
++         off the end of the array. The hand is a separate device on its own topics and is
++         driven through qfrc_applied instead. armature deliberately dominates the physical
++         finger inertia (~1e-5 kg m^2): it puts the hardware's own kp=1.5 / kd=0.2 at
++         ~39 rad/s and overdamped at the 2 ms timestep, so the real gains drive the sim
++         unchanged rather than being retuned for it. -->
++    <default class="dex3_motor">
++      <joint damping="0.01" armature="0.001" frictionloss="0.01"/>
++    </default>
++    <!-- Visual only, exactly like the rubber hand these replace. Grasping is modelled by
++         attaching the object to the arm in MoveIt's planning scene, so finger contact
++         would cost solver time every step and buy nothing until grasp physics itself is
++         under test. -->
++    <default class="dex3_visual">
++      <geom type="mesh" contype="0" conaffinity="0" group="1" density="0"
++        rgba="0.7 0.7 0.7 1"/>
++    </default>
+   </default>
+ 
+   <asset>
+@@ -48,7 +66,14 @@
+     <mesh name="left_wrist_roll_link" file="left_wrist_roll_link.STL" />
+     <mesh name="left_wrist_pitch_link" file="left_wrist_pitch_link.STL" />
+     <mesh name="left_wrist_yaw_link" file="left_wrist_yaw_link.STL" />
+-    <mesh name="left_rubber_hand" file="left_rubber_hand.STL" />
++    <mesh name="left_hand_palm_link" file="left_hand_palm_link.STL" />
++    <mesh name="left_hand_thumb_0_link" file="left_hand_thumb_0_link.STL" />
++    <mesh name="left_hand_thumb_1_link" file="left_hand_thumb_1_link.STL" />
++    <mesh name="left_hand_thumb_2_link" file="left_hand_thumb_2_link.STL" />
++    <mesh name="left_hand_middle_0_link" file="left_hand_middle_0_link.STL" />
++    <mesh name="left_hand_middle_1_link" file="left_hand_middle_1_link.STL" />
++    <mesh name="left_hand_index_0_link" file="left_hand_index_0_link.STL" />
++    <mesh name="left_hand_index_1_link" file="left_hand_index_1_link.STL" />
+     <mesh name="right_shoulder_pitch_link" file="right_shoulder_pitch_link.STL" />
+     <mesh name="right_shoulder_roll_link" file="right_shoulder_roll_link.STL" />
+     <mesh name="right_shoulder_yaw_link" file="right_shoulder_yaw_link.STL" />
+@@ -56,7 +81,14 @@
+     <mesh name="right_wrist_roll_link" file="right_wrist_roll_link.STL" />
+     <mesh name="right_wrist_pitch_link" file="right_wrist_pitch_link.STL" />
+     <mesh name="right_wrist_yaw_link" file="right_wrist_yaw_link.STL" />
+-    <mesh name="right_rubber_hand" file="right_rubber_hand.STL" />
++    <mesh name="right_hand_palm_link" file="right_hand_palm_link.STL" />
++    <mesh name="right_hand_thumb_0_link" file="right_hand_thumb_0_link.STL" />
++    <mesh name="right_hand_thumb_1_link" file="right_hand_thumb_1_link.STL" />
++    <mesh name="right_hand_thumb_2_link" file="right_hand_thumb_2_link.STL" />
++    <mesh name="right_hand_middle_0_link" file="right_hand_middle_0_link.STL" />
++    <mesh name="right_hand_middle_1_link" file="right_hand_middle_1_link.STL" />
++    <mesh name="right_hand_index_0_link" file="right_hand_index_0_link.STL" />
++    <mesh name="right_hand_index_1_link" file="right_hand_index_1_link.STL" />
+   </asset>
+ 
+   <worldbody>
+@@ -284,17 +316,54 @@
+                           rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
+                         <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
+                         <body name="left_wrist_yaw_link" pos="0.046 0 0">
+-                          <inertial pos="0.0708244 0.000191745 0.00161742"
+-                            quat="0.510571 0.526295 0.468078 0.493188" mass="0.254576"
+-                            diaginertia="0.000646113 0.000559993 0.000147566" />
++                          <inertial pos="0.0220038157 0.00049485096 0.00053861123" mass="0.08457647" fullinertia="4.92912883e-05 5.97333813e-05 3.92808383e-05 -4.5735494e-07 4.45867591e-06 4.3217198e-07" />
+                           <joint name="left_wrist_yaw_joint" pos="0 0 0" axis="0 0 1"
+                             range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                           <geom type="mesh" contype="0" conaffinity="0" group="1" density="0"
+                             rgba="0.7 0.7 0.7 1" mesh="left_wrist_yaw_link" />
+                           <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_yaw_link" />
+-                          <geom pos="0.0415 0.003 0" quat="1 0 0 0" type="mesh" contype="0"
+-                            conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1"
+-                            mesh="left_rubber_hand" />
++                          <!-- Dex3-1, generated from g1_29dof_with_hand_rev_1_0.urdf so the sim and the
++                               model MoveIt plans against cannot drift. The wrist inertial above is the
++                               URDF's own again: the stock model folded a 0.170 kg rubber hand into it. -->
++                          <body name="left_hand_palm_link" pos="0.0415 0.003 0">
++                            <inertial pos="0.0621463484 -0.00050869656 -0.00058171093" mass="0.37283854" fullinertia="0.00027535181 0.000539518272 0.000396233909 -1.59551946e-05 -2.4216189e-06 -4.2279435e-07" />
++                            <geom class="dex3_visual" mesh="left_hand_palm_link" />
++                            <body name="left_hand_thumb_0_link" pos="0.0255 0 0">
++                              <inertial pos="-0.0008842458 -0.00863407079 0.00094429336" mass="0.08623657" fullinertia="1.60291924e-05 1.45179501e-05 1.63787766e-05 1.0683177e-07 1.6728875e-07 -5.1094752e-07" />
++                              <joint name="left_hand_thumb_0_joint" axis="0 1 0" range="-1.04719755 1.04719755" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="left_hand_thumb_0_link" />
++                              <body name="left_hand_thumb_1_link" pos="-0.0025 -0.0193 0">
++                                <inertial pos="-0.00082788768 -0.0354743577 -0.0003808996" mass="0.0588507" fullinertia="1.27469994e-05 6.01573947e-06 1.23454358e-05 -5.0770784e-07 1.608885e-07 -2.7839003e-07" />
++                                <joint name="left_hand_thumb_1_joint" axis="0 0 1" range="-0.61086523 1.04719755" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="left_hand_thumb_1_link" />
++                                <body name="left_hand_thumb_2_link" pos="0 -0.0458 0">
++                                  <inertial pos="-0.00171735242 -0.0262819294 0.00010778879" mass="0.02030626" fullinertia="4.61267817e-06 1.53561368e-06 3.86625776e-06 -3.42213e-08 -8.23881e-09 -2.549885e-08" />
++                                  <joint name="left_hand_thumb_2_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
++                                  <geom class="dex3_visual" mesh="left_hand_thumb_2_link" />
++                                </body>
++                              </body>
++                            </body>
++                            <body name="left_hand_middle_0_link" pos="0.0777 0.0016 -0.0285">
++                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 -5.0770784e-07 -2.7839003e-07 1.608885e-07" />
++                              <joint name="left_hand_middle_0_joint" axis="0 0 1" range="-1.57079632 0" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="left_hand_middle_0_link" />
++                              <body name="left_hand_middle_1_link" pos="0.0458 0 0">
++                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 -3.42213e-08 -2.549885e-08 -8.23881e-09" />
++                                <joint name="left_hand_middle_1_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="left_hand_middle_1_link" />
++                              </body>
++                            </body>
++                            <body name="left_hand_index_0_link" pos="0.0777 0.0016 0.0285">
++                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 -5.0770784e-07 -2.7839003e-07 1.608885e-07" />
++                              <joint name="left_hand_index_0_joint" axis="0 0 1" range="-1.57079632 0" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="left_hand_index_0_link" />
++                              <body name="left_hand_index_1_link" pos="0.0458 0 0">
++                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 -3.42213e-08 -2.549885e-08 -8.23881e-09" />
++                                <joint name="left_hand_index_1_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="left_hand_index_1_link" />
++                              </body>
++                            </body>
++                          </body>
+                         </body>
+                       </body>
+                     </body>
+@@ -360,17 +429,54 @@
+                           rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
+                         <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
+                         <body name="right_wrist_yaw_link" pos="0.046 0 0">
+-                          <inertial pos="0.0708244 -0.000191745 0.00161742"
+-                            quat="0.493188 0.468078 0.526295 0.510571" mass="0.254576"
+-                            diaginertia="0.000646113 0.000559993 0.000147566" />
++                          <inertial pos="0.0220038157 -0.00049485096 0.00053861123" mass="0.08457647" fullinertia="4.92912883e-05 5.97333813e-05 3.92808383e-05 4.5735494e-07 4.45867591e-06 -4.3217198e-07" />
+                           <joint name="right_wrist_yaw_joint" pos="0 0 0" axis="0 0 1"
+                             range="-1.61443 1.61443" actuatorfrcrange="-5 5" class="wrist_motor" />
+                           <geom type="mesh" contype="0" conaffinity="0" group="1" density="0"
+                             rgba="0.7 0.7 0.7 1" mesh="right_wrist_yaw_link" />
+                           <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_yaw_link" />
+-                          <geom pos="0.0415 -0.003 0" quat="1 0 0 0" type="mesh" contype="0"
+-                            conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1"
+-                            mesh="right_rubber_hand" />
++                          <!-- Dex3-1, generated from g1_29dof_with_hand_rev_1_0.urdf so the sim and the
++                               model MoveIt plans against cannot drift. The wrist inertial above is the
++                               URDF's own again: the stock model folded a 0.170 kg rubber hand into it. -->
++                          <body name="right_hand_palm_link" pos="0.0415 -0.003 0">
++                            <inertial pos="0.0621463484 0.00050869656 -0.00058171093" mass="0.37283854" fullinertia="0.00027535181 0.000539518272 0.000396233909 1.59551946e-05 -2.4216189e-06 4.2279435e-07" />
++                            <geom class="dex3_visual" mesh="right_hand_palm_link" />
++                            <body name="right_hand_thumb_0_link" pos="0.0255 0 0">
++                              <inertial pos="-0.0008842458 0.00863407079 0.00094429336" mass="0.08623657" fullinertia="1.60291924e-05 1.45179501e-05 1.63787766e-05 -1.0683177e-07 1.6728875e-07 5.1094752e-07" />
++                              <joint name="right_hand_thumb_0_joint" axis="0 1 0" range="-1.04719755 1.04719755" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="right_hand_thumb_0_link" />
++                              <body name="right_hand_thumb_1_link" pos="-0.0025 0.0193 0">
++                                <inertial pos="-0.00082788768 0.0354743577 -0.0003808996" mass="0.0588507" fullinertia="1.27469994e-05 6.01573947e-06 1.23454358e-05 5.0770784e-07 1.608885e-07 2.7839003e-07" />
++                                <joint name="right_hand_thumb_1_joint" axis="0 0 1" range="-1.04719755 0.61086523" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="right_hand_thumb_1_link" />
++                                <body name="right_hand_thumb_2_link" pos="0 0.0458 0">
++                                  <inertial pos="-0.00171735242 0.0262819294 0.00010778879" mass="0.02030626" fullinertia="4.61267817e-06 1.53561368e-06 3.86625776e-06 3.42213e-08 -8.23881e-09 2.549885e-08" />
++                                  <joint name="right_hand_thumb_2_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
++                                  <geom class="dex3_visual" mesh="right_hand_thumb_2_link" />
++                                </body>
++                              </body>
++                            </body>
++                            <body name="right_hand_middle_0_link" pos="0.0777 -0.0016 -0.0285">
++                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 5.0770784e-07 -2.7839003e-07 -1.608885e-07" />
++                              <joint name="right_hand_middle_0_joint" axis="0 0 1" range="0 1.57079632" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="right_hand_middle_0_link" />
++                              <body name="right_hand_middle_1_link" pos="0.0458 0 0">
++                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 3.42213e-08 -2.549885e-08 8.23881e-09" />
++                                <joint name="right_hand_middle_1_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="right_hand_middle_1_link" />
++                              </body>
++                            </body>
++                            <body name="right_hand_index_0_link" pos="0.0777 -0.0016 0.0285">
++                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 5.0770784e-07 -2.7839003e-07 -1.608885e-07" />
++                              <joint name="right_hand_index_0_joint" axis="0 0 1" range="0 1.57079632" class="dex3_motor" />
++                              <geom class="dex3_visual" mesh="right_hand_index_0_link" />
++                              <body name="right_hand_index_1_link" pos="0.0458 0 0">
++                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 3.42213e-08 -2.549885e-08 8.23881e-09" />
++                                <joint name="right_hand_index_1_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
++                                <geom class="dex3_visual" mesh="right_hand_index_1_link" />
++                              </body>
++                            </body>
++                          </body>
+                         </body>
+                       </body>
+                     </body>

--- a/workspace/patches/unitree_mujoco/003-add-dex3-hands.patch
+++ b/workspace/patches/unitree_mujoco/003-add-dex3-hands.patch
@@ -16,11 +16,26 @@ those arrays. Keeping nu at 29 leaves the vendored bridge byte-identical and cor
 the hand is a separate device on its own DDS topics anyway (docs/CONTROL_MODES.md), so it
 is driven through qfrc_applied by dex3_handler instead.
 
-Each wrist_yaw_link inertial goes back to the URDF's own value. The stock model lumps a
-0.170 kg rubber hand into it, which would double-count against the new palm body. Net
-effect on the model is +1.053 kg, all of it at the ends of the arms: 2 x 0.697 kg of Dex3
-in, 2 x 0.170 kg of rubber hand out. That is the mass the real robot carries, but it is a
-real change to what the walking policy balances.
+HAND MASS IS SCALED TO 0.170 kg PER HAND, not the real 0.697 kg, and that is a deliberate
+simulator-only deviation. 0.170 kg is what the stock model lumped into each wrist_yaw_link
+for the rubber hand, so the model's total mass and its distribution come out exactly where
+they were: 35.112143 kg against the stock 35.112142 kg. Each wrist_yaw_link inertial goes
+back to the URDF's own value, since the hand is now a body of its own and the lumped mass
+would double-count.
+
+Why: the walking policy in g1_motion_service_sim is a third-party RL checkpoint, and it is
+this stack's stand-in for a controller the real robot has and the simulator does not. Under
+the true hand mass it loses its balance, measured: 6 of 12 balance tests failing, the robot
+sinking to 0.10 m and reaching 1.9 rad of roll and pitch while merely standing. On hardware
+locomotion goes through LocoClient to Unitree's own onboard controller, which never sees this
+policy and is tuned for the robot Unitree ships, Dex3 hands included. So the instability is
+structurally simulator-only.
+
+What it costs: the simulated arm carries less inertia than the real one, so arm motion under
+arm_sdk will track better here than on hardware. Revisit when the locomotion policy is
+retrained or replaced. The real per-link masses are in the URDF and this file is generated
+from it, so restoring them is a one-line change to the generator.
+See docs/notes/hand-mass-rest-pose.md.
 
 --- a/unitree_robots/g1/g1_29dof.xml
 +++ b/unitree_robots/g1/g1_29dof.xml
@@ -81,7 +96,7 @@ real change to what the walking policy balances.
    </asset>
  
    <worldbody>
-@@ -284,17 +316,54 @@
+@@ -284,17 +316,55 @@
                            rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
                          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="left_wrist_pitch_link" />
                          <body name="left_wrist_yaw_link" pos="0.046 0 0">
@@ -98,42 +113,43 @@ real change to what the walking policy balances.
 -                            conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1"
 -                            mesh="left_rubber_hand" />
 +                          <!-- Dex3-1, generated from g1_29dof_with_hand_rev_1_0.urdf so the sim and the
-+                               model MoveIt plans against cannot drift. The wrist inertial above is the
-+                               URDF's own again: the stock model folded a 0.170 kg rubber hand into it. -->
++                               model MoveIt plans against cannot drift. Masses are scaled to 0.170 kg per
++                               hand, the mass the vendored model lumped into the wrist; the patch header
++                               says why. The wrist inertial above is the URDF's own again. -->
 +                          <body name="left_hand_palm_link" pos="0.0415 0.003 0">
-+                            <inertial pos="0.0621463484 -0.00050869656 -0.00058171093" mass="0.37283854" fullinertia="0.00027535181 0.000539518272 0.000396233909 -1.59551946e-05 -2.4216189e-06 -4.2279435e-07" />
++                            <inertial pos="0.0621463484 -0.00050869656 -0.00058171093" mass="0.0909955017" fullinertia="6.72027525e-05 0.000131675593 9.67054086e-05 -3.89404738e-06 -5.91023736e-07 -1.03187787e-07" />
 +                            <geom class="dex3_visual" mesh="left_hand_palm_link" />
 +                            <body name="left_hand_thumb_0_link" pos="0.0255 0 0">
-+                              <inertial pos="-0.0008842458 -0.00863407079 0.00094429336" mass="0.08623657" fullinertia="1.60291924e-05 1.45179501e-05 1.63787766e-05 1.0683177e-07 1.6728875e-07 -5.1094752e-07" />
++                              <inertial pos="-0.0008842458 -0.00863407079 0.00094429336" mass="0.0210470193" fullinertia="3.91210738e-06 3.54327145e-06 3.9974274e-06 2.6073513e-08 4.08287291e-08 -1.24702575e-07" />
 +                              <joint name="left_hand_thumb_0_joint" axis="0 1 0" range="-1.04719755 1.04719755" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="left_hand_thumb_0_link" />
 +                              <body name="left_hand_thumb_1_link" pos="-0.0025 -0.0193 0">
-+                                <inertial pos="-0.00082788768 -0.0354743577 -0.0003808996" mass="0.0588507" fullinertia="1.27469994e-05 6.01573947e-06 1.23454358e-05 -5.0770784e-07 1.608885e-07 -2.7839003e-07" />
++                                <inertial pos="-0.00082788768 -0.0354743577 -0.0003808996" mass="0.0143631851" fullinertia="3.11105072e-06 1.46820989e-06 3.01304454e-06 -1.23911894e-07 3.9266675e-08 -6.79442647e-08" />
 +                                <joint name="left_hand_thumb_1_joint" axis="0 0 1" range="-0.61086523 1.04719755" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="left_hand_thumb_1_link" />
 +                                <body name="left_hand_thumb_2_link" pos="0 -0.0458 0">
-+                                  <inertial pos="-0.00171735242 -0.0262819294 0.00010778879" mass="0.02030626" fullinertia="4.61267817e-06 1.53561368e-06 3.86625776e-06 -3.42213e-08 -8.23881e-09 -2.549885e-08" />
++                                  <inertial pos="-0.00171735242 -0.0262819294 0.00010778879" mass="0.00495597455" fullinertia="1.12577676e-06 3.74784048e-07 9.4360434e-07 -8.3520989e-09 -2.01077563e-09 -6.22328541e-09" />
 +                                  <joint name="left_hand_thumb_2_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
 +                                  <geom class="dex3_visual" mesh="left_hand_thumb_2_link" />
 +                                </body>
 +                              </body>
 +                            </body>
 +                            <body name="left_hand_middle_0_link" pos="0.0777 0.0016 -0.0285">
-+                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 -5.0770784e-07 -2.7839003e-07 1.608885e-07" />
++                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0143631851" fullinertia="1.46820989e-06 3.11105072e-06 3.01304454e-06 -1.23911894e-07 -6.79442647e-08 3.9266675e-08" />
 +                              <joint name="left_hand_middle_0_joint" axis="0 0 1" range="-1.57079632 0" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="left_hand_middle_0_link" />
 +                              <body name="left_hand_middle_1_link" pos="0.0458 0 0">
-+                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 -3.42213e-08 -2.549885e-08 -8.23881e-09" />
++                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.00495597455" fullinertia="3.74784048e-07 1.12577676e-06 9.4360434e-07 -8.3520989e-09 -6.22328541e-09 -2.01077563e-09" />
 +                                <joint name="left_hand_middle_1_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="left_hand_middle_1_link" />
 +                              </body>
 +                            </body>
 +                            <body name="left_hand_index_0_link" pos="0.0777 0.0016 0.0285">
-+                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 -5.0770784e-07 -2.7839003e-07 1.608885e-07" />
++                              <inertial pos="0.0354743577 0.00082788768 0.0003808996" mass="0.0143631851" fullinertia="1.46820989e-06 3.11105072e-06 3.01304454e-06 -1.23911894e-07 -6.79442647e-08 3.9266675e-08" />
 +                              <joint name="left_hand_index_0_joint" axis="0 0 1" range="-1.57079632 0" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="left_hand_index_0_link" />
 +                              <body name="left_hand_index_1_link" pos="0.0458 0 0">
-+                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 -3.42213e-08 -2.549885e-08 -8.23881e-09" />
++                                <inertial pos="0.0262819294 0.00171735242 -0.00010778879" mass="0.00495597455" fullinertia="3.74784048e-07 1.12577676e-06 9.4360434e-07 -8.3520989e-09 -6.22328541e-09 -2.01077563e-09" />
 +                                <joint name="left_hand_index_1_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="left_hand_index_1_link" />
 +                              </body>
@@ -142,7 +158,7 @@ real change to what the walking policy balances.
                          </body>
                        </body>
                      </body>
-@@ -360,17 +429,54 @@
+@@ -360,17 +430,55 @@
                            rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
                          <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="right_wrist_pitch_link" />
                          <body name="right_wrist_yaw_link" pos="0.046 0 0">
@@ -159,42 +175,43 @@ real change to what the walking policy balances.
 -                            conaffinity="0" group="1" density="0" rgba="0.7 0.7 0.7 1"
 -                            mesh="right_rubber_hand" />
 +                          <!-- Dex3-1, generated from g1_29dof_with_hand_rev_1_0.urdf so the sim and the
-+                               model MoveIt plans against cannot drift. The wrist inertial above is the
-+                               URDF's own again: the stock model folded a 0.170 kg rubber hand into it. -->
++                               model MoveIt plans against cannot drift. Masses are scaled to 0.170 kg per
++                               hand, the mass the vendored model lumped into the wrist; the patch header
++                               says why. The wrist inertial above is the URDF's own again. -->
 +                          <body name="right_hand_palm_link" pos="0.0415 -0.003 0">
-+                            <inertial pos="0.0621463484 0.00050869656 -0.00058171093" mass="0.37283854" fullinertia="0.00027535181 0.000539518272 0.000396233909 1.59551946e-05 -2.4216189e-06 4.2279435e-07" />
++                            <inertial pos="0.0621463484 0.00050869656 -0.00058171093" mass="0.0909955017" fullinertia="6.72027525e-05 0.000131675593 9.67054086e-05 3.89404738e-06 -5.91023736e-07 1.03187787e-07" />
 +                            <geom class="dex3_visual" mesh="right_hand_palm_link" />
 +                            <body name="right_hand_thumb_0_link" pos="0.0255 0 0">
-+                              <inertial pos="-0.0008842458 0.00863407079 0.00094429336" mass="0.08623657" fullinertia="1.60291924e-05 1.45179501e-05 1.63787766e-05 -1.0683177e-07 1.6728875e-07 5.1094752e-07" />
++                              <inertial pos="-0.0008842458 0.00863407079 0.00094429336" mass="0.0210470193" fullinertia="3.91210738e-06 3.54327145e-06 3.9974274e-06 -2.6073513e-08 4.08287291e-08 1.24702575e-07" />
 +                              <joint name="right_hand_thumb_0_joint" axis="0 1 0" range="-1.04719755 1.04719755" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="right_hand_thumb_0_link" />
 +                              <body name="right_hand_thumb_1_link" pos="-0.0025 0.0193 0">
-+                                <inertial pos="-0.00082788768 0.0354743577 -0.0003808996" mass="0.0588507" fullinertia="1.27469994e-05 6.01573947e-06 1.23454358e-05 5.0770784e-07 1.608885e-07 2.7839003e-07" />
++                                <inertial pos="-0.00082788768 0.0354743577 -0.0003808996" mass="0.0143631851" fullinertia="3.11105072e-06 1.46820989e-06 3.01304454e-06 1.23911894e-07 3.9266675e-08 6.79442647e-08" />
 +                                <joint name="right_hand_thumb_1_joint" axis="0 0 1" range="-1.04719755 0.61086523" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="right_hand_thumb_1_link" />
 +                                <body name="right_hand_thumb_2_link" pos="0 0.0458 0">
-+                                  <inertial pos="-0.00171735242 0.0262819294 0.00010778879" mass="0.02030626" fullinertia="4.61267817e-06 1.53561368e-06 3.86625776e-06 3.42213e-08 -8.23881e-09 2.549885e-08" />
++                                  <inertial pos="-0.00171735242 0.0262819294 0.00010778879" mass="0.00495597455" fullinertia="1.12577676e-06 3.74784048e-07 9.4360434e-07 8.3520989e-09 -2.01077563e-09 6.22328541e-09" />
 +                                  <joint name="right_hand_thumb_2_joint" axis="0 0 1" range="-1.74532925 0" class="dex3_motor" />
 +                                  <geom class="dex3_visual" mesh="right_hand_thumb_2_link" />
 +                                </body>
 +                              </body>
 +                            </body>
 +                            <body name="right_hand_middle_0_link" pos="0.0777 -0.0016 -0.0285">
-+                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 5.0770784e-07 -2.7839003e-07 -1.608885e-07" />
++                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0143631851" fullinertia="1.46820989e-06 3.11105072e-06 3.01304454e-06 1.23911894e-07 -6.79442647e-08 -3.9266675e-08" />
 +                              <joint name="right_hand_middle_0_joint" axis="0 0 1" range="0 1.57079632" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="right_hand_middle_0_link" />
 +                              <body name="right_hand_middle_1_link" pos="0.0458 0 0">
-+                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 3.42213e-08 -2.549885e-08 8.23881e-09" />
++                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.00495597455" fullinertia="3.74784048e-07 1.12577676e-06 9.4360434e-07 8.3520989e-09 -6.22328541e-09 2.01077563e-09" />
 +                                <joint name="right_hand_middle_1_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="right_hand_middle_1_link" />
 +                              </body>
 +                            </body>
 +                            <body name="right_hand_index_0_link" pos="0.0777 -0.0016 0.0285">
-+                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0588507" fullinertia="6.01573947e-06 1.27469994e-05 1.23454358e-05 5.0770784e-07 -2.7839003e-07 -1.608885e-07" />
++                              <inertial pos="0.0354743577 -0.00082788768 0.0003808996" mass="0.0143631851" fullinertia="1.46820989e-06 3.11105072e-06 3.01304454e-06 1.23911894e-07 -6.79442647e-08 -3.9266675e-08" />
 +                              <joint name="right_hand_index_0_joint" axis="0 0 1" range="0 1.57079632" class="dex3_motor" />
 +                              <geom class="dex3_visual" mesh="right_hand_index_0_link" />
 +                              <body name="right_hand_index_1_link" pos="0.0458 0 0">
-+                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.02030626" fullinertia="1.53561368e-06 4.61267817e-06 3.86625776e-06 3.42213e-08 -2.549885e-08 8.23881e-09" />
++                                <inertial pos="0.0262819294 -0.00171735242 -0.00010778879" mass="0.00495597455" fullinertia="3.74784048e-07 1.12577676e-06 9.4360434e-07 8.3520989e-09 -6.22328541e-09 2.01077563e-09" />
 +                                <joint name="right_hand_index_1_joint" axis="0 0 1" range="0 1.74532925" class="dex3_motor" />
 +                                <geom class="dex3_visual" mesh="right_hand_index_1_link" />
 +                              </body>

--- a/workspace/patches/unitree_mujoco/004-register-dex3-handler.patch
+++ b/workspace/patches/unitree_mujoco/004-register-dex3-handler.patch
@@ -1,0 +1,67 @@
+Registers grove-g1's Dex3 hand handler in the vendored unitree_mujoco.
+
+Generated against unitree_mujoco ae6a8403e272733e9996ef59990880330496177f, on top of
+001 (whose main.cc context this diff includes).
+
+The handler's own source is COPYed in by the Dockerfile and is NOT part of this patch, so
+this stays a registration hook: an include, a start, two stops, and one source file added
+to the target. simulate/src/unitree_sdk2_bridge.h is untouched, and stays correct, because
+the fingers deliberately have no actuators (see 003).
+
+Started from the bridge thread rather than from main() because it opens DDS channels
+immediately and ChannelFactory::Init happens in that thread, a few lines above. That also
+means m and d are already valid there.
+
+Stopped at both model-replacement paths (the viewer's Reload button and drag-and-drop) with
+a blocking join, before mj_deleteModel, for the same reason the sensor sampler is: it caches
+joint addresses resolved against the old model and writes mjData outside sim.mtx. It is not
+restarted afterwards, so a reload ends with the hands inert.
+
+--- a/simulate/CMakeLists.txt
++++ b/simulate/CMakeLists.txt
+@@ -42,6 +42,6 @@
+   fmt
+ )
+ 
+-add_executable(unitree_mujoco ${SIM_SRC} src/main.cc src/sensor_publisher.cc)
++add_executable(unitree_mujoco ${SIM_SRC} src/main.cc src/sensor_publisher.cc src/dex3_handler.cc)
+ 
+ add_executable(jstest src/joystick/jstest.cc src/joystick/joystick.cc)
+\ No newline at end of file
+--- a/simulate/src/main.cc
++++ b/simulate/src/main.cc
+@@ -34,6 +34,7 @@
+ #include "array_safety.h"
+ #include "unitree_sdk2_bridge.h"
+ #include "sensor_publisher.h"
++#include "dex3_handler.h"
+ #include "param.h"
+ 
+ #define MUJOCO_PLUGIN_DIR "mujoco_plugin"
+@@ -354,6 +355,7 @@
+           // Blocking join before the model is freed. The sampler touches the model
+           // outside sim.mtx by design, so nothing lock-based can make this safe.
+           grove_g1::StopSensorPublisher();
++          grove_g1::StopDex3Handler();
+ 
+           mj_deleteData(d);
+           mj_deleteModel(m);
+@@ -388,6 +390,7 @@
+           // Blocking join before the model is freed. The sampler touches the model
+           // outside sim.mtx by design, so nothing lock-based can make this safe.
+           grove_g1::StopSensorPublisher();
++          grove_g1::StopDex3Handler();
+ 
+           mj_deleteData(d);
+           mj_deleteModel(m);
+@@ -609,6 +612,10 @@
+     interface = std::make_unique<Go2Bridge>(m, d);
+   }
+   interface->start();
++
++  // grove-g1: the Dex3 hands. Here and not in main() because it opens DDS channels, so it
++  // has to run after ChannelFactory::Init above. A no-op on models without finger joints.
++  grove_g1::StartDex3Handler(&m, &d);
+   
+   while (true)
+   {

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -8,20 +8,24 @@ compiled code of its own.
 ```mermaid
 flowchart LR
     B["bringup.launch.py"]
-    B -->|"mode:=none"| S["sim.launch.py"]
-    B -->|"mode:=mapping<br/>mode:=localization"| N["g1_navigation<br/>nav_sim.launch.py"]
-    B -->|"rviz:=true"| R["rviz.launch.py"]
-    N --> S
+    B --> S["sim.launch.py"]
+    B -->|"mode:=mapping<br/>mode:=localization"| N["g1_navigation<br/>nav_stack.launch.py"]
+    B -->|"moveit:=true"| MG["g1_moveit_config<br/>move_group.launch.py"]
+    B -->|"rviz:=true"| R["rviz.launch.py<br/>or moveit_rviz.launch.py"]
     S --> C["control.launch.py"]
     S --> L["loco.launch.py"]
     S --> MJ["unitree_mujoco +<br/>motion_service_sim"]
 ```
 
+The simulator edge is unconditional: this file stages exactly one, and the optional stacks are
+composed beside it rather than wrapped around it. Neither `nav_stack.launch.py` nor
+`move_group.launch.py` stages a simulator of its own.
+
 ## Launch files
 
 | File | Purpose |
 |---|---|
-| `bringup.launch.py` | What an operator runs. Routes to bare simulator or the navigation stack. |
+| `bringup.launch.py` | What an operator runs. Stages the simulator and composes the navigation stack and MoveIt onto it as asked. |
 | `sim.launch.py` | Starts `unitree_mujoco`, `motion_service_sim`, `control.launch.py` and `loco.launch.py`. Checks the DDS environment first. Works standalone. |
 | `control.launch.py` | `robot_state_publisher`, `ros2_control_node` and the spawners. No simulator, so it carries to hardware unchanged. |
 | `loco.launch.py` | Starts `g1_loco_bridge` and drives it from configure to active. |
@@ -37,12 +41,14 @@ All of these belong to `bringup.launch.py`.
 |---|---|---|
 | `mode` | `none` | `none` is the simulator alone. `mapping` adds the scan pipeline and slam_toolbox. `localization` adds `map_server` and AMCL. |
 | `nav` | `false` | Start Nav2, the gait shaper and the authority bracket. Needs `mode:=localization`. |
-| `rviz` | `false` | Open RViz on the config that matches the mode. |
+| `moveit` | `false` | Start `move_group` for arm planning. Works with any mode. Planning is immediate; executing still needs `activate_arm`. |
+| `rviz` | `false` | Open RViz on the config that matches what is running. `moveit:=true` wins, because only MoveIt's launcher passes the panel its parameters. |
 | `sensors` | `false` | LiDAR, the relay and the `odom` to `base_footprint` chain. The navigation modes turn this on themselves. |
 | `world` | `navigation` | Which scene to stage. `navigation` is the facility the committed map was built from. |
 | `headless` | `true` | `false` shows the MuJoCo viewer. |
-| `pin_pelvis` | `false` | Welds the pelvis and disables the walking policy, for exercising the arm bridge alone. `mode:=none` only. |
-| `sim_start_delay_s` | branch default | Seconds to delay the simulator. Empty means 2.0 for `mode:=none`, 4.0 for the navigation modes. |
+| `pin_pelvis` | `false` | Welds the pelvis and disables the walking policy, for exercising the arms alone. `mode:=none` only. |
+| `waist_hold_rad` | `""` | Sim only. Three comma-separated radians (yaw,roll,pitch) to stand the waist at. Needs `pin_pelvis:=true`. |
+| `sim_start_delay_s` | branch default | Seconds to delay the simulator. Empty means 2.0 bare, 4.0 whenever navigation or MoveIt starts alongside it. |
 
 ## Running
 
@@ -50,7 +56,13 @@ All of these belong to `bringup.launch.py`.
 ros2 launch g1_bringup bringup.launch.py                                      # simulator only
 ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true             # build a map
 ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+ros2 launch g1_bringup bringup.launch.py moveit:=true pin_pelvis:=true rviz:=true
+ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true moveit:=true
 ```
+
+`moveit:=true` also turns on the non-arm joint states MoveIt needs, without being asked: the arms
+hang off three waist joints `joint_state_broadcaster` does not own, and `move_group` will not plan
+until every joint it models has a state.
 
 Arms, in order. The order is mandatory: Humble ties command-interface availability to hardware
 component state, so activating the controller before the component can fail the switch.
@@ -76,16 +88,18 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args \
 Both teleop overrides matter. The defaults sit inside the gait's dead zone and the robot will not
 move. See `g1_motion_service_sim` for the measured thresholds.
 
-## g1_navigation is referenced but not depended on
+## g1_navigation and g1_moveit_config are referenced but not depended on
 
-`bringup.launch.py` includes launch files and an RViz config from `g1_navigation`, and
-`package.xml` says nothing about it. That is deliberate. `g1_navigation` already depends on
-`g1_bringup`, so declaring the reverse makes colcon refuse to order the workspace at all.
+`bringup.launch.py` includes launch files from both, and an RViz config from `g1_navigation`, and
+`package.xml` says nothing about either. That is deliberate. Both already depend on `g1_bringup`,
+so declaring the reverse makes colcon refuse to order the workspace at all.
 
-The reference is a launch-time path lookup. This package builds and runs with `g1_navigation`
-absent; only the two navigation modes name it, and their absence is reported as an actionable
-message. Nothing will warn you if `g1_navigation` renames a launch file, so `test_launch_threading`
-in that package is the compensating check.
+Both references are launch-time path lookups. This package builds and runs with either absent:
+only `mode:=mapping` and `mode:=localization` name `g1_navigation`, only `moveit:=true` names
+`g1_moveit_config`, and each absence is reported as an actionable message rather than a search-path
+dump. Nothing will warn you if either package renames a launch file, so `test_launch_threading` in
+*each* of them is the compensating check. Neither suite can live here, for the same reason the
+dependency cannot.
 
 ## Configuration
 

--- a/workspace/src/g1_bringup/README.md
+++ b/workspace/src/g1_bringup/README.md
@@ -64,14 +64,19 @@ ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true moveit:=tr
 hang off three waist joints `joint_state_broadcaster` does not own, and `move_group` will not plan
 until every joint it models has a state.
 
-Arms, in order. The order is mandatory: Humble ties command-interface availability to hardware
-component state, so activating the controller before the component can fail the switch.
+Arms and hands, in order. The order is mandatory: Humble ties command-interface availability to
+hardware component state, so activating the controller before the component can fail the switch.
 
 ```bash
 ros2 launch g1_bringup activate_arm.launch.py
-# send a FollowJointTrajectory goal to arm_trajectory_controller
+# send a FollowJointTrajectory goal to arm_trajectory_controller,
+# left_hand_controller or right_hand_controller
 ros2 launch g1_bringup deactivate_arm.launch.py
 ```
+
+The same step acquires both Dex3 hands, but only best-effort: a hand that is absent, unpowered or
+not publishing state logs a warning and leaves the arm usable. The arm is the part that fails the
+whole acquire.
 
 `deactivate_arm.launch.py` blocks for about two seconds while the blend weight ramps to zero. That
 is the ramp, not a hang. Ctrl-C is also safe.

--- a/workspace/src/g1_bringup/config/controllers.yaml
+++ b/workspace/src/g1_bringup/config/controllers.yaml
@@ -51,7 +51,12 @@ arm_trajectory_controller:
       - velocity
     state_publish_rate: 100.0   # Hz; default
     action_monitor_rate: 20.0   # Hz; default
-    allow_partial_joints_goal: false
+    # MoveIt plans one arm at a time -- its left_arm and right_arm groups are 7 joints each,
+    # and with this false the JTC rejects any goal that does not name all 14. Humble fills the
+    # unnamed joints with their last commanded position (measured, if nothing was commanded
+    # yet) at zero velocity, so the idle arm holds station rather than being left undefined.
+    # g1_moveit_config's drift test pins this, because turning it back breaks every plan.
+    allow_partial_joints_goal: true
 
     # Sim-tuning: unitree_mujoco's PD tracking plus the motion_service_sim's
     # own weight/slew ramping add latency the JTC's tight built-in defaults

--- a/workspace/src/g1_bringup/config/controllers.yaml
+++ b/workspace/src/g1_bringup/config/controllers.yaml
@@ -9,14 +9,30 @@ controller_manager:
     # immediately, but nothing publishes to /arm_sdk until the explicit
     # activate_arm step (see README.md's operating procedure and the
     # mandatory component-then-controller acquire order).
+    # The two hands are here for a weaker reason than the arm: activating a Dex3 only starts
+    # holding the fingers where they already are. They are still gated so that acquiring the
+    # robot is one explicit step rather than three, and so a hand that is absent or unpowered
+    # fails at a point we control instead of during controller_manager's own startup.
     hardware_components_initial_state:
       inactive:
         - "G1ArmSdkSystem"
+        - "G1Dex3SystemLeft"
+        - "G1Dex3SystemRight"
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
     arm_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    # JointTrajectoryController and not GripperActionController: that one drives a single
+    # joint (plus a URDF mimic), which is a parallel-jaw gripper. A Dex3 is seven independent
+    # finger joints, so MoveIt drives it the way it drives any multi-finger hand -- named
+    # postures on a planning group, executed as a trajectory.
+    left_hand_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    right_hand_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
 joint_state_broadcaster:
@@ -62,6 +78,54 @@ arm_trajectory_controller:
     # own weight/slew ramping add latency the JTC's tight built-in defaults
     # don't expect. Relaxed here for the sim milestone -- re-tighten against
     # real hardware dynamics when that milestone arrives.
+    constraints:
+      stopped_velocity_tolerance: 0.05
+      goal_time: 5.0
+
+# Both hands, in Dex3 wire order. The order is for readers -- the JTC remaps by name -- but
+# g1_moveit_config's drift test pins it against the SRDF group and the hardware component,
+# which does care: HandCmd.motor_cmd is a positional array.
+left_hand_controller:
+  ros__parameters:
+    joints:
+      - left_hand_thumb_0_joint
+      - left_hand_thumb_1_joint
+      - left_hand_thumb_2_joint
+      - left_hand_middle_0_joint
+      - left_hand_middle_1_joint
+      - left_hand_index_0_joint
+      - left_hand_index_1_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    # A grasp usually drives some fingers and leaves others where they are.
+    allow_partial_joints_goal: true
+    constraints:
+      stopped_velocity_tolerance: 0.05
+      goal_time: 5.0
+
+right_hand_controller:
+  ros__parameters:
+    joints:
+      - right_hand_thumb_0_joint
+      - right_hand_thumb_1_joint
+      - right_hand_thumb_2_joint
+      - right_hand_middle_0_joint
+      - right_hand_middle_1_joint
+      - right_hand_index_0_joint
+      - right_hand_index_1_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: true
     constraints:
       stopped_velocity_tolerance: 0.05
       goal_time: 5.0

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -29,9 +29,21 @@ knowing before touching it:
     file names change; the launch fails at runtime instead.
   * Do not "fix" this by adding the dependency. It is load-bearing that it stays absent.
 
-The direction of composition is still navigation-over-bringup: on the nav branch this file
-includes g1_navigation's nav_sim.launch.py, which includes sim.launch.py itself. This file
-routes, it does not orchestrate navigation.
+This file composes independent pieces; it does not delegate to one bundled entry point per
+package. It stages exactly one simulator itself -- `_simulator()`, the only place the simulator
+is named anywhere in this file -- and the navigation modes add g1_navigation's
+nav_stack.launch.py, which stages none of its own. Exactly one simulator per launch, always:
+two would put two motion_service_sim processes on /lowcmd, and CONTROL_MODES.md puts that
+failure first for a reason.
+
+The direction of composition is unchanged and still navigation-over-bringup. What changed is
+the granularity: bring-up reaches a genuinely sim-independent piece of g1_navigation directly,
+rather than a wrapper that bundles a simulator in with it.
+
+nav_sim.launch.py still exists and still runs standalone, composing the same two pieces for a
+nav-only session, and it is what the g1_navigation integration suites launch. That leaves
+exactly one fact stated in two files -- sensors:=true on the simulator -- because each stages
+its own and there is nowhere shared to put it. test_launch_threading asserts it on both.
 """
 
 import os
@@ -42,14 +54,15 @@ from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, Opaq
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-# 'none' keeps g1_navigation entirely out of the picture; the other two route through it.
+# 'none' keeps g1_navigation entirely out of the picture; the other two bring it in.
 MODES = ("none", "mapping", "localization")
 
-# sim.launch.py wants 2.0, nav_sim.launch.py wants 4.0 (more nodes start before the first
-# physics tick). Declaring either as this file's default would silently override whichever
-# child was right, because an included launch file inherits the parent's configurations.
+# A bare simulator wants 2.0; anything that starts a stack alongside it wants 4.0, because more
+# nodes come up before the first physics tick and the robot topples at spawn if discovery is
+# still in progress. Declaring either as this file's default would silently override whichever
+# branch was right, because an included launch file inherits the parent's configurations.
 # The empty sentinel means "let the branch decide", and a concrete value is always forwarded.
-DEFAULT_SIM_START_DELAY_S = {"bare": "2.0", "navigation": "4.0"}
+DEFAULT_SIM_START_DELAY_S = {"bare": "2.0", "loaded": "4.0"}
 
 
 def _navigation_share():
@@ -67,6 +80,22 @@ def _navigation_share():
             "builds it for you.\n"
             "mode:=none needs none of this and runs the simulator on its own."
         ) from exc
+
+
+def _simulator(sim_args):
+    """The one simulator this file stages, and the only place it is named.
+
+    Isolated deliberately. Everything above composes around it, so swapping in a hardware
+    bring-up later replaces this function's body and nothing else: the branches only decide
+    what goes in sim_args. There is no platform:= argument because there is no second
+    implementation yet, and one would be a knob with a single position.
+    """
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("g1_bringup"), "launch", "sim.launch.py")
+        ),
+        launch_arguments=sim_args.items(),
+    )
 
 
 def _setup(context, *args, **kwargs):
@@ -97,43 +126,51 @@ def _setup(context, *args, **kwargs):
 
     delay = LaunchConfiguration("sim_start_delay_s").perform(context)
     if not delay:
-        delay = DEFAULT_SIM_START_DELAY_S["navigation" if navigating else "bare"]
+        delay = DEFAULT_SIM_START_DELAY_S["loaded" if navigating else "bare"]
 
     # Every argument below is forwarded EXPLICITLY, including the ones whose values match
     # this file's own defaults. Included launch files inherit the parent's configurations,
     # so a child's DeclareLaunchArgument default never fires for anything declared here --
     # relying on it is how this stack has already shipped two silent bugs (a second RViz
     # window, and use_composition ignoring its own default).
-    if navigating:
-        launch_file = os.path.join(_navigation_share(), "launch", "nav_sim.launch.py")
-        forwarded = {
-            "mode": mode,
-            "nav": "true" if want_nav else "false",
-            "world": LaunchConfiguration("world"),
-            "headless": LaunchConfiguration("headless"),
-            "sim_start_delay_s": delay,
-            # We own RViz, below. Without this the child opens its own on the wrong config.
-            "rviz": "false",
-        }
-    else:
-        launch_file = os.path.join(
-            get_package_share_directory("g1_bringup"), "launch", "sim.launch.py"
-        )
-        forwarded = {
-            "sensors": LaunchConfiguration("sensors"),
-            "world": LaunchConfiguration("world"),
-            "headless": LaunchConfiguration("headless"),
-            "pin_pelvis": "true" if pin_pelvis else "false",
-            "sim_start_delay_s": delay,
-            "rviz": "false",
-        }
+    sim_args = {
+        # Not optional on the navigation modes, whatever the operator asked for: sensors gates
+        # the LiDAR sweep, the relay, the odom -> base_footprint -> pelvis chain and the waist
+        # joint states, and navigation is dead without all four. Forced here rather than by
+        # flipping sim.launch.py's default, which is still provisional on an unthrottled
+        # re-measurement of test_arm_command.
+        "sensors": "true" if navigating else LaunchConfiguration("sensors"),
+        "world": LaunchConfiguration("world"),
+        "headless": LaunchConfiguration("headless"),
+        "pin_pelvis": "true" if pin_pelvis else "false",
+        "sim_start_delay_s": delay,
+        # We own RViz, below. Without this the simulator opens its own on the wrong config.
+        "rviz": "false",
+    }
 
-    actions = [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(launch_file),
-            launch_arguments=forwarded.items(),
+    actions = [_simulator(sim_args)]
+
+    if navigating:
+        # nav_stack.launch.py stages no simulator of its own, which is what makes including it
+        # next to _simulator() safe; two would be two writers on /lowcmd.
+        #
+        # use_composition and container_name are deliberately NOT declared by this file and
+        # NOT forwarded, so nav_stack's own defaults are the ones that apply. That is safe for
+        # the same reason the explicit forwarding above is necessary: inheritance only leaks
+        # through a name the parent also declares. No name here, nothing to leak, and an
+        # operator who wants to decompose the container runs nav_sim.launch.py, which exposes
+        # both.
+        actions.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(_navigation_share(), "launch", "nav_stack.launch.py")
+                ),
+                launch_arguments={
+                    "mode": mode,
+                    "nav": "true" if want_nav else "false",
+                }.items(),
+            )
         )
-    ]
 
     if want_rviz:
         # The nav config carries a nav2_rviz_plugins display, so it ships from g1_navigation.

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -71,7 +71,13 @@ import os
 
 from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+    TimerAction,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
@@ -232,6 +238,34 @@ def _setup(context, *args, **kwargs):
             )
         )
 
+    if want_moveit and LaunchConfiguration("activate_arm").perform(context).lower() == "true":
+        # Off by default, and it stays off by default. Acquiring the arm is a deliberate act:
+        # on hardware this is the moment /arm_sdk starts driving real joints, and a stack that
+        # goes live on `ros2 launch` is a stack that goes live when someone launches it to look
+        # at something else. This argument is a sim convenience, nothing more.
+        #
+        # Delayed rather than sequenced on an event: the component only accepts activation once
+        # controller_manager has loaded it and /lowstate is flowing, and neither emits anything
+        # this file can wait on. scripts/activate_arm still enforces the component-then-
+        # controller order, and still fails loudly if it runs too early.
+        #
+        # The principled version of this is a lifecycle authority bracket like g1_locomotion's
+        # g1_loco_authority, which acquires on activate and releases on the way out even on
+        # failure -- what CONTROL_MODES.md rule 4 actually asks for. That is a node, not a
+        # launch argument, and it belongs with the behaviour-tree work that will need it.
+        actions.append(
+            TimerAction(
+                period=float(LaunchConfiguration("activate_arm_delay_s").perform(context)),
+                actions=[
+                    ExecuteProcess(
+                        cmd=["ros2", "run", "g1_bringup", "activate_arm"],
+                        name="activate_arm",
+                        output="screen",
+                    )
+                ],
+            )
+        )
+
     if want_rviz:
         actions.append(_rviz(navigating, want_moveit))
 
@@ -246,25 +280,17 @@ def _rviz(navigating, want_moveit):
     robot_description_semantic and robot_description_kinematics as node parameters, and without
     them it loads with no planning groups, which reads as a broken install.
 
-    On mode:=localization moveit:=true the navigation config is NOT substituted in, though it
-    would type-check and the launch would look healthy. Measured 2026-08-06: running that
-    combination gives an RViz with the MoveIt parameters loaded and nothing that consumes them,
-    because the MotionPlanning panel comes from the config's display list and
-    g1_navigation.rviz has none. `ros2 node info` on the resulting RViz shows no
-    monitored_planning_scene subscription at all -- the panel is simply not there.
-
-    So a navigation mode plus MoveIt shows the MoveIt config: the arms are what the panel is
-    for, and Nav2's displays are recoverable by running RViz on the nav config separately. A
-    genuine combined view needs its own .rviz carrying both the Nav2 display group and a
-    MotionPlanning display on one fixed frame. That is a file to author and review, not an
-    argument to re-point, and it belongs with the milestone that needs both at once.
+    On a navigation mode with moveit:=true this still shows the MoveIt config, and a combined
+    single-window view is NOT available. Three merges were built and every one segfaulted rviz2
+    on load (exit -11) once the navigation stack was up. Run a second RViz on
+    g1_navigation.rviz for the map and costmaps. docs/notes has what was tried.
     """
     bringup_share = get_package_share_directory("g1_bringup")
 
     if want_moveit:
         launch_file = os.path.join(_moveit_share(), "launch", "moveit_rviz.launch.py")
-        # rviz_config deliberately unset: this file never declares that name, so there is
-        # nothing for the child's default to inherit from and the MoveIt config is what
+        # Bare MoveIt leaves rviz_config unset on purpose: this file never declares that name,
+        # so there is nothing for the child's default to inherit from and g1_moveit.rviz is what
         # applies. The one case where relying on a child default is safe.
         rviz_args = {}
     else:
@@ -310,6 +336,20 @@ def generate_launch_description():
             default_value="false",
             description="Start move_group for arm planning. Works with any mode. Planning is "
             "available immediately; executing a plan still needs activate_arm.launch.py.",
+        ),
+        DeclareLaunchArgument(
+            "activate_arm",
+            default_value="false",
+            description="SIM CONVENIENCE: run scripts/activate_arm automatically once the stack "
+            "is up, instead of as a separate command. Needs moveit:=true. Off by default -- "
+            "acquiring the arm is deliberate, and on hardware it is the moment /arm_sdk starts "
+            "driving real joints.",
+        ),
+        DeclareLaunchArgument(
+            "activate_arm_delay_s",
+            default_value="25.0",
+            description="Seconds to wait before the automatic activation. The component has to "
+            "be loaded and /lowstate flowing first; too early and activate_arm fails loudly.",
         ),
         DeclareLaunchArgument(
             "waist_hold_rad",

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -1,49 +1,70 @@
-"""The operator entry point: one command for bare sim, mapping, localization or full Nav2.
+"""The operator entry point: bare sim, mapping, localization, Nav2, MoveIt, or a combination.
 
     ros2 launch g1_bringup bringup.launch.py                                  # bare sim
     ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true         # + SLAM
     ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+    ros2 launch g1_bringup bringup.launch.py moveit:=true pin_pelvis:=true rviz:=true
+    ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true moveit:=true
 
 sim.launch.py and control.launch.py are unchanged and still work standalone; this file sits
-above them and adds nothing of its own except the routing.
+above them and adds nothing of its own except the composition.
 
 ================================================================================
-g1_navigation is referenced WITHOUT being declared as a dependency. On purpose.
+g1_navigation and g1_moveit_config are referenced WITHOUT being declared as
+dependencies. On purpose.
 ================================================================================
 
-g1_navigation already declares <exec_depend>g1_bringup</exec_depend>, because navigation
-composes bring-up and not the other way round (docs/notes, M6). Adding the reciprocal
-dependency here is not merely untidy, it does not build -- colcon refuses outright:
+Both already declare <exec_depend>g1_bringup</exec_depend>, because each composes bring-up and
+not the other way round (docs/notes, M6 and M7). Adding a reciprocal dependency here is not
+merely untidy, it does not build -- colcon refuses outright:
 
     ERROR:colcon:colcon list: Unable to order packages topologically:
     g1_bringup: ['g1_navigation']
     g1_navigation: ['g1_bringup']
 
-So the reference below is a launch-time path lookup and nothing else. Consequences worth
-knowing before touching it:
+So both references below are launch-time path lookups and nothing else. Consequences worth
+knowing before touching them:
 
-  * g1_bringup builds, installs and runs with g1_navigation absent from the workspace. Only
-    the mode:=mapping / mode:=localization branches ever name it, and _navigation_share()
-    turns its absence into an actionable message rather than a raw ament search-path dump.
-  * colcon and rosdep cannot see this edge. Nothing will warn you if g1_navigation's launch
-    file names change; the launch fails at runtime instead.
+  * g1_bringup builds, installs and runs with either package absent from the workspace. Only
+    mode:=mapping / mode:=localization name g1_navigation, and only moveit:=true names
+    g1_moveit_config; _navigation_share() and _moveit_share() turn an absence into an
+    actionable message rather than a raw ament search-path dump.
+  * colcon and rosdep cannot see these edges. Nothing will warn you if either package renames
+    a launch file; the launch fails at runtime instead. test_launch_threading in each of those
+    packages is the compensating check, and neither can live here for the same reason the
+    dependency cannot.
   * Do not "fix" this by adding the dependency. It is load-bearing that it stays absent.
 
 This file composes independent pieces; it does not delegate to one bundled entry point per
-package. It stages exactly one simulator itself -- `_simulator()`, the only place the simulator
-is named anywhere in this file -- and the navigation modes add g1_navigation's
-nav_stack.launch.py, which stages none of its own. Exactly one simulator per launch, always:
-two would put two motion_service_sim processes on /lowcmd, and CONTROL_MODES.md puts that
-failure first for a reason.
+package. Three pieces, each conditional and each unaware of the others:
+
+  * the simulator -- `_simulator()`, the only place it is named anywhere in this file, and
+    exactly once per launch. Two would put two motion_service_sim processes on /lowcmd, and
+    CONTROL_MODES.md puts that failure first for a reason. Swapping in a hardware bring-up
+    later means replacing that function's body; the branches only decide what goes in its
+    arguments.
+  * navigation -- g1_navigation's nav_stack.launch.py, which stages no simulator of its own.
+  * manipulation -- g1_moveit_config's move_group.launch.py, sim-free by the same design.
 
 The direction of composition is unchanged and still navigation-over-bringup. What changed is
-the granularity: bring-up reaches a genuinely sim-independent piece of g1_navigation directly,
-rather than a wrapper that bundles a simulator in with it.
+the granularity: bring-up reaches genuinely sim-independent pieces of those packages directly,
+rather than wrappers that bundle a simulator in with them. A package may expose several such
+pieces, and bring-up may reach whichever it needs.
 
-nav_sim.launch.py still exists and still runs standalone, composing the same two pieces for a
-nav-only session, and it is what the g1_navigation integration suites launch. That leaves
-exactly one fact stated in two files -- sensors:=true on the simulator -- because each stages
-its own and there is nowhere shared to put it. test_launch_threading asserts it on both.
+nav_sim.launch.py and moveit_sim.launch.py still exist and still run standalone, each composing
+the same pieces for a single-package session, and they are what those packages' integration
+suites launch. That leaves two facts stated in two files each -- sensors:=true and
+non_arm_joint_states:=true on the simulator -- because every one of these files stages its own
+simulator and there is nowhere shared to put them. test_launch_threading asserts both copies.
+
+A note on what is NOT forwarded, since the reflex here is to forward everything. The hazard is
+inheritance: a child's DeclareLaunchArgument default never fires for a name the PARENT also
+declares, so a name declared in both places must be forwarded explicitly or the parent's value
+silently wins. That requires the same name on both sides. Names this file never declares --
+nav_stack's use_composition and container_name, moveit_rviz's rviz_config on the bare MoveIt
+branch -- have nothing to inherit from and resolve to the child's own default, which is the
+intended value. So they are deliberately left alone, and an operator who needs to set them runs
+the standalone wrapper, which does declare them.
 """
 
 import os
@@ -82,6 +103,23 @@ def _navigation_share():
         ) from exc
 
 
+def _moveit_share():
+    """g1_moveit_config's share directory, or a message an operator can act on."""
+    try:
+        return get_package_share_directory("g1_moveit_config")
+    except PackageNotFoundError as exc:
+        raise RuntimeError(
+            "bringup.launch.py: moveit:=true needs the g1_moveit_config package, which is not "
+            "on the ament prefix path.\n"
+            "  - Build it:  colcon build --packages-select g1_moveit_config\n"
+            "  - Then source install/setup.bash again in this shell.\n"
+            "g1_bringup deliberately does not declare g1_moveit_config as a dependency (the "
+            "two would form a colcon dependency cycle -- see this file's docstring), so "
+            "nothing builds it for you.\n"
+            "moveit:=false, the default, needs none of this."
+        ) from exc
+
+
 def _simulator(sim_args):
     """The one simulator this file stages, and the only place it is named.
 
@@ -110,6 +148,7 @@ def _setup(context, *args, **kwargs):
     navigating = mode != "none"
     want_nav = LaunchConfiguration("nav").perform(context).lower() == "true"
     want_rviz = LaunchConfiguration("rviz").perform(context).lower() == "true"
+    want_moveit = LaunchConfiguration("moveit").perform(context).lower() == "true"
     pin_pelvis = LaunchConfiguration("pin_pelvis").perform(context).lower() == "true"
 
     if want_nav and mode != "localization":
@@ -126,7 +165,7 @@ def _setup(context, *args, **kwargs):
 
     delay = LaunchConfiguration("sim_start_delay_s").perform(context)
     if not delay:
-        delay = DEFAULT_SIM_START_DELAY_S["loaded" if navigating else "bare"]
+        delay = DEFAULT_SIM_START_DELAY_S["loaded" if navigating or want_moveit else "bare"]
 
     # Every argument below is forwarded EXPLICITLY, including the ones whose values match
     # this file's own defaults. Included launch files inherit the parent's configurations,
@@ -143,10 +182,18 @@ def _setup(context, *args, **kwargs):
         "world": LaunchConfiguration("world"),
         "headless": LaunchConfiguration("headless"),
         "pin_pelvis": "true" if pin_pelvis else "false",
+        "waist_hold_rad": LaunchConfiguration("waist_hold_rad"),
         "sim_start_delay_s": delay,
         # We own RViz, below. Without this the simulator opens its own on the wrong config.
         "rviz": "false",
     }
+
+    if want_moveit:
+        # MoveIt refuses to plan until every active joint has a state, and the arms hang off
+        # three waist joints joint_state_broadcaster does not own. Not exposed as an operator
+        # argument: moveit:=true with this off is a move_group that comes up healthy and then
+        # silently never plans, which is a worse failure than not having the knob.
+        sim_args["non_arm_joint_states"] = "true"
 
     actions = [_simulator(sim_args)]
 
@@ -172,28 +219,68 @@ def _setup(context, *args, **kwargs):
             )
         )
 
-    if want_rviz:
-        # The nav config carries a nav2_rviz_plugins display, so it ships from g1_navigation.
-        # On the bare branch this resolves g1_bringup's own share and g1_navigation is never
-        # named -- same rule as the launch include above.
-        if navigating:
-            rviz_config = os.path.join(_navigation_share(), "config", "g1_navigation.rviz")
-        else:
-            rviz_config = os.path.join(
-                get_package_share_directory("g1_bringup"), "config", "g1_sensors.rviz"
-            )
+    if want_moveit:
+        # move_group.launch.py declares no arguments, so there is nothing to forward. It is
+        # sim-free by design -- planning needs joint states, which bring-up publishes from the
+        # moment it runs -- and it activates nothing: executing a plan still needs the ordered
+        # acquire in scripts/activate_arm.
         actions.append(
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
-                    os.path.join(
-                        get_package_share_directory("g1_bringup"), "launch", "rviz.launch.py"
-                    )
-                ),
-                launch_arguments={"rviz_config": rviz_config}.items(),
+                    os.path.join(_moveit_share(), "launch", "move_group.launch.py")
+                )
             )
         )
 
+    if want_rviz:
+        actions.append(_rviz(navigating, want_moveit))
+
     return actions
+
+
+def _rviz(navigating, want_moveit):
+    """One RViz, on the config that matches what is running. MoveIt wins when both are on.
+
+    MoveIt's own launcher rather than this package's generic rviz.launch.py, which takes only
+    an rviz_config and passes no parameters: the MotionPlanning panel needs
+    robot_description_semantic and robot_description_kinematics as node parameters, and without
+    them it loads with no planning groups, which reads as a broken install.
+
+    On mode:=localization moveit:=true the navigation config is NOT substituted in, though it
+    would type-check and the launch would look healthy. Measured 2026-08-06: running that
+    combination gives an RViz with the MoveIt parameters loaded and nothing that consumes them,
+    because the MotionPlanning panel comes from the config's display list and
+    g1_navigation.rviz has none. `ros2 node info` on the resulting RViz shows no
+    monitored_planning_scene subscription at all -- the panel is simply not there.
+
+    So a navigation mode plus MoveIt shows the MoveIt config: the arms are what the panel is
+    for, and Nav2's displays are recoverable by running RViz on the nav config separately. A
+    genuine combined view needs its own .rviz carrying both the Nav2 display group and a
+    MotionPlanning display on one fixed frame. That is a file to author and review, not an
+    argument to re-point, and it belongs with the milestone that needs both at once.
+    """
+    bringup_share = get_package_share_directory("g1_bringup")
+
+    if want_moveit:
+        launch_file = os.path.join(_moveit_share(), "launch", "moveit_rviz.launch.py")
+        # rviz_config deliberately unset: this file never declares that name, so there is
+        # nothing for the child's default to inherit from and the MoveIt config is what
+        # applies. The one case where relying on a child default is safe.
+        rviz_args = {}
+    else:
+        launch_file = os.path.join(bringup_share, "launch", "rviz.launch.py")
+        # The nav config carries a nav2_rviz_plugins display, so it ships from g1_navigation.
+        # On the bare branch this resolves g1_bringup's own share and g1_navigation is never
+        # named -- same rule as the launch includes above.
+        if navigating:
+            rviz_config = os.path.join(_navigation_share(), "config", "g1_navigation.rviz")
+        else:
+            rviz_config = os.path.join(bringup_share, "config", "g1_sensors.rviz")
+        rviz_args = {"rviz_config": rviz_config}
+
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(launch_file), launch_arguments=rviz_args.items()
+    )
 
 
 def generate_launch_description():
@@ -217,6 +304,19 @@ def generate_launch_description():
             description="Open RViz. mode:=none uses g1_bringup's sensor config (fixed frame "
             "odom); the navigation modes use g1_navigation's, which adds the Nav2 display "
             "group and is fixed on map.",
+        ),
+        DeclareLaunchArgument(
+            "moveit",
+            default_value="false",
+            description="Start move_group for arm planning. Works with any mode. Planning is "
+            "available immediately; executing a plan still needs activate_arm.launch.py.",
+        ),
+        DeclareLaunchArgument(
+            "waist_hold_rad",
+            default_value="",
+            description="SIM-ONLY: three comma-separated radians (yaw,roll,pitch) to stand the "
+            "waist at. Requires pin_pelvis:=true, which sim.launch.py enforces. Use it to "
+            "check arm planning against a torso that is not square to the pelvis.",
         ),
         DeclareLaunchArgument(
             "sensors",

--- a/workspace/src/g1_bringup/launch/control.launch.py
+++ b/workspace/src/g1_bringup/launch/control.launch.py
@@ -85,6 +85,23 @@ def generate_launch_description():
         output="screen",
     )
 
+    # Same story as the arm: loaded inactive, activated once the hand component is.
+    hand_controller_spawners = [
+        ExecuteProcess(
+            cmd=[
+                "ros2",
+                "run",
+                "controller_manager",
+                "spawner",
+                f"{side}_hand_controller",
+                "--inactive",
+            ],
+            name=f"{side}_hand_controller_spawner",
+            output="screen",
+        )
+        for side in ("left", "right")
+    ]
+
     # Tear down the whole launch if controller_manager dies.
     shutdown_on_control_node_exit = RegisterEventHandler(
         OnProcessExit(
@@ -99,6 +116,7 @@ def generate_launch_description():
             control_node,
             joint_state_broadcaster_spawner,
             arm_trajectory_controller_spawner,
+            *hand_controller_spawners,
             shutdown_on_control_node_exit,
         ]
     )

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -284,6 +284,20 @@ def _launch_setup(context, *args, **kwargs):
     sim_start_delay_s = float(LaunchConfiguration("sim_start_delay_s").perform(context))
     actions.append(TimerAction(period=sim_start_delay_s, actions=[sim_process]))
 
+    # Empty means "whatever sensors: decided", which is what every caller before MoveIt
+    # wanted. Kept as a sentinel rather than a plain bool default because the answer differs
+    # per branch and a bool would silently override the sensor track's choice.
+    non_arm_arg = LaunchConfiguration("non_arm_joint_states").perform(context).strip().lower()
+    if non_arm_arg == "":
+        publish_non_arm = sensors
+    elif non_arm_arg in ("true", "false"):
+        publish_non_arm = non_arm_arg == "true"
+    else:
+        raise RuntimeError(
+            f"non_arm_joint_states:={non_arm_arg!r} is not true, false or empty. Empty follows "
+            "sensors:, which is the historical behaviour."
+        )
+
     # Empty unless asked for, and only the stiff-hold path reads it -- see the argument's
     # own description for why that means pin_pelvis.
     waist_hold = LaunchConfiguration("waist_hold_rad").perform(context).strip()
@@ -320,9 +334,9 @@ def _launch_setup(context, *args, **kwargs):
             os.path.join(motion_service_sim_share, "config", "motion_service_sim.yaml"),
             os.path.join(motion_service_sim_share, "config", "walk_policy.yaml"),
             # Completes pelvis -> torso_link so the sensor frames are not stranded in their
-            # own TF tree, and fills in the hands, which no controller owns. Only when
-            # sensors run: it costs work on the 1 kHz /lowstate path.
-            {"publish_non_arm_joint_states": sensors},
+            # own TF tree, and fills in the hands, which no controller owns. Costs work on
+            # the 1 kHz /lowstate path, so it is not on by default.
+            {"publish_non_arm_joint_states": publish_non_arm},
             {"walk_policy.enabled": not pin_pelvis},
             waist_params,
         ],
@@ -395,6 +409,15 @@ def generate_launch_description():
                 description="SIM-ONLY debugging aid: weld the pelvis to the world AND disable the "
                 "walking policy, so the arm bridge can be exercised with nothing else driving the "
                 "legs. Default false -- the policy balances the robot itself.",
+            ),
+            DeclareLaunchArgument(
+                "non_arm_joint_states",
+                default_value="",
+                description="Publish the joints joint_state_broadcaster does not own -- legs, "
+                "waist and hands. Empty follows sensors:, which is what the sensor frames "
+                "needed and the only behaviour that existed before. Set true to get the full "
+                "43-joint robot state without the LiDAR: MoveIt will not plan until every "
+                "active joint has a state, and the arms hang off the waist.",
             ),
             DeclareLaunchArgument(
                 "waist_hold_rad",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -284,6 +284,31 @@ def _launch_setup(context, *args, **kwargs):
     sim_start_delay_s = float(LaunchConfiguration("sim_start_delay_s").perform(context))
     actions.append(TimerAction(period=sim_start_delay_s, actions=[sim_process]))
 
+    # Empty unless asked for, and only the stiff-hold path reads it -- see the argument's
+    # own description for why that means pin_pelvis.
+    waist_hold = LaunchConfiguration("waist_hold_rad").perform(context).strip()
+    waist_params = {}
+    if waist_hold:
+        if not pin_pelvis:
+            raise RuntimeError(
+                "waist_hold_rad needs pin_pelvis:=true. With the walking policy running it "
+                "owns the waist and overwrites the hold pose every tick, so the setting would "
+                "look like it applied and then quietly do nothing."
+            )
+        try:
+            waist_values = [float(v) for v in waist_hold.split(",")]
+        except ValueError as exc:
+            raise RuntimeError(
+                f"waist_hold_rad:={waist_hold!r} is not numbers. Expected three comma-separated "
+                "radians, yaw,roll,pitch."
+            ) from exc
+        if len(waist_values) != 3:
+            raise RuntimeError(
+                f"waist_hold_rad:={waist_hold!r} has {len(waist_values)} values; the waist has "
+                "three joints (yaw, roll, pitch)."
+            )
+        waist_params = {"waist_hold_rad": waist_values}
+
     # Pelvis weld and walking policy are mutually exclusive.
     motion_service_sim_share = get_package_share_directory("g1_motion_service_sim")
     motion_service_sim_node  = Node(
@@ -299,6 +324,7 @@ def _launch_setup(context, *args, **kwargs):
             # sensors run: it costs work on the 1 kHz /lowstate path.
             {"publish_non_arm_joint_states": sensors},
             {"walk_policy.enabled": not pin_pelvis},
+            waist_params,
         ],
     )
 
@@ -369,6 +395,15 @@ def generate_launch_description():
                 description="SIM-ONLY debugging aid: weld the pelvis to the world AND disable the "
                 "walking policy, so the arm bridge can be exercised with nothing else driving the "
                 "legs. Default false -- the policy balances the robot itself.",
+            ),
+            DeclareLaunchArgument(
+                "waist_hold_rad",
+                default_value="",
+                description="SIM-ONLY: three comma-separated radians (yaw,roll,pitch) to stand "
+                "the waist at instead of the pose it spawned in. Needs pin_pelvis:=true, "
+                "because a running walking policy owns the waist and overwrites this. Exists "
+                "so manipulation can be exercised with a torso that is not square to the "
+                "pelvis, which is the case a zero waist hides.",
             ),
             DeclareLaunchArgument(
                 "sim_start_delay_s",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -295,8 +295,9 @@ def _launch_setup(context, *args, **kwargs):
             os.path.join(motion_service_sim_share, "config", "motion_service_sim.yaml"),
             os.path.join(motion_service_sim_share, "config", "walk_policy.yaml"),
             # Completes pelvis -> torso_link so the sensor frames are not stranded in their
-            # own TF tree. Only when sensors run: it costs work on the 1 kHz /lowstate path.
-            {"publish_lower_joint_states": sensors},
+            # own TF tree, and fills in the hands, which no controller owns. Only when
+            # sensors run: it costs work on the 1 kHz /lowstate path.
+            {"publish_non_arm_joint_states": sensors},
             {"walk_policy.enabled": not pin_pelvis},
         ],
     )

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -65,6 +65,15 @@
     <geom name="obstacle_cyl" group="2" type="cylinder" size="0.25 0.75" pos="-1.5 -2.0 0.75"
           material="obstacle"/>
 
+    <!-- Inside the arms' reach, which nothing else in this scene is: the other obstacles sit
+         1.5 m or further out and the colour target is on the floor. MoveIt's octomap only
+         demonstrates anything if there is something to plan around, so this is the obstacle
+         g1_moveit_config's test_octomap_blocks_a_plan drives a hand into. 0.42 m ahead at
+         0.95 m puts it in front of the chest, well within the ~0.7 m reach and comfortably
+         inside the MID360's field of view. -->
+    <geom name="reach_obstacle" group="2" type="box" size="0.12 0.25 0.12" pos="0.42 0.0 0.95"
+          material="obstacle"/>
+
     <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes
          cam_xpos/cam_xmat into its own snapshot every frame from torso_link's live pose,
          because the mount belongs to the vendored robot and cannot host a camera element. -->

--- a/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_perception_scene.xml
@@ -68,10 +68,18 @@
     <!-- Inside the arms' reach, which nothing else in this scene is: the other obstacles sit
          1.5 m or further out and the colour target is on the floor. MoveIt's octomap only
          demonstrates anything if there is something to plan around, so this is the obstacle
-         g1_moveit_config's test_octomap_blocks_a_plan drives a hand into. 0.42 m ahead at
-         0.95 m puts it in front of the chest, well within the ~0.7 m reach and comfortably
-         inside the MID360's field of view. -->
-    <geom name="reach_obstacle" group="2" type="box" size="0.12 0.25 0.12" pos="0.42 0.0 0.95"
+         g1_moveit_config's test_octomap_blocks_a_plan drives a hand into.
+
+         A slab rather than a small block, so the test does not depend on guessing joint angles
+         precisely. Placed by measurement: /compute_fk puts the right palm at x 0.213, z 0.518
+         in the pelvis frame for that test pose, which is 1.273 in world with the pelvis pinned.
+         An arm raised forward on this robot goes up as well as out, so a slab at chest height
+         and 0.42 m out (the obvious guess) is missed entirely.
+
+         Spans x 0.18 to 0.38 and z 1.00 to 1.50. The torso front and the resting hands sit
+         inside 0.18, which is what keeps the sensors-off control assertion meaningful.
+         Comfortably inside the MID360's field of view. -->
+    <geom name="reach_obstacle" group="2" type="box" size="0.10 0.45 0.25" pos="0.28 0.0 1.25"
           material="obstacle"/>
 
     <!-- D435i intrinsics only. Its pose here is a placeholder: the sensor thread writes

--- a/workspace/src/g1_bringup/package.xml
+++ b/workspace/src/g1_bringup/package.xml
@@ -35,6 +35,7 @@
   <!-- Loaded at runtime by control.launch.py as a ros2_control plugin; nothing here
        compiles against it. -->
   <exec_depend>g1_hardware_interface</exec_depend>
+  <exec_depend>g1_hand_interface</exec_depend>
 
   <!-- The sim-only motion service sim.launch.py starts. -->
   <exec_depend>g1_motion_service_sim</exec_depend>

--- a/workspace/src/g1_bringup/scripts/activate_arm
+++ b/workspace/src/g1_bringup/scripts/activate_arm
@@ -28,6 +28,17 @@ COMPONENT_NAME = "G1ArmSdkSystem"
 CONTROLLER_NAME = "arm_trajectory_controller"
 LOWSTATE_TOPIC = "/lowstate"
 
+# The hands, acquired in the same order and by the same rules. Best-effort on purpose: a
+# Dex3 that is absent, unpowered or simply not publishing state must not stop the arm from
+# being usable, and G1Dex3System refuses to activate without fresh feedback precisely so
+# that shows up here rather than as fingers driven from a stale measurement.
+HANDS = (
+    ("G1Dex3SystemLeft", "left_hand_controller"),
+    ("G1Dex3SystemRight", "right_hand_controller"),
+)
+# Shorter than the arm's: an absent hand should be reported quickly, not waited out twice.
+HAND_ACTIVATE_TIMEOUT_S = 5.0
+
 # Generous versus the component's own lowstate_timeout_ms (100 ms default):
 # this check only proves /lowstate is flowing at all before we even attempt
 # activation, not the component's own freshness gate.
@@ -67,7 +78,7 @@ def wait_for_fresh_lowstate(node, timeout_s):
         node.destroy_subscription(sub)
 
 
-def set_component_state(node, client, target_state_id, target_label, retry_timeout_s):
+def set_component_state(node, client, name, target_state_id, target_label, retry_timeout_s):
     """Bounded retry: the component/controller_manager may not be discovered
     yet, or activation may be legitimately refused if /lowstate just barely
     missed the freshness window (see g1_hardware_interface's on_activate).
@@ -81,7 +92,7 @@ def set_component_state(node, client, target_state_id, target_label, retry_timeo
             continue
 
         request = SetHardwareComponentState.Request()
-        request.name = COMPONENT_NAME
+        request.name = name
         request.target_state.id = target_state_id
         request.target_state.label = target_label
 
@@ -93,7 +104,7 @@ def set_component_state(node, client, target_state_id, target_label, retry_timeo
         last_error = f"rejected (result={result})"
         time.sleep(COMPONENT_RETRY_PERIOD_S)
 
-    node.get_logger().error(f"timed out setting {COMPONENT_NAME} to {target_label!r}: {last_error}")
+    node.get_logger().error(f"timed out setting {name} to {target_label!r}: {last_error}")
     return False
 
 
@@ -137,6 +148,7 @@ def main():
         if not set_component_state(
             node,
             component_client,
+            COMPONENT_NAME,
             State.PRIMARY_STATE_ACTIVE,
             "active",
             COMPONENT_ACTIVATE_TIMEOUT_S,
@@ -150,6 +162,23 @@ def main():
         ):
             node.get_logger().error(f"failed to activate {CONTROLLER_NAME}")
             return 1
+
+        for component, controller in HANDS:
+            node.get_logger().info(f"activating hand {component}...")
+            if not set_component_state(
+                node,
+                component_client,
+                component,
+                State.PRIMARY_STATE_ACTIVE,
+                "active",
+                HAND_ACTIVATE_TIMEOUT_S,
+            ) or not switch_controller(
+                node, controller_client, [controller], [], SERVICE_CALL_TIMEOUT_S
+            ):
+                node.get_logger().warning(
+                    f"{component} did not come up; the arm is still usable but this hand "
+                    "will not move. Check that it is powered and publishing state."
+                )
 
         node.get_logger().info("activation complete: component and controller both active.")
         return 0

--- a/workspace/src/g1_bringup/scripts/deactivate_arm
+++ b/workspace/src/g1_bringup/scripts/deactivate_arm
@@ -24,6 +24,13 @@ COMPONENT_NAME = "G1ArmSdkSystem"
 CONTROLLER_NAME = "arm_trajectory_controller"
 SERVICE_CALL_TIMEOUT_S = 5.0
 
+# Released before the arm and best-effort, mirroring activate_arm: a hand that never came up
+# must not stand between the arm and its ramp-down, which is the release that matters.
+HANDS = (
+    ("G1Dex3SystemLeft", "left_hand_controller"),
+    ("G1Dex3SystemRight", "right_hand_controller"),
+)
+
 # Must comfortably exceed blend_ramp_down_s (2.0 s default): on_deactivate
 # blocks the whole service call for the ramp's duration by design (see
 # g1_hardware_interface's README -- resource_manager serializes lifecycle
@@ -50,13 +57,13 @@ def switch_controller(node, client, activate, deactivate, timeout_s):
     return result is not None and result.ok
 
 
-def set_component_state(node, client, target_state_id, target_label, timeout_s):
+def set_component_state(node, client, name, target_state_id, target_label, timeout_s):
     if not client.wait_for_service(timeout_sec=5.0):
         node.get_logger().error("set_hardware_component_state service not available")
         return False
 
     request = SetHardwareComponentState.Request()
-    request.name = COMPONENT_NAME
+    request.name = name
     request.target_state.id = target_state_id
     request.target_state.label = target_label
 
@@ -77,6 +84,18 @@ def main():
             SetHardwareComponentState, "/controller_manager/set_hardware_component_state"
         )
 
+        for component, controller in HANDS:
+            node.get_logger().info(f"releasing hand {component}...")
+            switch_controller(node, controller_client, [], [controller], SERVICE_CALL_TIMEOUT_S)
+            set_component_state(
+                node,
+                component_client,
+                component,
+                State.PRIMARY_STATE_INACTIVE,
+                "inactive",
+                SERVICE_CALL_TIMEOUT_S,
+            )
+
         # Controller-then-component: see this script's module docstring.
         node.get_logger().info(f"deactivating controller {CONTROLLER_NAME}...")
         if not switch_controller(
@@ -92,6 +111,7 @@ def main():
         if not set_component_state(
             node,
             component_client,
+            COMPONENT_NAME,
             State.PRIMARY_STATE_INACTIVE,
             "inactive",
             COMPONENT_DEACTIVATE_TIMEOUT_S,

--- a/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
@@ -213,8 +213,11 @@ class LidarGeometryTest(unittest.TestCase):
             int(floor.sum()), 200, f"only {floor.sum()} returns on the floor plane"
         )
 
-        # Every wall, so a sweep that lost a sector fails rather than averaging out.
-        for axis, sign, name in ((0, 1, "+x"), (0, -1, "-x"), (1, 1, "+y"), (1, -1, "-y")):
+        # Three walls, so a sweep that lost a sector fails rather than averaging out. The +x
+        # wall is deliberately absent: reach_obstacle sits 0.18 m in front of the sensor at its
+        # own height and occludes that whole direction, which is exactly what makes
+        # g1_moveit_config's octomap test work. Measured, the cloud stops at x = 1.60.
+        for axis, sign, name in ((0, -1, "-x"), (1, 1, "+y"), (1, -1, "-y")):
             on_wall = np.abs(world[:, axis] - sign * ROOM_HALF) < 0.05
             self.assertGreater(
                 int(on_wall.sum()), 20, f"only {on_wall.sum()} returns on the {name} wall"

--- a/workspace/src/g1_bringup/test/test_sim_bringup.launch.py
+++ b/workspace/src/g1_bringup/test/test_sim_bringup.launch.py
@@ -129,7 +129,10 @@ class TestSimBringup(unittest.TestCase):
 
         self.assertGreater(len(samples), 0)
         last = samples[-1]
-        self.assertEqual(len(last.name), 14)
+        # 14 arm joints plus 7 fingers per hand: joint_state_broadcaster covers every
+        # configured component, and the two Dex3 components are configured from startup even
+        # though they are not activated until the acquire step.
+        self.assertEqual(len(last.name), 28)
         for value in list(last.position) + list(last.velocity):
             self.assertTrue(math.isfinite(value), f"non-finite joint_states value: {value}")
 

--- a/workspace/src/g1_description/config/dex3_params.yaml
+++ b/workspace/src/g1_description/config/dex3_params.yaml
@@ -1,0 +1,41 @@
+# Hardware parameters for g1_hand_interface/G1Dex3System, one component per hand.
+#
+# Consumed by urdf/g1_arm_sdk.urdf.xacro via xacro.load_yaml, for the same reason
+# arm_sdk_params.yaml is: Humble ros2_control plugins only see parameters that arrive
+# as <ros2_control><param> tags, never controller_manager's own YAML.
+
+# Common to both hands. Gains are the hand's own -- roughly 300x smaller than the arm's,
+# because these are finger motors. From Unitree's maintained teleop path; their SDK example
+# sweeps at 0.5/0.1 and grips at 1.5/0.1.
+system:
+  kp: 1.5
+  kd: 0.2
+  command_publish_rate: 100.0    # Hz; what Unitree's own teleop publishes at
+  max_joint_velocity_rad_s: 3.0  # rad/s; slew clamp. There is no blend weight on this
+                                 # interface, so this is the only thing between a large
+                                 # trajectory step and a finger moving at motor speed.
+  state_timeout_ms: 200.0        # ms; HandState older than this blocks activation
+
+# Position limits, straight from g1_29dof_with_hand_rev_1_0.urdf. Duplicated here because
+# HardwareInfo does not carry the URDF's own <limit> tags, and the component clamps to these
+# as a backstop against a bad command. The two hands mirror: left closes negative, right
+# positive. Unitree's SDK example disagrees on thumb_1 (0.724, and 0.742 on the right, which
+# looks like a transposed digit); the URDF matches the published spec and is the conservative
+# pair, so it wins.
+#
+# Order is the Dex3 WIRE order and the component refuses to init if the xacro reorders it.
+joints:
+  left_hand_thumb_0_joint:   { min: -1.04719755, max:  1.04719755 }
+  left_hand_thumb_1_joint:   { min: -0.61086523, max:  1.04719755 }
+  left_hand_thumb_2_joint:   { min:  0.0,        max:  1.74532925 }
+  left_hand_middle_0_joint:  { min: -1.57079632, max:  0.0        }
+  left_hand_middle_1_joint:  { min: -1.74532925, max:  0.0        }
+  left_hand_index_0_joint:   { min: -1.57079632, max:  0.0        }
+  left_hand_index_1_joint:   { min: -1.74532925, max:  0.0        }
+  right_hand_thumb_0_joint:  { min: -1.04719755, max:  1.04719755 }
+  right_hand_thumb_1_joint:  { min: -1.04719755, max:  0.61086523 }
+  right_hand_thumb_2_joint:  { min: -1.74532925, max:  0.0        }
+  right_hand_middle_0_joint: { min:  0.0,        max:  1.57079632 }
+  right_hand_middle_1_joint: { min:  0.0,        max:  1.74532925 }
+  right_hand_index_0_joint:  { min:  0.0,        max:  1.57079632 }
+  right_hand_index_1_joint:  { min:  0.0,        max:  1.74532925 }

--- a/workspace/src/g1_description/package.xml
+++ b/workspace/src/g1_description/package.xml
@@ -26,4 +26,5 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
+  <exec_depend>realsense2_description</exec_depend>
 </package>

--- a/workspace/src/g1_description/package.xml
+++ b/workspace/src/g1_description/package.xml
@@ -23,8 +23,10 @@
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <!-- The d435 mesh the sensor visual points at. -->
+  <exec_depend>realsense2_description</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-  <exec_depend>realsense2_description</exec_depend>
 </package>

--- a/workspace/src/g1_description/test/test_arm_sdk_xacro.py
+++ b/workspace/src/g1_description/test/test_arm_sdk_xacro.py
@@ -89,3 +89,30 @@ def test_no_non_arm_joints_leak_into_ros2_control(expanded_urdf_path):
     root = ET.parse(expanded_urdf_path).getroot()
     joints = root.find("ros2_control").findall("joint")
     assert len(joints) == 14
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_each_hand_is_its_own_component_in_wire_order(expanded_urdf_path, side):
+    # The Dex3 is a separate device with its own authority, so it gets its own component
+    # rather than extra joints on the arm's. Order is load-bearing here and not merely
+    # tidy: HandCmd.motor_cmd is positional, and G1Dex3System refuses to init on a
+    # mismatch precisely so a reordered list cannot silently close the wrong fingers.
+    name = f"G1Dex3System{side.capitalize()}"
+    root = ET.parse(expanded_urdf_path).getroot()
+    component = next(c for c in root.findall("ros2_control") if c.get("name") == name)
+
+    assert component.find("hardware/plugin").text == "g1_hand_interface/G1Dex3System"
+    params = {p.get("name"): p.text for p in component.findall("hardware/param")}
+    assert params["side"] == side
+    assert {"kp", "kd", "command_publish_rate", "max_joint_velocity_rad_s"} <= params.keys()
+
+    joints = component.findall("joint")
+    assert [j.get("name") for j in joints] == [
+        f"{side}_hand_{suffix}_joint"
+        for suffix in ("thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1",
+                       "index_0", "index_1")
+    ]
+    for joint in joints:
+        assert [c.get("name") for c in joint.findall("command_interface")] == ["position"]
+        limits = {p.get("name"): float(p.text) for p in joint.findall("param")}
+        assert limits["min"] < limits["max"]

--- a/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
+++ b/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
@@ -27,6 +27,51 @@
     <origin xyz="0 0 0" rpy="-1.5707963267948966 0 -1.5707963267948966"/>
   </joint>
 
+  <!-- Sensor bodies. The vendored URDF leaves d435_link and mid360_link as EMPTY links, so both
+       sensors are invisible in RViz and it is impossible to see where either is pointing.
+       Attached as child links rather than by editing those links, for the same reason the
+       optical frames above are: the vendored file stays byte-for-byte diffable against
+       Unitree's.
+
+       VISUAL ONLY, deliberately. Collision geometry here would be swept into MoveIt's
+       self-filter and its planning scene, so a mis-sized box would silently either carve a hole
+       in the octomap or block plans near the head. These exist to be looked at, nothing more.
+       See g1_moveit_config/config/sensors_3d.yaml for what the sensors actually feed. -->
+  <link name="d435_visual">
+    <visual>
+      <!-- Intel's own placement from realsense2_description's _d435.urdf.xacro: the mesh origin
+           sits at the front plate between the two infrared cameras, so it needs this offset and
+           rotation to line up with the link. Values are
+           d435_zero_depth_to_glass + d435_glass_to_front, and -d435_cam_depth_py. -->
+      <origin xyz="0.0043 -0.0175 0" rpy="1.5707963267948966 0 1.5707963267948966"/>
+      <geometry>
+        <mesh filename="package://realsense2_description/meshes/d435.dae"/>
+      </geometry>
+    </visual>
+  </link>
+  <joint name="d435_visual_joint" type="fixed">
+    <parent link="d435_link"/>
+    <child link="d435_visual"/>
+  </joint>
+
+  <link name="mid360_visual">
+    <visual>
+      <!-- Livox ship no ROS description package, so this is a primitive from the published
+           MID360 dimensions (65 x 65 x 60 mm) rather than a mesh. It marks where the LiDAR is
+           and roughly how big; do not read anything finer off it. -->
+      <geometry>
+        <cylinder radius="0.0325" length="0.060"/>
+      </geometry>
+      <material name="dark_grey">
+        <color rgba="0.15 0.15 0.15 1.0"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="mid360_visual_joint" type="fixed">
+    <parent link="mid360_link"/>
+    <child link="mid360_visual"/>
+  </joint>
+
   <!-- Load tunable YAML for ROS 2 control parameters. -->
   <xacro:property name="arm_sdk_params" value="${xacro.load_yaml('../config/arm_sdk_params.yaml')}"/>
 

--- a/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
+++ b/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
@@ -115,4 +115,50 @@
     <xacro:g1_arm_joint name="right_wrist_yaw_joint"/>
   </ros2_control>
 
+  <xacro:property name="dex3_params" value="${xacro.load_yaml('../config/dex3_params.yaml')}"/>
+
+  <xacro:macro name="g1_hand_joint" params="name">
+    <joint name="${name}">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+      <param name="min">${dex3_params.joints[name].min}</param>
+      <param name="max">${dex3_params.joints[name].max}</param>
+    </joint>
+  </xacro:macro>
+
+  <!-- One component per hand. The Dex3 is a separate device on its own DDS topics with its
+       own authority (docs/CONTROL_MODES.md), so it is neither folded into G1ArmSdkSystem nor
+       shared between the two hands: a fault on one hand must not take the arms or the other
+       hand down with it.
+
+       Joint order is the Dex3 wire order and G1Dex3System refuses to init if it is disturbed,
+       because HandCmd.motor_cmd is a positional array and a reordered list would close the
+       wrong fingers. -->
+  <xacro:macro name="g1_dex3_hand" params="side">
+    <ros2_control name="G1Dex3System${'Left' if side == 'left' else 'Right'}" type="system">
+      <hardware>
+        <plugin>g1_hand_interface/G1Dex3System</plugin>
+        <param name="side">${side}</param>
+        <param name="kp">${dex3_params.system.kp}</param>
+        <param name="kd">${dex3_params.system.kd}</param>
+        <param name="command_publish_rate">${dex3_params.system.command_publish_rate}</param>
+        <param name="max_joint_velocity_rad_s">${dex3_params.system.max_joint_velocity_rad_s}</param>
+        <param name="state_timeout_ms">${dex3_params.system.state_timeout_ms}</param>
+      </hardware>
+
+      <xacro:g1_hand_joint name="${side}_hand_thumb_0_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_thumb_1_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_thumb_2_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_middle_0_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_middle_1_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_index_0_joint"/>
+      <xacro:g1_hand_joint name="${side}_hand_index_1_joint"/>
+    </ros2_control>
+  </xacro:macro>
+
+  <xacro:g1_dex3_hand side="left"/>
+  <xacro:g1_dex3_hand side="right"/>
+
 </robot>

--- a/workspace/src/g1_hand_interface/CMakeLists.txt
+++ b/workspace/src/g1_hand_interface/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_hand_interface)
+
+find_package(ament_cmake REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(unitree_hg REQUIRED)
+
+add_library(g1_dex3_system SHARED src/g1_dex3_system.cpp)
+target_include_directories(g1_dex3_system PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(g1_dex3_system PUBLIC cxx_std_20)
+ament_target_dependencies(g1_dex3_system PUBLIC
+  hardware_interface pluginlib rclcpp rclcpp_lifecycle realtime_tools unitree_hg)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(g1_dex3_system PRIVATE -Wall -Wextra)
+endif()
+
+pluginlib_export_plugin_description_file(hardware_interface g1_hand_interface.xml)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS g1_dex3_system EXPORT export_${PROJECT_NAME} DESTINATION lib)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+ament_export_dependencies(hardware_interface pluginlib rclcpp realtime_tools unitree_hg)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/workspace/src/g1_hand_interface/CMakeLists.txt
+++ b/workspace/src/g1_hand_interface/CMakeLists.txt
@@ -34,6 +34,14 @@ ament_export_dependencies(hardware_interface pluginlib rclcpp realtime_tools uni
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gmock REQUIRED)
+
+  # The wire format, plus the plugin discovery proof: a clean compile says nothing about
+  # whether controller_manager can actually find the class through its XML export.
+  ament_add_gmock(test_wire_contract test/test_wire_contract.cpp)
+  target_link_libraries(test_wire_contract g1_dex3_system)
+  ament_target_dependencies(test_wire_contract pluginlib hardware_interface)
 endif()
 
 ament_package()

--- a/workspace/src/g1_hand_interface/README.md
+++ b/workspace/src/g1_hand_interface/README.md
@@ -56,6 +56,25 @@ and arming it would stop the fingers a second after any hiccup in the control lo
 disagrees on `thumb_1` (0.724 vs 0.611 rad) and its right hand says 0.742, which looks like a
 transposed digit.
 
+## In simulation
+
+`unitree_mujoco` answers the same two topics, so this component is not swapped out for sim. The
+responder is `workspace/vendor/unitree_mujoco/dex3_handler.cc`, registered by patch 004; the
+finger joints themselves come from patch 003.
+
+It runs the PD the hardware runs, from the `kp`/`kd` in the command, and clamps to the URDF's
+effort limits. Two behaviours worth knowing:
+
+- The fingers are driven through `qfrc_applied`, not through MuJoCo actuators. The vendored SDK
+  bridge sizes itself from the actuator count and indexes a fixed 35-slot `LowCmd`, so 29 body
+  motors plus 14 fingers would run it off the end of that array.
+- `status = Lock` holds the finger where it is rather than going limp, which is what the
+  hardware's own status byte means. The same applies before any command arrives and one second
+  after the last one.
+
+Finger contact is not simulated: the geometry is visual only, and grasping is modelled by
+attaching the object in MoveIt's planning scene.
+
 ## Not yet verified on hardware
 
 The real state publish rate, the press-sensor index-to-pad map, and the `thumb_1` upper limit.

--- a/workspace/src/g1_hand_interface/README.md
+++ b/workspace/src/g1_hand_interface/README.md
@@ -1,0 +1,62 @@
+# g1_hand_interface
+
+`ros2_control` `SystemInterface` for one Unitree Dex3-1 hand, over the hand's own DDS topics.
+
+`ament_cmake`, C++20. **Real hardware code** — it speaks Unitree's published Dex3 contract and
+runs unchanged on the robot; the simulator answers the same topics.
+
+Separate from `g1_hardware_interface` on purpose. The hand is a different device with different
+topics and its own authority (`docs/CONTROL_MODES.md`), and one component per hand keeps a hand
+fault from taking the arms down with it.
+
+## Interfaces
+
+| Interface | Kind | Source |
+|---|---|---|
+| `position` | command | ramped, then clamped to the URDF limits |
+| `position`, `velocity`, `effort` | state | `motor_state[i].q` / `.dq` / `.tau_est` |
+
+| Topic | Direction | Type |
+|---|---|---|
+| `/dex3/<side>/cmd` | out | `unitree_hg/msg/HandCmd` |
+| `/dex3/<side>/state` | in | `unitree_hg/msg/HandState` |
+
+Both at sensor QoS. `<side>` comes from the `side` parameter and must be `left` or `right`.
+
+## Parameters
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `side` | — | `left` or `right`. Picks the topics and the joint prefix. Required. |
+| `kp` | 1.5 | Finger motors, not arm motors. Roughly 300× smaller than the arm's gains. |
+| `kd` | 0.2 | |
+| `command_publish_rate` | 100.0 | Hz. What Unitree's own teleop uses. |
+| `max_joint_velocity_rad_s` | 3.0 | Slew clamp on the commanded position. |
+| `state_timeout_ms` | 200.0 | State older than this blocks activation. |
+
+## Things the wire format will punish you for
+
+**`motor_cmd` is an unbounded sequence, not a fixed array.** Publish it unresized and DDS accepts
+the message while nothing moves. `on_configure` resizes once and `publish()` resizes again.
+
+**Joint order is positional**, and it is the URDF's own order: thumb_0, thumb_1, thumb_2,
+middle_0, middle_1, index_0, index_1 — identical for both hands. `on_init` refuses to start if
+the declared joints disagree, because the failure is otherwise a hand that closes the wrong
+fingers. Unitree's own `Dex3_1_Right_JointIndex` enum lists index before middle and contradicts
+their documented order; it is inert in their code but must not be copied here.
+
+**There is no blend weight.** Unlike `rt/arm_sdk`, the first publish takes full authority
+immediately. That is why this component seeds its command from the measured position on activate
+and slews toward the target: nothing upstream will soften a step for you.
+
+**Timeout protection** is armed only on release. While driving, the controller is the heartbeat,
+and arming it would stop the fingers a second after any hiccup in the control loop.
+
+**Limits come from the URDF**, which matches Unitree's published spec. Their SDK example
+disagrees on `thumb_1` (0.724 vs 0.611 rad) and its right hand says 0.742, which looks like a
+transposed digit.
+
+## Not yet verified on hardware
+
+The real state publish rate, the press-sensor index-to-pad map, and the `thumb_1` upper limit.
+None are documented publicly. See `docs/notes/milestone8-gripper-plan.md`.

--- a/workspace/src/g1_hand_interface/g1_hand_interface.xml
+++ b/workspace/src/g1_hand_interface/g1_hand_interface.xml
@@ -1,0 +1,7 @@
+<library path="g1_dex3_system">
+  <class name="g1_hand_interface/G1Dex3System"
+         type="g1_hand_interface::G1Dex3System"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>One Unitree Dex3-1 hand on /dex3/&lt;side&gt;/{cmd,state}.</description>
+  </class>
+</library>

--- a/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
+++ b/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
@@ -1,0 +1,126 @@
+#ifndef G1_HAND_INTERFACE__G1_DEX3_SYSTEM_HPP_
+#define G1_HAND_INTERFACE__G1_DEX3_SYSTEM_HPP_
+
+/**
+ * @file g1_dex3_system.hpp
+ * @brief ros2_control SystemInterface for one Unitree Dex3-1 hand, over its own DDS topics.
+ *
+ * Real hardware code. It speaks Unitree's published Dex3 contract and carries to the robot
+ * unchanged; the simulator is expected to answer the same topics.
+ *
+ * Deliberately NOT part of G1ArmSdkSystem. The hand is a separate device on separate topics
+ * with separate authority (docs/CONTROL_MODES.md), and one component per hand keeps a hand
+ * fault from taking the arms down with it.
+ */
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/system_interface.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "realtime_tools/realtime_publisher.h"
+#include "unitree_hg/msg/hand_cmd.hpp"
+#include "unitree_hg/msg/hand_state.hpp"
+
+namespace g1_hand_interface
+{
+
+/// Seven joints per hand. HandCmd.motor_cmd is an unbounded sequence, so it must be resized to
+/// this before publishing -- an empty sequence is accepted and silently does nothing.
+inline constexpr std::size_t kNumHandJoints = 7;
+
+/// Wire order, identical for both hands: thumb_0, thumb_1, thumb_2, middle_0, middle_1,
+/// index_0, index_1. This is also the URDF's own document order, so the map is positional.
+///
+/// Do NOT copy Unitree's Dex3_1_Right_JointIndex enum from xr_teleoperate/avp_teleoperate: it
+/// lists index before middle, contradicting their documented order. It is inert there (every
+/// use is enumerate(), so the value never permutes anything) but transcribing it here would
+/// close the wrong fingers.
+inline constexpr std::array<const char*, kNumHandJoints> kJointSuffixes = {
+    "thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1", "index_0", "index_1",
+};
+
+/// The packed `mode` byte Unitree's motors expect: id in bits 0-3, status in 4-6, timeout in 7.
+/// `id` must equal the motor's own index; 15 would broadcast to every motor.
+inline constexpr std::uint8_t packMode(std::size_t index, std::uint8_t status, bool timeout)
+{
+    return static_cast<std::uint8_t>(
+        (index & 0x0F) | ((status & 0x07) << 4) | ((timeout ? 1U : 0U) << 7));
+}
+
+inline constexpr std::uint8_t kStatusLock = 0x00;  ///< motor held, gains ignored
+inline constexpr std::uint8_t kStatusFoc  = 0x01;  ///< driven
+
+class G1Dex3System : public hardware_interface::SystemInterface
+{
+public:
+    hardware_interface::CallbackReturn
+    on_init(const hardware_interface::HardwareInfo& info) override;
+    hardware_interface::CallbackReturn
+    on_configure(const rclcpp_lifecycle::State& previous) override;
+    hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous) override;
+    hardware_interface::CallbackReturn
+    on_deactivate(const rclcpp_lifecycle::State& previous) override;
+
+    std::vector<hardware_interface::StateInterface>   export_state_interfaces() override;
+    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+    hardware_interface::return_type
+    read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+    hardware_interface::return_type
+    write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+private:
+    void handStateCallback(const unitree_hg::msg::HandState::ConstSharedPtr& msg);
+
+    /// Fills every motor slot and publishes. `driven` false emits the release command: status
+    /// Lock, timeout armed, zero gains.
+    void publish(bool driven);
+
+    std::string side_;  ///< "left" or "right"; picks the topic pair and the joint prefix.
+
+    /// Per joint, in wire order.
+    std::array<double, kNumHandJoints> position_command_{};
+    std::array<double, kNumHandJoints> ramped_command_{};
+    std::array<double, kNumHandJoints> position_state_{};
+    std::array<double, kNumHandJoints> velocity_state_{};
+    std::array<double, kNumHandJoints> effort_state_{};
+    std::array<double, kNumHandJoints> lower_limit_{};
+    std::array<double, kNumHandJoints> upper_limit_{};
+
+    /// From <param> tags on the ros2_control block. kp/kd are ~300x smaller than the arm's:
+    /// these are finger motors, and arm gains here would be violent.
+    double kp_{ 1.5 };
+    double kd_{ 0.2 };
+    double command_publish_rate_{ 100.0 };
+    double max_joint_velocity_{ 3.0 };
+    double state_timeout_s_{ 0.2 };
+
+    /// There is no blend weight on this interface -- unlike rt/arm_sdk, the first publish takes
+    /// full authority. So the ramp is ours to do, and it is the only thing standing between a
+    /// large command step and a fast finger.
+    bool                                  seeded_{ false };
+    std::chrono::steady_clock::time_point last_publish_{};
+    std::chrono::steady_clock::time_point last_state_{};
+
+    rclcpp::Node::SharedPtr                                                      node_;
+    rclcpp::Subscription<unitree_hg::msg::HandState>::SharedPtr                  state_sub_;
+    std::shared_ptr<realtime_tools::RealtimePublisher<unitree_hg::msg::HandCmd>> cmd_pub_;
+    rclcpp::Publisher<unitree_hg::msg::HandCmd>::SharedPtr                       cmd_pub_raw_;
+    std::thread                                                                  spin_thread_;
+    std::atomic<bool>                                                            spinning_{ false };
+
+    /// Written by the subscription thread, read by read(). Small and trivially copyable, and
+    /// the executor is single-threaded, so a seqlock would buy nothing here.
+    std::array<double, kNumHandJoints> rx_position_{};
+    std::array<double, kNumHandJoints> rx_velocity_{};
+    std::array<double, kNumHandJoints> rx_effort_{};
+    std::atomic<bool>                  rx_valid_{ false };
+};
+
+}  // namespace g1_hand_interface
+
+#endif  // G1_HAND_INTERFACE__G1_DEX3_SYSTEM_HPP_

--- a/workspace/src/g1_hand_interface/package.xml
+++ b/workspace/src/g1_hand_interface/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>g1_hand_interface</name>
+  <version>0.1.0</version>
+  <description>ros2_control system interface for the Unitree Dex3-1 hand, over its own DDS topics.</description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh Gupta</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
+  <depend>unitree_hg</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_hand_interface/package.xml
+++ b/workspace/src/g1_hand_interface/package.xml
@@ -15,6 +15,8 @@
   <depend>unitree_hg</depend>
 
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
 
   <export>

--- a/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
+++ b/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
@@ -1,0 +1,289 @@
+/**
+ * @file g1_dex3_system.cpp
+ * @brief One Dex3-1 hand as a ros2_control system, over /dex3/<side>/{cmd,state}.
+ */
+
+#include "g1_hand_interface/g1_dex3_system.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_list_macros.hpp"
+
+namespace g1_hand_interface
+{
+namespace
+{
+double paramOr(const hardware_interface::HardwareInfo& info, const std::string& key, double fallback)
+{
+    const auto it = info.hardware_parameters.find(key);
+    return it == info.hardware_parameters.end() ? fallback : std::stod(it->second);
+}
+}  // namespace
+
+hardware_interface::CallbackReturn
+G1Dex3System::on_init(const hardware_interface::HardwareInfo& info)
+{
+    if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    {
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    const auto side_it = info.hardware_parameters.find("side");
+    if (side_it == info.hardware_parameters.end() ||
+        (side_it->second != "left" && side_it->second != "right"))
+    {
+        RCLCPP_FATAL(
+            rclcpp::get_logger("G1Dex3System"),
+            "the 'side' parameter must be exactly \"left\" or \"right\"; it picks both "
+            "the topic pair and the joint prefix");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    side_ = side_it->second;
+
+    if (info.joints.size() != kNumHandJoints)
+    {
+        RCLCPP_FATAL(
+            rclcpp::get_logger("G1Dex3System"),
+            "expected %zu joints for the %s hand but got %zu",
+            kNumHandJoints,
+            side_.c_str(),
+            info.joints.size());
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    // The wire is a positional array, so the joints must be declared in wire order. Checked
+    // rather than assumed: a reordered URDF would otherwise close the wrong fingers, and that
+    // is exactly the failure Unitree's own mislabelled enum causes.
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        const std::string expected = side_ + "_hand_" + kJointSuffixes[i] + "_joint";
+        if (info.joints[i].name != expected)
+        {
+            RCLCPP_FATAL(
+                rclcpp::get_logger("G1Dex3System"),
+                "joint %zu is '%s' but the Dex3 wire order needs '%s' there",
+                i,
+                info.joints[i].name.c_str(),
+                expected.c_str());
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+        // Clamp to the URDF, which agrees with Unitree's published spec. Their SDK example
+        // disagrees on thumb_1 (0.724 vs 0.611) and its right hand says 0.742, which looks
+        // like a transposed digit. The conservative pair is the right one to trust.
+        const auto& limits = info.joints[i].parameters;
+        lower_limit_[i]    = limits.count("min") ? std::stod(limits.at("min")) : -3.15;
+        upper_limit_[i]    = limits.count("max") ? std::stod(limits.at("max")) : 3.15;
+    }
+
+    kp_                   = paramOr(info, "kp", 1.5);
+    kd_                   = paramOr(info, "kd", 0.2);
+    command_publish_rate_ = paramOr(info, "command_publish_rate", 100.0);
+    max_joint_velocity_   = paramOr(info, "max_joint_velocity_rad_s", 3.0);
+    state_timeout_s_      = paramOr(info, "state_timeout_ms", 200.0) / 1000.0;
+
+    if (command_publish_rate_ <= 0.0 || max_joint_velocity_ <= 0.0 || state_timeout_s_ <= 0.0)
+    {
+        RCLCPP_FATAL(
+            rclcpp::get_logger("G1Dex3System"),
+            "command_publish_rate, max_joint_velocity_rad_s and state_timeout_ms must "
+            "all be strictly positive");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn G1Dex3System::on_configure(const rclcpp_lifecycle::State&)
+{
+    node_ = std::make_shared<rclcpp::Node>("g1_dex3_" + side_ + "_system");
+
+    // Sensor QoS both ways: this is a device stream, and it is what Unitree's own tooling uses.
+    const auto qos = rclcpp::SensorDataQoS();
+    state_sub_     = node_->create_subscription<unitree_hg::msg::HandState>(
+        "/dex3/" + side_ + "/state",
+        qos,
+        [this](const unitree_hg::msg::HandState::ConstSharedPtr& msg) { handStateCallback(msg); });
+    cmd_pub_raw_ =
+        node_->create_publisher<unitree_hg::msg::HandCmd>("/dex3/" + side_ + "/cmd", qos);
+    cmd_pub_ =
+        std::make_shared<realtime_tools::RealtimePublisher<unitree_hg::msg::HandCmd>>(cmd_pub_raw_);
+
+    // motor_cmd is an UNBOUNDED SEQUENCE, not a fixed array. Publishing it unresized is
+    // accepted by DDS and silently moves nothing, which is a miserable thing to debug.
+    cmd_pub_->msg_.motor_cmd.resize(kNumHandJoints);
+
+    spinning_    = true;
+    spin_thread_ = std::thread([this] {
+        rclcpp::executors::SingleThreadedExecutor executor;
+        executor.add_node(node_);
+        while (rclcpp::ok() && spinning_)
+        {
+            executor.spin_some(std::chrono::milliseconds(10));
+        }
+    });
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+void G1Dex3System::handStateCallback(const unitree_hg::msg::HandState::ConstSharedPtr& msg)
+{
+    if (msg->motor_state.size() < kNumHandJoints)
+    {
+        RCLCPP_WARN_THROTTLE(
+            node_->get_logger(),
+            *node_->get_clock(),
+            2000,
+            "HandState carried %zu motors, need %zu -- ignoring",
+            msg->motor_state.size(),
+            kNumHandJoints);
+        return;
+    }
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        rx_position_[i] = msg->motor_state[i].q;
+        rx_velocity_[i] = msg->motor_state[i].dq;
+        rx_effort_[i]   = msg->motor_state[i].tau_est;
+    }
+    last_state_ = std::chrono::steady_clock::now();
+    rx_valid_   = true;
+}
+
+hardware_interface::CallbackReturn G1Dex3System::on_activate(const rclcpp_lifecycle::State&)
+{
+    // Refuse to drive fingers we cannot see. Same gate the arm bridge applies, and for the same
+    // reason: seeding from measured is what makes the first command a no-op instead of a jump.
+    if (!rx_valid_ ||
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - last_state_).count() >
+            state_timeout_s_)
+    {
+        RCLCPP_ERROR(
+            node_->get_logger(),
+            "no fresh HandState on /dex3/%s/state -- refusing to activate",
+            side_.c_str());
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        position_state_[i]   = rx_position_[i];
+        position_command_[i] = rx_position_[i];
+        ramped_command_[i]   = rx_position_[i];
+    }
+    seeded_       = true;
+    last_publish_ = std::chrono::steady_clock::now();
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn G1Dex3System::on_deactivate(const rclcpp_lifecycle::State&)
+{
+    // Release: Lock status with zero gains, and timeout armed so the motor stops on its own if
+    // anything downstream keeps the last frame alive.
+    publish(false);
+    seeded_ = false;
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> G1Dex3System::export_state_interfaces()
+{
+    std::vector<hardware_interface::StateInterface> interfaces;
+    interfaces.reserve(kNumHandJoints * 3);
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        interfaces.emplace_back(
+            info_.joints[i].name,
+            hardware_interface::HW_IF_POSITION,
+            &position_state_[i]);
+        interfaces.emplace_back(
+            info_.joints[i].name,
+            hardware_interface::HW_IF_VELOCITY,
+            &velocity_state_[i]);
+        interfaces.emplace_back(
+            info_.joints[i].name,
+            hardware_interface::HW_IF_EFFORT,
+            &effort_state_[i]);
+    }
+    return interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> G1Dex3System::export_command_interfaces()
+{
+    std::vector<hardware_interface::CommandInterface> interfaces;
+    interfaces.reserve(kNumHandJoints);
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        interfaces.emplace_back(
+            info_.joints[i].name,
+            hardware_interface::HW_IF_POSITION,
+            &position_command_[i]);
+    }
+    return interfaces;
+}
+
+hardware_interface::return_type G1Dex3System::read(const rclcpp::Time&, const rclcpp::Duration&)
+{
+    if (rx_valid_)
+    {
+        for (std::size_t i = 0; i < kNumHandJoints; ++i)
+        {
+            position_state_[i] = rx_position_[i];
+            velocity_state_[i] = rx_velocity_[i];
+            effort_state_[i]   = rx_effort_[i];
+        }
+    }
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type
+G1Dex3System::write(const rclcpp::Time&, const rclcpp::Duration& period)
+{
+    if (!seeded_)
+    {
+        return hardware_interface::return_type::OK;
+    }
+
+    // Slew toward the commanded position. There is no blend weight on this interface: the very
+    // first publish takes full authority, so this ramp is the only thing between a large
+    // trajectory step and a finger moving as fast as the motor can manage.
+    const double step = max_joint_velocity_ * period.seconds();
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        const double target = std::clamp(position_command_[i], lower_limit_[i], upper_limit_[i]);
+        ramped_command_[i] += std::clamp(target - ramped_command_[i], -step, step);
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (std::chrono::duration<double>(now - last_publish_).count() < 1.0 / command_publish_rate_)
+    {
+        return hardware_interface::return_type::OK;
+    }
+    last_publish_ = now;
+    publish(true);
+    return hardware_interface::return_type::OK;
+}
+
+void G1Dex3System::publish(bool driven)
+{
+    if (!cmd_pub_ || !cmd_pub_->trylock())
+    {
+        return;
+    }
+    auto& msg = cmd_pub_->msg_;
+    msg.motor_cmd.resize(kNumHandJoints);
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        auto& motor = msg.motor_cmd[i];
+        // timeout armed on release only: while driving, the controller is the heartbeat, and
+        // arming it would stop the fingers a second after any hiccup in the control loop.
+        motor.mode = packMode(i, driven ? kStatusFoc : kStatusLock, !driven);
+        motor.q    = static_cast<float>(driven ? ramped_command_[i] : position_state_[i]);
+        motor.dq   = 0.0F;
+        motor.tau  = 0.0F;  // feedforward; Unitree's own examples leave it at zero
+        motor.kp   = static_cast<float>(driven ? kp_ : 0.0);
+        motor.kd   = static_cast<float>(driven ? kd_ : 0.0);
+    }
+    cmd_pub_->unlockAndPublish();
+}
+
+}  // namespace g1_hand_interface
+
+PLUGINLIB_EXPORT_CLASS(g1_hand_interface::G1Dex3System, hardware_interface::SystemInterface)

--- a/workspace/src/g1_hand_interface/test/test_wire_contract.cpp
+++ b/workspace/src/g1_hand_interface/test/test_wire_contract.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file test_wire_contract.cpp
+ * @brief The two things about the Dex3 wire format that are easy to get wrong and expensive
+ * to discover on hardware: the packed mode byte and the joint order.
+ */
+
+#include <gmock/gmock.h>
+
+#include <pluginlib/class_loader.hpp>
+
+#include "g1_hand_interface/g1_dex3_system.hpp"
+#include "hardware_interface/system_interface.hpp"
+
+using g1_hand_interface::kJointSuffixes;
+using g1_hand_interface::kNumHandJoints;
+using g1_hand_interface::kStatusFoc;
+using g1_hand_interface::kStatusLock;
+using g1_hand_interface::packMode;
+
+TEST(Dex3WireContract, ModePacksIdStatusAndTimeoutIntoTheirOwnFields)
+{
+    // id in bits 0-3, status in 4-6, timeout in 7. Getting the shift wrong produces a byte
+    // the motor still accepts, so nothing complains and the wrong finger moves.
+    EXPECT_EQ(packMode(0, kStatusLock, false), 0x00);
+    EXPECT_EQ(packMode(3, kStatusFoc, false), 0x13);
+    EXPECT_EQ(packMode(6, kStatusFoc, true), 0x96);
+    EXPECT_EQ(packMode(6, kStatusLock, true), 0x86);
+}
+
+TEST(Dex3WireContract, EveryMotorCarriesItsOwnIndex)
+{
+    // id 15 is the broadcast address, so an index that overflowed the nibble would command
+    // all seven motors at once with one finger's target.
+    for (std::size_t i = 0; i < kNumHandJoints; ++i)
+    {
+        EXPECT_EQ(packMode(i, kStatusFoc, false) & 0x0F, i);
+    }
+}
+
+TEST(Dex3WireContract, JointOrderIsThumbThenMiddleThenIndex)
+{
+    // Unitree's own Dex3_1_Right_JointIndex enum lists index before middle, contradicting
+    // their documented order. It is inert in their code and a hand that closes the wrong
+    // fingers here, so it is pinned rather than trusted.
+    EXPECT_THAT(
+        kJointSuffixes,
+        ::testing::ElementsAre(
+            ::testing::StrEq("thumb_0"),
+            ::testing::StrEq("thumb_1"),
+            ::testing::StrEq("thumb_2"),
+            ::testing::StrEq("middle_0"),
+            ::testing::StrEq("middle_1"),
+            ::testing::StrEq("index_0"),
+            ::testing::StrEq("index_1")));
+}
+
+/**
+ * @brief Confirms g1_hand_interface/G1Dex3System is discoverable through pluginlib's
+ * ament-index lookup, the same path controller_manager uses, rather than merely compiling.
+ */
+TEST(G1Dex3SystemPluginlib, DiscoversAndInstantiates)
+{
+    pluginlib::ClassLoader<hardware_interface::SystemInterface> loader(
+        "hardware_interface",
+        "hardware_interface::SystemInterface");
+
+    ASSERT_TRUE(loader.isClassAvailable("g1_hand_interface/G1Dex3System"));
+
+    auto instance = loader.createUniqueInstance("g1_hand_interface/G1Dex3System");
+    ASSERT_NE(instance, nullptr);
+}

--- a/workspace/src/g1_hardware_interface/README.md
+++ b/workspace/src/g1_hardware_interface/README.md
@@ -81,6 +81,28 @@ The CRC is vendored to match Unitree's implementation bit for bit, pinned by a `
 the message size. It computes exactly what the robot validates against, so it is not a place to
 tidy up.
 
+## Known gap: the waist is not commanded
+
+`assembleLowCmd` writes the 14 arm motors and the weight slot, and nothing else. Motors 12-14,
+the waist, go out as the zero-initialised message: `q=0`, **`kp=0`, `kd=0`**.
+
+On hardware that is very likely a defect. `rt/arm_sdk` is documented as owning the arms *and*
+the waist -- Unitree's own `g1_arm5`/`arm7` examples put motors 12-14 in the commanded set with
+real gains, and so do g1pilot and Amazon FAR's holosoma. If the blend weight applies across
+12-28, then at `weight = 1` our limp zero-gain waist command displaces whatever the onboard
+controller was holding. Four users on real G1s report the robot "bending forward at the waist"
+when arms move under `arm_sdk` (unitree_sdk2_python issues #146 and #173), and #173 found that
+adding a small waist-pitch command fixed it.
+
+**Simulation cannot show this.** There the walking policy owns motors 0-14 and holds the waist
+every tick, so the slots we leave empty are never the ones that matter. A green sim proves
+nothing about this particular failure.
+
+Deliberately not fixed yet: it changes which joints this component asserts authority over, so
+it wants its own change with the sim-side blend updated to match (otherwise the simulator
+ignores a command hardware honours, and the two diverge the other way). **Fix it before any
+hardware bring-up.** Full reasoning and sources in `docs/notes/arm-motion-and-balance.md`.
+
 ## Threading
 
 | Thread | Does |

--- a/workspace/src/g1_motion_service_sim/README.md
+++ b/workspace/src/g1_motion_service_sim/README.md
@@ -49,7 +49,7 @@ at all.
 | `/sportmodestate` | in | `unitree_go/msg/SportModeState` |
 | `/api/sport/request` | in | `unitree_api/msg/Request` |
 | `/api/sport/response` | out | `unitree_api/msg/Response` |
-| `/joint_states` | out | `sensor_msgs/msg/JointState`, legs, waist and hands |
+| `/joint_states` | out | `sensor_msgs/msg/JointState`, legs and waist |
 
 Reliability and durability on `/api/sport/*` are matched to the vendor's. Do not deviate.
 

--- a/workspace/src/g1_motion_service_sim/README.md
+++ b/workspace/src/g1_motion_service_sim/README.md
@@ -127,6 +127,7 @@ that makes it a teleop-grade locomotion source, not a planner-grade one. `g1_loc
 | `arm_hold_kp` / `arm_hold_kd` | `40.0` / `1.0` | Arm gains at blend weight 0. |
 | `arm_sdk_timeout_ms` | `500.0` | `/arm_sdk` age beyond this counts as stale. |
 | `timeout_ramp_down_s` | `1.0` | Weight decay and resume rate. |
+| `waist_hold_rad` | `[]` | Yaw, roll, pitch to hold the waist at instead of the captured pose. Empty holds what was captured. Ignored while a live walking policy owns the waist. |
 
 `config/walk_policy.yaml` holds the policy's joint names, default posture, action scales, per-joint
 gains and limits. The file is commented; read it directly.

--- a/workspace/src/g1_motion_service_sim/README.md
+++ b/workspace/src/g1_motion_service_sim/README.md
@@ -49,7 +49,7 @@ at all.
 | `/sportmodestate` | in | `unitree_go/msg/SportModeState` |
 | `/api/sport/request` | in | `unitree_api/msg/Request` |
 | `/api/sport/response` | out | `unitree_api/msg/Response` |
-| `/joint_states` | out | `sensor_msgs/msg/JointState`, lower body only |
+| `/joint_states` | out | `sensor_msgs/msg/JointState`, legs, waist and hands |
 
 Reliability and durability on `/api/sport/*` are matched to the vendor's. Do not deviate.
 
@@ -132,7 +132,7 @@ that makes it a teleop-grade locomotion source, not a planner-grade one. `g1_loc
 gains and limits. The file is commented; read it directly.
 
 `sim.launch.py` supplies two more, because both are launch decisions rather than tuning:
-`publish_lower_joint_states` and `walk_policy.enabled`.
+`publish_non_arm_joint_states` and `walk_policy.enabled`.
 
 ## Tests
 

--- a/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
+++ b/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
@@ -40,21 +40,13 @@
     # Where the arms are held when nothing is driving them, motors 15 to 28: left shoulder
     # pitch/roll/yaw, elbow, wrist roll/pitch/yaw, then the right arm.
     #
-    # These are g1_moveit_config's `home` group state, and g1_moveit_config's drift test pins
-    # the two together. That is deliberate rather than convenient: `home` documents itself as
-    # the posture the simulator holds the arms at, so setting it here is what makes that true.
+    # g1_moveit_config's `home` group state, pinned to it by that package's drift test, so the
+    # pose MoveIt calls home is the one the simulator actually rests at.
     #
-    # Holding at the walking policy's own arm defaults instead was tried, on the theory that
-    # mask_arm_observations already tells the policy the arms are there. It made no measurable
-    # difference to standing or walking, and it has not been collision-checked, so the pose that
-    # has been wins.
-    #
-    # SIM-ONLY, and it removes a simulator artifact rather than adding one. Without it the hold
-    # target is the first /lowstate sample, by which point the arms have been swinging freely
-    # under gravity since the simulator started, so the resting posture depended on startup
-    # timing and on how heavy the hands were. With real Dex3 hands they fell far enough to put
-    # the palm against the thigh. The real robot's onboard controller holds the arms; none of
-    # this code runs there. docs/notes/hand-mass-rest-pose.md has the measurements.
+    # SIM-ONLY, and it removes an artifact rather than adding one: without it the hold target is
+    # the first /lowstate sample, by which point the arms have been falling freely since the
+    # simulator started. The real robot's onboard controller holds the arms and none of this
+    # code runs there. Measurements in docs/notes/hand-mass-rest-pose.md.
     arm_hold_rad: [-0.70,  0.15, 0.0, 1.50, 0.0, 0.0, 0.0,
                    -0.70, -0.15, 0.0, 1.50, 0.0, 0.0, 0.0]
 

--- a/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
+++ b/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
@@ -37,6 +37,27 @@
     # drag the arms back to the spawn pose. Below it the target freezes and actually holds.
     arm_hold_tracking_weight: 0.05
 
+    # Where the arms are held when nothing is driving them, motors 15 to 28: left shoulder
+    # pitch/roll/yaw, elbow, wrist roll/pitch/yaw, then the right arm.
+    #
+    # These are g1_moveit_config's `home` group state, and g1_moveit_config's drift test pins
+    # the two together. That is deliberate rather than convenient: `home` documents itself as
+    # the posture the simulator holds the arms at, so setting it here is what makes that true.
+    #
+    # Holding at the walking policy's own arm defaults instead was tried, on the theory that
+    # mask_arm_observations already tells the policy the arms are there. It made no measurable
+    # difference to standing or walking, and it has not been collision-checked, so the pose that
+    # has been wins.
+    #
+    # SIM-ONLY, and it removes a simulator artifact rather than adding one. Without it the hold
+    # target is the first /lowstate sample, by which point the arms have been swinging freely
+    # under gravity since the simulator started, so the resting posture depended on startup
+    # timing and on how heavy the hands were. With real Dex3 hands they fell far enough to put
+    # the palm against the thigh. The real robot's onboard controller holds the arms; none of
+    # this code runs there. docs/notes/hand-mass-rest-pose.md has the measurements.
+    arm_hold_rad: [-0.70,  0.15, 0.0, 1.50, 0.0, 0.0, 0.0,
+                   -0.70, -0.15, 0.0, 1.50, 0.0, 0.0, 0.0]
+
     # Hide the arms from the walking policy: it sees the default arm posture and a zero arm
     # last-action instead of what /arm_sdk is actually doing. This is a SIM-FIDELITY fix, not a
     # crutch -- the real onboard controller is not this policy and does not have its

--- a/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
+++ b/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
@@ -25,8 +25,25 @@
     # Matches this repo's own g1_description/config/arm_sdk_params.yaml
     # shoulder/elbow default (a single scalar pair approximates all 14 arm
     # joints here, which is fine for a static hold pose).
+    # Raised from 40/1.0 once MoveIt started driving the arms while the robot walks. This pair
+    # applies at weight 0 only -- the blend hands kp/kd over to whatever /arm_sdk carries as the
+    # weight rises, so this does not fight a running trajectory. A stiffer hold keeps the arms
+    # from swinging with the gait between manipulation moves, and that swing is a moving mass
+    # the walking policy has to reject.
     arm_hold_kp: 40.0
     arm_hold_kd: 1.0
+
+    # Above this blend weight the arm hold target tracks the measured arm, so releasing does not
+    # drag the arms back to the spawn pose. Below it the target freezes and actually holds.
+    arm_hold_tracking_weight: 0.05
+
+    # Hide the arms from the walking policy: it sees the default arm posture and a zero arm
+    # last-action instead of what /arm_sdk is actually doing. This is a SIM-FIDELITY fix, not a
+    # crutch -- the real onboard controller is not this policy and does not have its
+    # out-of-distribution problem, so an unmasked sim fails in a way hardware will not. See the
+    # comment in lowstateCallback() and docs/notes/arm-motion-and-balance.md.
+    # false reproduces the old behaviour, which is only useful for demonstrating the failure.
+    mask_arm_observations: true
 
     # arm_sdk staleness policy -- BRIDGE policy, not vendor semantics (see
     # README): /arm_sdk older than this is "stale", and the effective blend

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
@@ -92,13 +92,11 @@ private:
     rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr lowstate_sub_;
     rclcpp::Subscription<unitree_hg::msg::LowCmd>::SharedPtr   arm_sdk_sub_;
     rclcpp::Publisher<unitree_hg::msg::LowCmd>::SharedPtr      lowcmd_pub_;
-    /// Every joint joint_state_broadcaster does not own: legs, waist and hands. The
-    /// hardware interface is arm-only, so without these robot_state_publisher cannot
-    /// connect pelvis to torso_link and every frame above the waist, sensors included,
-    /// is stranded in its own TF tree.
+    /// The legs and waist, which the onboard controller owns and no hardware interface of
+    /// ours reads. Without them robot_state_publisher cannot connect pelvis to torso_link,
+    /// and every frame above the waist, sensors included, is stranded in its own TF tree.
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr non_arm_joint_pub_;
-    /// Names filled once; only the numbers change per sample, and the hand entries
-    /// not even then.
+    /// Names filled once; only the numbers change per sample.
     sensor_msgs::msg::JointState non_arm_joint_msg_;
     /// /lowstate arrives at ~1 kHz. Publishing joint states that fast is pure
     /// waste next to joint_state_broadcaster's ~200 Hz, and it measurably

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "g1_motion_service_sim/blend_math.hpp"
 #include "g1_motion_service_sim/loco_fsm.hpp"
@@ -84,6 +85,9 @@ private:
     double arm_hold_kd_{};
     double arm_sdk_timeout_s_{};
     double timeout_ramp_down_s_{};
+    /// Waist targets that replace the captured ones, or empty to hold whatever was captured.
+    /// Only meaningful while the legs are stiff-holding; a live walking policy owns the waist.
+    std::vector<double> waist_hold_rad_;
 
     rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr lowstate_sub_;
     rclcpp::Subscription<unitree_hg::msg::LowCmd>::SharedPtr   arm_sdk_sub_;

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
@@ -89,6 +89,18 @@ private:
     /// Only meaningful while the legs are stiff-holding; a live walking policy owns the waist.
     std::vector<double> waist_hold_rad_;
 
+    /// Arm targets that replace the captured ones, or empty to hold whatever was captured.
+    ///
+    /// Not optional in practice. The capture takes the first /lowstate sample, and by then the
+    /// arms have been swinging under gravity with nothing driving them since the simulator
+    /// started, so "captured" means "wherever they happened to fall". That was survivable while
+    /// the model's hands were massless stubs; with real 0.7 kg Dex3 hands they fall further and
+    /// the palm ends up against the thigh, which is a self-collision MoveIt refuses to plan out
+    /// of. Nothing here runs on the robot -- the onboard controller holds the arms there -- so
+    /// this is a simulator artifact being removed, not hardware behaviour being papered over.
+    /// See docs/notes/hand-mass-rest-pose.md.
+    std::vector<double> arm_hold_rad_;
+
     rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr lowstate_sub_;
     rclcpp::Subscription<unitree_hg::msg::LowCmd>::SharedPtr   arm_sdk_sub_;
     rclcpp::Publisher<unitree_hg::msg::LowCmd>::SharedPtr      lowcmd_pub_;

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
@@ -119,14 +119,29 @@ private:
     /// own boot state (see loco_fsm.hpp's legality table for why SET_VELOCITY is illegal here).
     int loco_fsm_state_{ kFsmDamp };
 
-    /// Set once, from the first /lowstate sample, and never touched again --
-    /// the frozen reference every subsequent tick holds legs/waist against
-    /// and blends arms toward at weight 0. All callbacks and the publish
-    /// timer run on the same single-threaded executor (this node's main()
-    /// does a plain rclcpp::spin), so there is no cross-thread contention to
-    /// guard here beyond this one publish-once latch.
+    /// Set once, from the first /lowstate sample -- the frozen reference every
+    /// subsequent tick holds legs/waist against. The ARM slots are the one
+    /// exception: they follow the measured arm while /arm_sdk owns the arms,
+    /// so releasing blends toward where the arms actually are (see
+    /// arm_hold_tracking_weight_). All callbacks and the publish timer run on
+    /// the same single-threaded executor (this node's main() does a plain
+    /// rclcpp::spin), so there is no cross-thread contention to guard here.
     bool                               hold_pose_captured_{ false };
     std::array<double, kNumBodyMotors> hold_q_{};
+
+    /// Above this effective weight the arm hold target tracks the measured arm;
+    /// at or below it the target freezes and becomes a real restoring
+    /// reference. Tracking on the wrong side of this would make the hold
+    /// command chase the measurement, leaving zero position error and letting
+    /// the arms sag under gravity on damping alone.
+    double arm_hold_tracking_weight_{ 0.05 };
+
+    /// Show the walking policy the default arm posture instead of the real one,
+    /// and zero the arm half of last_action. /arm_sdk owns those joints here, so
+    /// the policy's arm actions are discarded anyway; what it sees otherwise is
+    /// an input it never trained on. False restores the raw observation, which
+    /// is only useful for reproducing the instability on purpose.
+    bool mask_arm_observations_{ true };
 
     /// Latest /arm_sdk command (arm slots + the weight slot) and its arrival
     /// time.

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/motion_service_sim_node.hpp
@@ -88,18 +88,19 @@ private:
     rclcpp::Subscription<unitree_hg::msg::LowState>::SharedPtr lowstate_sub_;
     rclcpp::Subscription<unitree_hg::msg::LowCmd>::SharedPtr   arm_sdk_sub_;
     rclcpp::Publisher<unitree_hg::msg::LowCmd>::SharedPtr      lowcmd_pub_;
-    /// Lower-body joint states. joint_state_broadcaster only publishes the arms,
-    /// because the hardware interface is arm-only; without these
-    /// robot_state_publisher cannot connect pelvis to torso_link and every frame
-    /// above the waist, sensors included, is stranded in its own TF tree.
-    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr lower_joint_pub_;
-    /// Names filled once; only the numbers change per sample.
-    sensor_msgs::msg::JointState lower_joint_msg_;
+    /// Every joint joint_state_broadcaster does not own: legs, waist and hands. The
+    /// hardware interface is arm-only, so without these robot_state_publisher cannot
+    /// connect pelvis to torso_link and every frame above the waist, sensors included,
+    /// is stranded in its own TF tree.
+    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr non_arm_joint_pub_;
+    /// Names filled once; only the numbers change per sample, and the hand entries
+    /// not even then.
+    sensor_msgs::msg::JointState non_arm_joint_msg_;
     /// /lowstate arrives at ~1 kHz. Publishing joint states that fast is pure
     /// waste next to joint_state_broadcaster's ~200 Hz, and it measurably
     /// disturbed bring-up, so it is decimated.
-    int                          lower_joint_decimate_ = 0;
-    bool                         publish_lower_joints_ = false;
+    int                          non_arm_joint_decimate_ = 0;
+    bool                         publish_non_arm_joints_ = false;
     rclcpp::TimerBase::SharedPtr publish_timer_;
 
     /// Base linear velocity for the policy observation. /lowstate carries no such field -- the

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -7,6 +7,7 @@
 
 #include "g1_motion_service_sim/motion_service_sim_node.hpp"
 
+#include <array>
 #include <cmath>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -30,6 +31,19 @@ constexpr std::int64_t kApiIdSetArmTask  = 7106;
 
 /// UT_ROBOT_TASK_UNKNOWN_ERROR -- matches g1_locomotion::kCodeTaskUnknownError.
 constexpr std::int32_t kCodeTaskUnknownError = -2;
+
+/// The hand's finger joints. They exist in the URDF but not in the 29-motor model
+/// unitree_mujoco runs, so nothing actuates or measures them; zero is where they sit.
+/// Published anyway because a consumer that reads the URDF expects them: MoveIt's
+/// CurrentStateMonitor waits for every active joint before it will plan, and an SRDF
+/// passive_joint declaration does not exempt one from that count.
+constexpr std::array<const char*, 14> kHandJointNames = {
+    "left_hand_thumb_0_joint",  "left_hand_thumb_1_joint",   "left_hand_thumb_2_joint",
+    "left_hand_middle_0_joint", "left_hand_middle_1_joint",  "left_hand_index_0_joint",
+    "left_hand_index_1_joint",  "right_hand_thumb_0_joint",  "right_hand_thumb_1_joint",
+    "right_hand_thumb_2_joint", "right_hand_middle_0_joint", "right_hand_middle_1_joint",
+    "right_hand_index_0_joint", "right_hand_index_1_joint",
+};
 
 /// Parses `{"data": <int>}` -- the shape both 7101's request parameter and 7001's response data
 /// share. Malformed JSON or a non-integer `data` field are both reported as nullopt, never as an
@@ -133,19 +147,25 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
     // Off unless asked for. This work lands on the ~1 kHz /lowstate callback, which is the
     // walking policy's own path, so only the sensor track pays for it. sim.launch.py turns
     // it on together with sensors, because that is what needs pelvis -> torso_link.
-    publish_lower_joints_ = declare_parameter<bool>("publish_lower_joint_states", false);
+    publish_non_arm_joints_ = declare_parameter<bool>("publish_non_arm_joint_states", false);
 
     // Latest-only: robot_state_publisher merges by joint name, so this coexists with
     // joint_state_broadcaster's arm-only publication rather than competing with it.
-    lower_joint_pub_ = create_publisher<sensor_msgs::msg::JointState>(
+    non_arm_joint_pub_ = create_publisher<sensor_msgs::msg::JointState>(
         "/joint_states",
         rclcpp::QoS(rclcpp::KeepLast(1)));
-    lower_joint_msg_.name.reserve(kNumLowerMotors);
-    lower_joint_msg_.position.resize(kNumLowerMotors);
-    lower_joint_msg_.velocity.resize(kNumLowerMotors);
+    const std::size_t non_arm_count = kNumLowerMotors + kHandJointNames.size();
+    non_arm_joint_msg_.name.reserve(non_arm_count);
+    // Hand entries are left at zero here and never written again.
+    non_arm_joint_msg_.position.resize(non_arm_count);
+    non_arm_joint_msg_.velocity.resize(non_arm_count);
     for (int i = 0; i < kNumLowerMotors; ++i)
     {
-        lower_joint_msg_.name.emplace_back(kDdsMotorOrder[i]);
+        non_arm_joint_msg_.name.emplace_back(kDdsMotorOrder[i]);
+    }
+    for (const auto* hand_joint : kHandJointNames)
+    {
+        non_arm_joint_msg_.name.emplace_back(hand_joint);
     }
 
     lowstate_sub_ = create_subscription<unitree_hg::msg::LowState>(
@@ -324,17 +344,18 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
 {
     // Legs and waist, which nothing else publishes. Motor index equals kDdsMotorOrder
     // index, asserted by test_walk_policy's joint-order check. Decimated to ~100 Hz:
-    // /lowstate is ~1 kHz and robot_state_publisher has no use for that.
-    if (publish_lower_joints_ && ++lower_joint_decimate_ >= 10)
+    // /lowstate is ~1 kHz and robot_state_publisher has no use for that. The hand
+    // entries past kNumLowerMotors have no motor to read and stay at their initial zero.
+    if (publish_non_arm_joints_ && ++non_arm_joint_decimate_ >= 10)
     {
-        lower_joint_decimate_         = 0;
-        lower_joint_msg_.header.stamp = now();
+        non_arm_joint_decimate_         = 0;
+        non_arm_joint_msg_.header.stamp = now();
         for (int i = 0; i < kNumLowerMotors; ++i)
         {
-            lower_joint_msg_.position[i] = msg->motor_state[i].q;
-            lower_joint_msg_.velocity[i] = msg->motor_state[i].dq;
+            non_arm_joint_msg_.position[i] = msg->motor_state[i].q;
+            non_arm_joint_msg_.velocity[i] = msg->motor_state[i].dq;
         }
-        lower_joint_pub_->publish(lower_joint_msg_);
+        non_arm_joint_pub_->publish(non_arm_joint_msg_);
     }
 
     // Refreshed every sample, unlike hold_q_ below: the policy observes live joint state.

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -123,6 +123,8 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
     waist_kd_                       = declare_parameter("waist_kd", 1.0);
     arm_hold_kp_                    = declare_parameter("arm_hold_kp", 40.0);
     arm_hold_kd_                    = declare_parameter("arm_hold_kd", 1.0);
+    mask_arm_observations_          = declare_parameter("mask_arm_observations", true);
+    arm_hold_tracking_weight_       = declare_parameter("arm_hold_tracking_weight", 0.05);
     const double arm_sdk_timeout_ms = declare_parameter("arm_sdk_timeout_ms", 500.0);
     arm_sdk_timeout_s_              = arm_sdk_timeout_ms / 1000.0;
     timeout_ramp_down_s_            = declare_parameter("timeout_ramp_down_s", 1.0);
@@ -381,6 +383,50 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
         walk_inputs_.joint_pos[i] = msg->motor_state[i].q;
         walk_inputs_.joint_vel[i] = msg->motor_state[i].dq;
     }
+
+    // The arms are hidden from the policy, and this is the single change that makes this
+    // simulator behave like the real robot rather than worse than it.
+    //
+    // The policy owns all 29 joints on paper, but /arm_sdk owns 15-28 here, so its arm actions
+    // are thrown away (walk_policy.yaml). It still SEES those joints: 42 of the 99 observation
+    // dimensions are arm position, arm velocity and arm last-action. During training the arms
+    // only ever sat within the policy's own action distribution around the default posture --
+    // about one action-scale unit, and the arm scales are 0.438577, which is exactly the
+    // plus/minus 0.4 rad envelope M3 measured as stable. A MoveIt goal of "arms straight ahead"
+    // is roughly four units out, so the policy is extrapolating on a third of its input.
+    //
+    // The real G1 has no equivalent failure: its onboard controller is not this policy, and per
+    // CMU's G1 notes it "is not aware of how the arms are being controlled" -- it rejects arm
+    // motion reactively, through the IMU, as an unmodelled disturbance. Showing our policy the
+    // default posture reproduces exactly that: the physical disturbance still reaches it through
+    // the base state, but the out-of-distribution input that hardware never suffers does not.
+    // So this makes sim MORE faithful, not less -- today sim fails in a way hardware will not.
+    //
+    // Same approach HuggingFace ship in LeRobot's production G1 integration
+    // (robots/unitree_g1/holosoma_locomotion.py) against a near-identical 100-obs/29-action
+    // policy, for the same reason: "prevents policy from reacting to teleop arm movements".
+    if (mask_arm_observations_)
+    {
+        for (std::size_t i = 0; i < kNumArmMotors; ++i)
+        {
+            const std::size_t motor       = static_cast<std::size_t>(kFirstArmMotor) + i;
+            walk_inputs_.joint_pos[motor] = walk_policy_config_.default_joint_pos[motor];
+            walk_inputs_.joint_vel[motor] = 0.0;
+        }
+    }
+
+    // While /arm_sdk owns the arms, the hold target follows them, so a release blends toward
+    // where the arms actually are instead of dragging them back to the spawn pose. Below the
+    // threshold it freezes: a target that keeps chasing the measurement has no position error
+    // to hold against, and the arms would sag on damping alone.
+    if (hold_pose_captured_ && effective_weight_ > arm_hold_tracking_weight_)
+    {
+        for (std::size_t i = 0; i < kNumArmMotors; ++i)
+        {
+            const std::size_t motor = static_cast<std::size_t>(kFirstArmMotor) + i;
+            hold_q_[motor]          = msg->motor_state[motor].q;
+        }
+    }
     for (std::size_t i = 0; i < 4; ++i)
     {
         walk_inputs_.base_quat[i] = msg->imu_state.quaternion[i];
@@ -444,7 +490,21 @@ void MotionServiceSim::walkPolicyTick()
             "untouched so the stiff-hold fallback engages if it keeps failing");
         return;
     }
-    walk_last_action_  = *action;
+    walk_last_action_ = *action;
+    if (mask_arm_observations_)
+    {
+        // The other half of hiding the arms, and the half that is easy to miss. last_action is
+        // fed straight back into the next observation, but only the lower 15 actions are ever
+        // executed -- the arm actions are discarded and /arm_sdk drives those joints instead.
+        // Left alone, the policy reads back arm commands that never happened, next to arm
+        // positions produced by something else entirely, so the action-to-state relationship it
+        // learned is broken on 14 joints every tick. Zero is the action that means "default
+        // posture", which is what the masked position and velocity above already claim.
+        //
+        // FALCON's deployment code slices its feedback to executed joints for the same reason
+        // (sim2real/rl_policy/dec_loco/dec_loco.py), arrived at independently.
+        std::fill(walk_last_action_.begin() + kFirstArmMotor, walk_last_action_.end(), 0.0F);
+    }
     const auto targets = actionToJointTargets(walk_last_action_, walk_policy_config_);
     std::copy(targets.begin(), targets.begin() + kNumLowerMotors, walk_target_q_.begin());
     walk_target_valid_ = true;

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -127,6 +127,23 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
     arm_sdk_timeout_s_              = arm_sdk_timeout_ms / 1000.0;
     timeout_ramp_down_s_            = declare_parameter("timeout_ramp_down_s", 1.0);
 
+    // The waist belongs to the onboard controller, so nothing in this stack can command it and
+    // the sim model always spawns it at zero. Overriding the captured hold target is the only
+    // way to stand the torso anywhere else, which manipulation needs: a waist locked at zero
+    // hides every error in the pelvis-to-torso transform that arm planning depends on.
+    waist_hold_rad_ = declare_parameter("waist_hold_rad", std::vector<double>{});
+    if (!waist_hold_rad_.empty() &&
+        waist_hold_rad_.size() != static_cast<std::size_t>(kFirstArmMotor - kNumLegMotors))
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "waist_hold_rad needs %d values (yaw, roll, pitch) but got %zu -- ignoring it and "
+            "holding the captured waist pose",
+            kFirstArmMotor - kNumLegMotors,
+            waist_hold_rad_.size());
+        waist_hold_rad_.clear();
+    }
+
     // Fail fast on non-positive rate/duration (same gate as G1ArmSdkSystem::on_init).
     if (publish_rate_hz_ <= 0.0 || arm_sdk_timeout_s_ <= 0.0 || timeout_ramp_down_s_ <= 0.0)
     {
@@ -378,6 +395,13 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
         for (int i = 0; i < kNumBodyMotors; ++i)
         {
             hold_q_[static_cast<std::size_t>(i)] = msg->motor_state[static_cast<std::size_t>(i)].q;
+        }
+        // Applied to the captured pose rather than to every command, so the waist ramps to the
+        // target through the same stiff-hold PD as any other hold -- no snap, and /lowstate
+        // still reports whatever the joint actually reached.
+        for (std::size_t i = 0; i < waist_hold_rad_.size(); ++i)
+        {
+            hold_q_[static_cast<std::size_t>(kNumLegMotors) + i] = waist_hold_rad_[i];
         }
         hold_pose_captured_ = true;
     }

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -32,19 +32,6 @@ constexpr std::int64_t kApiIdSetArmTask  = 7106;
 /// UT_ROBOT_TASK_UNKNOWN_ERROR -- matches g1_locomotion::kCodeTaskUnknownError.
 constexpr std::int32_t kCodeTaskUnknownError = -2;
 
-/// The hand's finger joints. They exist in the URDF but not in the 29-motor model
-/// unitree_mujoco runs, so nothing actuates or measures them; zero is where they sit.
-/// Published anyway because a consumer that reads the URDF expects them: MoveIt's
-/// CurrentStateMonitor waits for every active joint before it will plan, and an SRDF
-/// passive_joint declaration does not exempt one from that count.
-constexpr std::array<const char*, 14> kHandJointNames = {
-    "left_hand_thumb_0_joint",  "left_hand_thumb_1_joint",   "left_hand_thumb_2_joint",
-    "left_hand_middle_0_joint", "left_hand_middle_1_joint",  "left_hand_index_0_joint",
-    "left_hand_index_1_joint",  "right_hand_thumb_0_joint",  "right_hand_thumb_1_joint",
-    "right_hand_thumb_2_joint", "right_hand_middle_0_joint", "right_hand_middle_1_joint",
-    "right_hand_index_0_joint", "right_hand_index_1_joint",
-};
-
 /// Parses `{"data": <int>}` -- the shape both 7101's request parameter and 7001's response data
 /// share. Malformed JSON or a non-integer `data` field are both reported as nullopt, never as an
 /// exception escaping to the caller.
@@ -173,18 +160,12 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
     non_arm_joint_pub_ = create_publisher<sensor_msgs::msg::JointState>(
         "/joint_states",
         rclcpp::QoS(rclcpp::KeepLast(1)));
-    const std::size_t non_arm_count = kNumLowerMotors + kHandJointNames.size();
-    non_arm_joint_msg_.name.reserve(non_arm_count);
-    // Hand entries are left at zero here and never written again.
-    non_arm_joint_msg_.position.resize(non_arm_count);
-    non_arm_joint_msg_.velocity.resize(non_arm_count);
+    non_arm_joint_msg_.name.reserve(kNumLowerMotors);
+    non_arm_joint_msg_.position.resize(kNumLowerMotors);
+    non_arm_joint_msg_.velocity.resize(kNumLowerMotors);
     for (int i = 0; i < kNumLowerMotors; ++i)
     {
         non_arm_joint_msg_.name.emplace_back(kDdsMotorOrder[i]);
-    }
-    for (const auto* hand_joint : kHandJointNames)
-    {
-        non_arm_joint_msg_.name.emplace_back(hand_joint);
     }
 
     lowstate_sub_ = create_subscription<unitree_hg::msg::LowState>(
@@ -363,8 +344,7 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
 {
     // Legs and waist, which nothing else publishes. Motor index equals kDdsMotorOrder
     // index, asserted by test_walk_policy's joint-order check. Decimated to ~100 Hz:
-    // /lowstate is ~1 kHz and robot_state_publisher has no use for that. The hand
-    // entries past kNumLowerMotors have no motor to read and stay at their initial zero.
+    // /lowstate is ~1 kHz and robot_state_publisher has no use for that.
     if (publish_non_arm_joints_ && ++non_arm_joint_decimate_ >= 10)
     {
         non_arm_joint_decimate_         = 0;

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -133,6 +133,18 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
         waist_hold_rad_.clear();
     }
 
+    arm_hold_rad_ = declare_parameter("arm_hold_rad", std::vector<double>{});
+    if (!arm_hold_rad_.empty() && arm_hold_rad_.size() != kNumArmMotors)
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "arm_hold_rad needs %zu values (left arm then right, motors 15 to 28) but got %zu -- "
+            "ignoring it and holding whatever the arms fell into at startup",
+            kNumArmMotors,
+            arm_hold_rad_.size());
+        arm_hold_rad_.clear();
+    }
+
     // Fail fast on non-positive rate/duration (same gate as G1ArmSdkSystem::on_init).
     if (publish_rate_hz_ <= 0.0 || arm_sdk_timeout_s_ <= 0.0 || timeout_ramp_down_s_ <= 0.0)
     {
@@ -428,6 +440,13 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
         for (std::size_t i = 0; i < waist_hold_rad_.size(); ++i)
         {
             hold_q_[static_cast<std::size_t>(kNumLegMotors) + i] = waist_hold_rad_[i];
+        }
+        // Same treatment, and for a stronger reason: the arms have been falling freely since
+        // the simulator started, so what the capture reads is a startup transient rather than a
+        // posture. See the member's comment.
+        for (std::size_t i = 0; i < arm_hold_rad_.size(); ++i)
+        {
+            hold_q_[static_cast<std::size_t>(kFirstArmMotor) + i] = arm_hold_rad_[i];
         }
         hold_pose_captured_ = true;
     }

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -68,6 +68,13 @@ if(BUILD_TESTING)
     TARGET test_moveit_plan_execute TIMEOUT 400)
   set_tests_properties(test_moveit_plan_execute PROPERTIES RESOURCE_LOCK g1_sim COST 90)
 
+  # Runs the sensor track on the perception scene: the octomap has to fill from the LiDAR
+  # before anything can be asserted. Note SIM_SETTLE_S inside that file cannot be raised to
+  # cover the fill -- launch_testing's own startup timeout fires first.
+  add_launch_test(test/test_octomap_blocks_a_plan.launch.py
+    TARGET test_octomap_blocks_a_plan TIMEOUT 500)
+  set_tests_properties(test_octomap_blocks_a_plan PROPERTIES RESOURCE_LOCK g1_sim COST 95)
+
   # Use workspace-root ruff.toml if available.
   find_program(RUFF_EXECUTABLE ruff)
   set(_ruff_config "${CMAKE_CURRENT_SOURCE_DIR}/../../ruff.toml")

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -4,7 +4,7 @@ project(g1_moveit_config)
 find_package(ament_cmake REQUIRED)
 
 install(
-  DIRECTORY config
+  DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME}
 )
 
@@ -13,6 +13,20 @@ if(BUILD_TESTING)
   # g1_navigation, the other launch-heavy packages.
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+
+  # Use workspace-root ruff.toml if available.
+  find_program(RUFF_EXECUTABLE ruff)
+  set(_ruff_config "${CMAKE_CURRENT_SOURCE_DIR}/../../ruff.toml")
+  if(RUFF_EXECUTABLE AND EXISTS "${_ruff_config}")
+    add_test(
+      NAME ruff_check_g1_moveit_config
+      COMMAND ${RUFF_EXECUTABLE} check --config ${_ruff_config}
+              ${CMAKE_CURRENT_SOURCE_DIR}/launch
+    )
+  else()
+    message(WARNING "ruff and/or workspace ruff.toml not found; skipping ruff_check_g1_moveit_config test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -24,6 +24,36 @@ if(BUILD_TESTING)
         "G1_DESCRIPTION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_description/config"
   )
 
+  # move_group plans against the expanded xacro, not a checked-in URDF, so the model test has
+  # to expand it too -- otherwise it validates a robot nobody runs. Regenerated whenever the
+  # xacro or the gains it loads change.
+  find_package(moveit_core REQUIRED)
+  find_package(urdf REQUIRED)
+  find_package(srdfdom REQUIRED)
+
+  set(_expanded_urdf "${CMAKE_CURRENT_BINARY_DIR}/g1_expanded.urdf")
+  set(_description_dir "${CMAKE_CURRENT_SOURCE_DIR}/../g1_description")
+  add_custom_command(
+    OUTPUT ${_expanded_urdf}
+    COMMAND xacro ${_description_dir}/urdf/g1_arm_sdk.urdf.xacro -o ${_expanded_urdf}
+    DEPENDS ${_description_dir}/urdf/g1_arm_sdk.urdf.xacro
+            ${_description_dir}/urdf/g1_29dof_with_hand_rev_1_0.urdf
+            ${_description_dir}/config/arm_sdk_params.yaml
+    COMMENT "Expanding g1_arm_sdk.urdf.xacro for test_robot_model"
+    VERBATIM
+  )
+  add_custom_target(g1_moveit_config_expanded_urdf ALL DEPENDS ${_expanded_urdf})
+
+  ament_add_gmock(test_robot_model test/test_robot_model.cpp)
+  if(TARGET test_robot_model)
+    add_dependencies(test_robot_model g1_moveit_config_expanded_urdf)
+    target_compile_definitions(test_robot_model PRIVATE
+      G1_TEST_URDF_PATH="${_expanded_urdf}"
+      G1_TEST_SRDF_PATH="${CMAKE_CURRENT_SOURCE_DIR}/config/g1.srdf")
+    ament_target_dependencies(test_robot_model moveit_core urdf srdfdom)
+  endif()
+
+
   # Use workspace-root ruff.toml if available.
   find_program(RUFF_EXECUTABLE ruff)
   set(_ruff_config "${CMAKE_CURRENT_SOURCE_DIR}/../../ruff.toml")

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -14,6 +14,15 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  find_package(ament_cmake_pytest REQUIRED)
+
+  # Reads three packages' config at once: MoveIt's arm, the controller's arm and the bridge's
+  # speed clamp all have to agree, and no single package's tests can see the disagreement.
+  ament_add_pytest_test(test_moveit_config_drift test/test_moveit_config_drift.py
+    ENV "G1_MOVEIT_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/config"
+        "G1_BRINGUP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_bringup/config"
+        "G1_DESCRIPTION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_description/config"
+  )
 
   # Use workspace-root ruff.toml if available.
   find_program(RUFF_EXECUTABLE ruff)
@@ -22,7 +31,7 @@ if(BUILD_TESTING)
     add_test(
       NAME ruff_check_g1_moveit_config
       COMMAND ${RUFF_EXECUTABLE} check --config ${_ruff_config}
-              ${CMAKE_CURRENT_SOURCE_DIR}/launch
+              ${CMAKE_CURRENT_SOURCE_DIR}/launch ${CMAKE_CURRENT_SOURCE_DIR}/test
     )
   else()
     message(WARNING "ruff and/or workspace ruff.toml not found; skipping ruff_check_g1_moveit_config test")

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_moveit_config)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  # Linters that don't conflict with ruff. No pep257, matching g1_bringup, g1_sim and
+  # g1_navigation, the other launch-heavy packages.
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -22,6 +22,7 @@ if(BUILD_TESTING)
     ENV "G1_MOVEIT_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/config"
         "G1_BRINGUP_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_bringup/config"
         "G1_DESCRIPTION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_description/config"
+        "G1_SIM_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_motion_service_sim/config"
   )
 
   # bringup's moveit branch names this package's share, so its threading assertions cannot

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -53,6 +53,12 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_robot_model moveit_core urdf srdfdom)
   endif()
 
+  # Headless sim suite. Shares g1_bringup's RESOURCE_LOCK: two suites on one DDS graph and one
+  # simulator is what makes them flaky.
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/test_moveit_plan_execute.launch.py
+    TARGET test_moveit_plan_execute TIMEOUT 400)
+  set_tests_properties(test_moveit_plan_execute PROPERTIES RESOURCE_LOCK g1_sim COST 90)
 
   # Use workspace-root ruff.toml if available.
   find_program(RUFF_EXECUTABLE ruff)

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -24,6 +24,14 @@ if(BUILD_TESTING)
         "G1_DESCRIPTION_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_description/config"
   )
 
+  # bringup's moveit branch names this package's share, so its threading assertions cannot
+  # live in g1_navigation alongside the navigation ones. Source directories rather than
+  # installed shares, same as above: these read launch files, not built artifacts.
+  ament_add_pytest_test(test_launch_threading test/test_launch_threading.py
+    ENV "G1_MOVEIT_LAUNCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}/launch"
+        "G1_BRINGUP_LAUNCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../g1_bringup/launch"
+  )
+
   # move_group plans against the expanded xacro, not a checked-in URDF, so the model test has
   # to expand it too -- otherwise it validates a robot nobody runs. Regenerated whenever the
   # xacro or the gains it loads change.

--- a/workspace/src/g1_moveit_config/README.md
+++ b/workspace/src/g1_moveit_config/README.md
@@ -121,6 +121,25 @@ Until then the controller refuses the goal, which is the intended failure rather
 `waist_hold_rad:=0.35,0.0,0.0` stands the torso off-square, which is worth doing when changing
 anything about frames.
 
+## Seeing the world
+
+`config/sensors_3d.yaml` feeds `/livox/lidar` into an octomap, so plans route around real
+obstacles rather than only the robot itself. It comes up with `sensors:=true`:
+
+```bash
+ros2 launch g1_moveit_config moveit_sim.launch.py sensors:=true pin_pelvis:=true world:=perception
+```
+
+The octomap is built in the **planning frame**, `pelvis` -- `octomap_frame` exists but is never
+read, because move_group constructs the monitor with the planning frame directly. That is fine
+while the pelvis is pinned or the robot stands still; a walking pelvis drags the voxel grid with
+it and the map smears. `/clear_octomap` (`std_srvs/Empty`) resets it; there is no time decay, so
+a voxel the sensor cannot currently see is never forgotten.
+
+The **LiDAR, not the depth camera**, and not by preference: the camera publishes a depth image,
+and `depth_image_proc`'s converter cannot receive from our best-effort relay. See
+`docs/notes/moveit-depth-octomap-plan.md` for what was tried.
+
 ## Regenerating the collision matrix
 
 `config/g1.srdf` is hand-written except for its `disable_collisions` block. That block is
@@ -150,6 +169,7 @@ a correctness requirement. Getting them needs the collision geometry simplified 
 | `test_moveit_config_drift` | no | This package against `g1_bringup`'s controller and `g1_description`'s speed clamp; the composite-group solver rule; SRDF well-formedness. |
 | `test_robot_model` | no | Group composition and order, planning frame, no hand or waist joints in an arm group, the collision matrix's adjacent pairs and its cross-arm pairs, and the named poses (per-group copies agree, all within joint limits). |
 | `test_launch_threading` | no | The arguments `g1_bringup`'s `moveit:=true` branch threads into the simulator, the RViz choice, and that `moveit_sim.launch.py` still composes what it did. |
+| `test_octomap_blocks_a_plan` | yes | That the octomap fills from the LiDAR **and** that MoveIt collision-checks against it: a reach into a mapped obstacle is rejected, with `<octomap>` named in the contact. |
 | `test_moveit_plan_execute` | yes | Execution refused before acquire, a coordinated `both_arms` plan, planned speed under the clamp, and hand placement with the waist turned. |
 
 ```bash

--- a/workspace/src/g1_moveit_config/README.md
+++ b/workspace/src/g1_moveit_config/README.md
@@ -8,14 +8,17 @@ already drives `rt/arm_sdk`.
 ```mermaid
 flowchart LR
     MG["move_group<br/>plan + collision check"] -- "FollowJointTrajectory" --> JTC["arm_trajectory_controller"]
+    MG -- "FollowJointTrajectory" --> HC["left/right_hand_controller"]
     JTC --> HW["G1ArmSdkSystem"]
+    HC --> HH["G1Dex3System (one per hand)"]
     HW -- "/arm_sdk" --> MS["motion_service_sim<br/>(onboard controller on hardware)"]
+    HH -- "/dex3/side/cmd" --> SIM["unitree_mujoco<br/>(the hand itself on hardware)"]
     MS -- "/lowstate" --> HW
-    JS["/joint_states<br/>arms + legs + waist + hands"] --> MG
+    JS["/joint_states<br/>arms + legs + waist + fingers"] --> MG
 ```
 
-MoveIt adds no command path. It is another client of the action the controller already serves,
-so `rt/arm_sdk` keeps exactly one writer.
+MoveIt adds no command path. It is another client of actions the controllers already serve, so
+`rt/arm_sdk` and each hand's topic keep exactly one writer.
 
 ## Planning groups
 
@@ -24,10 +27,17 @@ so `rt/arm_sdk` keeps exactly one writer.
 | `left_arm` | 7 | `torso_link` to `left_hand_palm_link` |
 | `right_arm` | 7 | `torso_link` to `right_hand_palm_link` |
 | `both_arms` | 14 | the two above, composed |
+| `left_hand` | 7 | the Dex3 fingers, a tree rather than a chain |
+| `right_hand` | 7 | as above |
 
 `both_arms` is what makes two-handed motion a single plan: it is the only group that
 collision-checks one arm against the other, and the only one that times a motion so both hands
 arrive together. The per-arm groups remain because a 7-DoF search is far cheaper.
+
+The hands are separate groups, never joints on an arm group, because they are a separate device
+reached over separate topics with separate authority (`docs/CONTROL_MODES.md`). `test_robot_model`
+pins that: no arm group may contain a finger joint. Each is listed as its arm's `end_effector`,
+which is what lets `attachObject` work out its own touch links.
 
 Groups are rooted at `torso_link`, not `pelvis`. The three waist joints belong to the onboard
 controller, so a group spanning them would plan motion this stack cannot command. Their *state*
@@ -55,6 +65,17 @@ Every value was collision-checked against a running `move_group` before being wr
 SRDF, and `test_robot_model` pins them: the three per-group copies must agree, and all must sit
 inside the joint limits. Poses are a convenience, not a safety mechanism, and MoveIt still plans
 and collision-checks the path to one.
+
+The hands have two postures each, on `left_hand` and `right_hand`:
+
+| Pose | What it is |
+|---|---|
+| `open` | Every finger joint at 0. Fingers straight, thumb mid-range. |
+| `closed` | A power grasp, curled short of the end stops so the fingers can press into an object. |
+
+That is the whole vocabulary a pick and place needs: reach open, close, `attachObject`, move,
+place, open, `detachObject`. Contact physics is not simulated, so in sim the object is held by
+the attachment rather than by friction. On hardware it is held by both.
 
 `tucked` is worth knowing about beyond convenience. Arm pose measurably disturbs a walking
 humanoid, and the standing recommendation is to manipulate stationary and navigate with the arms

--- a/workspace/src/g1_moveit_config/README.md
+++ b/workspace/src/g1_moveit_config/README.md
@@ -1,0 +1,111 @@
+# g1_moveit_config
+
+MoveIt 2 planning for the G1's two 7-DoF arms, layered on the `arm_trajectory_controller` that
+already drives `rt/arm_sdk`.
+
+`ament_cmake`, configuration and launch only. No nodes: `move_group` is upstream.
+
+```mermaid
+flowchart LR
+    MG["move_group<br/>plan + collision check"] -- "FollowJointTrajectory" --> JTC["arm_trajectory_controller"]
+    JTC --> HW["G1ArmSdkSystem"]
+    HW -- "/arm_sdk" --> MS["motion_service_sim<br/>(onboard controller on hardware)"]
+    MS -- "/lowstate" --> HW
+    JS["/joint_states<br/>arms + legs + waist + hands"] --> MG
+```
+
+MoveIt adds no command path. It is another client of the action the controller already serves,
+so `rt/arm_sdk` keeps exactly one writer.
+
+## Planning groups
+
+| Group | Joints | Chain |
+|---|---|---|
+| `left_arm` | 7 | `torso_link` to `left_hand_palm_link` |
+| `right_arm` | 7 | `torso_link` to `right_hand_palm_link` |
+| `both_arms` | 14 | the two above, composed |
+
+`both_arms` is what makes two-handed motion a single plan: it is the only group that
+collision-checks one arm against the other, and the only one that times a motion so both hands
+arrive together. The per-arm groups remain because a 7-DoF search is far cheaper.
+
+Groups are rooted at `torso_link`, not `pelvis`. The three waist joints belong to the onboard
+controller, so a group spanning them would plan motion this stack cannot command. Their *state*
+still matters, since it places the torso under the pelvis, which is why `motion_service_sim`
+publishes it.
+
+The planning frame is `pelvis` — the vendored URDF's floating base is commented out upstream and
+the SRDF declares no virtual joint. Fine while the robot stands still to manipulate; scene
+objects fixed in `odom` would need a virtual joint instead.
+
+## Kinematics
+
+`pick_ik` on each arm. Each arm is 7 joints against a 6-DoF pose, so the solver's choice within
+the null space is the whole question, and KDL's pseudo-inverse wanders it and clamps at joint
+limits. Swapping back is one line in `config/kinematics.yaml`.
+
+`both_arms` deliberately has **no** solver entry. pick_ik, like KDL and TRAC-IK, rejects any
+group that is not a chain; MoveIt instead routes a pose goal per hand through the per-arm
+solvers, and it only builds that subgroup map for groups with no solver of their own. Adding an
+entry for `both_arms` silently breaks its IK. A test asserts this.
+
+For two simultaneous Cartesian goals, call `setPoseTarget(pose, link)` once per hand.
+`setPoseTargets` means something else: alternative goals for one link.
+
+## Speed
+
+`config/joint_limits.yaml` caps every arm joint at 0.8 rad/s against the bridge's 1.0 rad/s slew
+clamp, and adds the acceleration limits the URDF does not declare. The URDF's own 22-37 rad/s are
+motor limits; timing a trajectory against them makes the bridge stretch it by a factor of thirty
+and the controller abort on a goal-time tolerance that looks unrelated. A test compares the two
+files.
+
+## Running
+
+```bash
+ros2 launch g1_moveit_config moveit_sim.launch.py pin_pelvis:=true
+ros2 launch g1_moveit_config moveit_rviz.launch.py
+```
+
+Planning works immediately. **Executing does not**, until the arm is acquired — the component
+first, then the controller:
+
+```bash
+ros2 launch g1_bringup activate_arm.launch.py
+```
+
+Until then the controller refuses the goal, which is the intended failure rather than a bug.
+`moveit_manage_controllers` is false so MoveIt never activates anything itself. Release with
+`deactivate_arm.launch.py` on success or failure alike.
+
+`waist_hold_rad:=0.35,0.0,0.0` stands the torso off-square, which is worth doing when changing
+anything about frames.
+
+## Regenerating the collision matrix
+
+`config/g1.srdf` is hand-written except for its `disable_collisions` block. That block is
+generated, and the header inside the file records the arguments and date. Humble ships a headless
+generator, so this needs no GUI:
+
+```bash
+xacro $(ros2 pkg prefix g1_description)/share/g1_description/urdf/g1_arm_sdk.urdf.xacro > /tmp/g1.urdf
+/opt/ros/humble/lib/moveit_setup_assistant/collisions_updater \
+  --urdf /tmp/g1.urdf --srdf config/g1.srdf --output config/g1.srdf \
+  --default --always --trials 10000 --min-collision-fraction 0.95
+```
+
+Expect it to take roughly half an hour: the G1's collision geometry is its full visual meshes.
+Review the diff before committing, and check that cross-arm pairs from the elbows out are still
+enabled — `both_arms` is pointless without them, and `test_robot_model` asserts it.
+
+## Tests
+
+| Test | Needs a simulator | Covers |
+|---|---|---|
+| `test_moveit_config_drift` | no | This package against `g1_bringup`'s controller and `g1_description`'s speed clamp; the composite-group solver rule; SRDF well-formedness. |
+| `test_robot_model` | no | Group composition and order, planning frame, no hand or waist joints in an arm group, the collision matrix's adjacent pairs and its cross-arm pairs. |
+| `test_moveit_plan_execute` | yes | Execution refused before acquire, a coordinated `both_arms` plan, planned speed under the clamp, and hand placement with the waist turned. |
+
+```bash
+colcon test --packages-select g1_moveit_config
+```

--- a/workspace/src/g1_moveit_config/README.md
+++ b/workspace/src/g1_moveit_config/README.md
@@ -38,6 +38,28 @@ The planning frame is `pelvis` — the vendored URDF's floating base is commente
 the SRDF declares no virtual joint. Fine while the robot stands still to manipulate; scene
 objects fixed in `odom` would need a virtual joint instead.
 
+## Named poses
+
+Set from the MotionPlanning panel's goal-state dropdown, or with
+`move_group.setNamedTarget("tucked")`. Each exists for `left_arm`, `right_arm` and `both_arms`.
+
+| Pose | What it is |
+|---|---|
+| `home` | Where the simulator actually holds the arms: shoulders back, elbows bent. Measured, not chosen. |
+| `zero` | Every arm joint at 0. Arms straight down at the sides. |
+| `tucked` | Arms in close, elbows well bent. The posture to navigate in: smallest swept volume and least COM offset. |
+| `ready` | Forearms up and forward, clear of the torso, without being extended. |
+| `reach_front` | Reaching a surface in front. The pick-and-place working posture. |
+
+Every value was collision-checked against a running `move_group` before being written into the
+SRDF, and `test_robot_model` pins them: the three per-group copies must agree, and all must sit
+inside the joint limits. Poses are a convenience, not a safety mechanism, and MoveIt still plans
+and collision-checks the path to one.
+
+`tucked` is worth knowing about beyond convenience. Arm pose measurably disturbs a walking
+humanoid, and the standing recommendation is to manipulate stationary and navigate with the arms
+in (`docs/notes/arm-motion-and-balance.md`).
+
 ## Kinematics
 
 `pick_ik` on each arm. Each arm is 7 joints against a 6-DoF pose, so the solver's choice within
@@ -80,10 +102,10 @@ joint it models has a state, and the arms hang off three waist joints `joint_sta
 does not own.
 
 With a navigation mode as well (`mode:=localization nav:=true moveit:=true rviz:=true`), the one
-RViz that opens is this package's. Substituting `g1_navigation.rviz` in was measured and does not
-work: the MotionPlanning panel comes from the config's display list, not from node parameters, so
-that combination launches cleanly and simply has no panel. A view carrying both needs its own
-`.rviz` with both display sets on one fixed frame.
+RViz that opens is this package's — run a second `rviz2 -d` on `g1_navigation.rviz` for the map
+and costmaps. A single combined window was attempted and abandoned: every merge segfaulted rviz2
+once Nav2 was actually running. `docs/notes/combined-nav-moveit-rviz.md` has the four runs and
+where to resume.
 
 Planning works immediately. **Executing does not**, until the arm is acquired — the component
 first, then the controller:
@@ -126,7 +148,7 @@ a correctness requirement. Getting them needs the collision geometry simplified 
 | Test | Needs a simulator | Covers |
 |---|---|---|
 | `test_moveit_config_drift` | no | This package against `g1_bringup`'s controller and `g1_description`'s speed clamp; the composite-group solver rule; SRDF well-formedness. |
-| `test_robot_model` | no | Group composition and order, planning frame, no hand or waist joints in an arm group, the collision matrix's adjacent pairs and its cross-arm pairs. |
+| `test_robot_model` | no | Group composition and order, planning frame, no hand or waist joints in an arm group, the collision matrix's adjacent pairs and its cross-arm pairs, and the named poses (per-group copies agree, all within joint limits). |
 | `test_launch_threading` | no | The arguments `g1_bringup`'s `moveit:=true` branch threads into the simulator, the RViz choice, and that `moveit_sim.launch.py` still composes what it did. |
 | `test_moveit_plan_execute` | yes | Execution refused before acquire, a coordinated `both_arms` plan, planned speed under the clamp, and hand placement with the waist turned. |
 

--- a/workspace/src/g1_moveit_config/README.md
+++ b/workspace/src/g1_moveit_config/README.md
@@ -62,10 +62,28 @@ files.
 
 ## Running
 
+One command, from the operator entry point:
+
+```bash
+ros2 launch g1_bringup bringup.launch.py moveit:=true pin_pelvis:=true rviz:=true
+```
+
+Or this package on its own, which is what the integration test launches:
+
 ```bash
 ros2 launch g1_moveit_config moveit_sim.launch.py pin_pelvis:=true
 ros2 launch g1_moveit_config moveit_rviz.launch.py
 ```
+
+Either route turns on the non-arm joint states for you. `move_group` will not plan until every
+joint it models has a state, and the arms hang off three waist joints `joint_state_broadcaster`
+does not own.
+
+With a navigation mode as well (`mode:=localization nav:=true moveit:=true rviz:=true`), the one
+RViz that opens is this package's. Substituting `g1_navigation.rviz` in was measured and does not
+work: the MotionPlanning panel comes from the config's display list, not from node parameters, so
+that combination launches cleanly and simply has no panel. A view carrying both needs its own
+`.rviz` with both display sets on one fixed frame.
 
 Planning works immediately. **Executing does not**, until the arm is acquired — the component
 first, then the controller:
@@ -84,19 +102,24 @@ anything about frames.
 ## Regenerating the collision matrix
 
 `config/g1.srdf` is hand-written except for its `disable_collisions` block. That block is
-generated, and the header inside the file records the arguments and date. Humble ships a headless
-generator, so this needs no GUI:
+generated, and the header inside the file records how and when.
 
-```bash
-xacro $(ros2 pkg prefix g1_description)/share/g1_description/urdf/g1_arm_sdk.urdf.xacro > /tmp/g1.urdf
-/opt/ros/humble/lib/moveit_setup_assistant/collisions_updater \
-  --urdf /tmp/g1.urdf --srdf config/g1.srdf --output config/g1.srdf \
-  --default --always --trials 10000 --min-collision-fraction 0.95
-```
+**`collisions_updater` does not finish on this model.** Measured 2026-08-06: it was left running
+for 1 h 22 m at `--trials 10000` and produced nothing, and 1000 trials, 1 trial and
+`--default --trials 0` all failed to complete either — the expensive phase runs whatever the flags
+say. The cause is the collision geometry: 38 of the URDF's 52 collision elements are the full
+visual STL meshes, about 525k triangles.
 
-Expect it to take roughly half an hour: the G1's collision geometry is its full visual meshes.
-Review the diff before committing, and check that cross-arm pairs from the elbows out are still
-enabled — `both_arms` is pointless without them, and `test_robot_model` asserts it.
+What the shipped matrix was generated from instead is the robot's own rest pose, which is all the
+"invalid start state" failure needs: link pairs joined by a joint, plus pairs found touching by
+`move_group`'s `/check_state_validity` contacts. 54 pairs, generated in seconds, and deliberately
+conservative — it disables what genuinely touches and nothing speculative. It contains no cross-arm
+pair, which matters: `both_arms` exists to collision-check one arm against the other, and
+`test_robot_model` asserts those stay enabled.
+
+The "never in collision" pairs a full sampling run would add are a planning-speed optimisation, not
+a correctness requirement. Getting them needs the collision geometry simplified first — see
+`docs/notes` — after which the upstream generator becomes usable again.
 
 ## Tests
 
@@ -104,6 +127,7 @@ enabled — `both_arms` is pointless without them, and `test_robot_model` assert
 |---|---|---|
 | `test_moveit_config_drift` | no | This package against `g1_bringup`'s controller and `g1_description`'s speed clamp; the composite-group solver rule; SRDF well-formedness. |
 | `test_robot_model` | no | Group composition and order, planning frame, no hand or waist joints in an arm group, the collision matrix's adjacent pairs and its cross-arm pairs. |
+| `test_launch_threading` | no | The arguments `g1_bringup`'s `moveit:=true` branch threads into the simulator, the RViz choice, and that `moveit_sim.launch.py` still composes what it did. |
 | `test_moveit_plan_execute` | yes | Execution refused before acquire, a coordinated `both_arms` plan, planned speed under the clamp, and hand placement with the waist turned. |
 
 ```bash

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -58,12 +58,200 @@
        needs an end effector yet. SRDF has no notion of a two-tip end effector in any case, so
        both_arms could not have one.
 
-       group_state named poses. Zero is a guess, and an arms-down posture may well self
-       collide. Derive them from a posture observed in sim when a skill needs one.
-
        passive_joint. It would document that the legs, waist and hands are not ours, but it
        reads as if it does more: MoveIt's CurrentStateMonitor counts every active joint, and
        the flag does not exempt one. This comment carries the same information honestly. -->
+
+
+  <!-- Named postures. Every value below was collision-checked against a running move_group
+       (/check_state_validity, both_arms) before being written here, not chosen on a diagram.
+       `home` is the posture the simulator actually holds the arms at, measured, with the few
+       hundredths of measurement noise zeroed.
+
+       An earlier version of this file said zero "may well self collide" and left these out on
+       that suspicion. It does not: checked, valid. The suspicion was wrong.
+
+       roll and yaw mirror between the arms so a positive value swings each arm away from the
+       torso on its own side; pitch and elbow do not mirror.
+
+       Each pose is declared three times because SRDF group states belong to one group, and a
+       skill may drive either arm alone or both together. test_robot_model asserts the three
+       copies agree, so they cannot drift apart. -->
+
+  <group_state name="home" group="left_arm">
+    <joint name="left_shoulder_pitch_joint" value="-0.70"/>
+    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.50"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="home" group="right_arm">
+    <joint name="right_shoulder_pitch_joint" value="-0.70"/>
+    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.50"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="home" group="both_arms">
+    <joint name="left_shoulder_pitch_joint" value="-0.70"/>
+    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.50"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+    <joint name="right_shoulder_pitch_joint" value="-0.70"/>
+    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.50"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+
+  <group_state name="zero" group="left_arm">
+    <joint name="left_shoulder_pitch_joint" value="0.00"/>
+    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="0.00"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="zero" group="right_arm">
+    <joint name="right_shoulder_pitch_joint" value="0.00"/>
+    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="0.00"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="zero" group="both_arms">
+    <joint name="left_shoulder_pitch_joint" value="0.00"/>
+    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="0.00"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+    <joint name="right_shoulder_pitch_joint" value="0.00"/>
+    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="0.00"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+
+  <group_state name="tucked" group="left_arm">
+    <joint name="left_shoulder_pitch_joint" value="0.25"/>
+    <joint name="left_shoulder_roll_joint" value="0.20"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.30"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="tucked" group="right_arm">
+    <joint name="right_shoulder_pitch_joint" value="0.25"/>
+    <joint name="right_shoulder_roll_joint" value="-0.20"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.30"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="tucked" group="both_arms">
+    <joint name="left_shoulder_pitch_joint" value="0.25"/>
+    <joint name="left_shoulder_roll_joint" value="0.20"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.30"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+    <joint name="right_shoulder_pitch_joint" value="0.25"/>
+    <joint name="right_shoulder_roll_joint" value="-0.20"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.30"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+
+  <group_state name="ready" group="left_arm">
+    <joint name="left_shoulder_pitch_joint" value="-0.35"/>
+    <joint name="left_shoulder_roll_joint" value="0.25"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.00"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="ready" group="right_arm">
+    <joint name="right_shoulder_pitch_joint" value="-0.35"/>
+    <joint name="right_shoulder_roll_joint" value="-0.25"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.00"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="ready" group="both_arms">
+    <joint name="left_shoulder_pitch_joint" value="-0.35"/>
+    <joint name="left_shoulder_roll_joint" value="0.25"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="1.00"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+    <joint name="right_shoulder_pitch_joint" value="-0.35"/>
+    <joint name="right_shoulder_roll_joint" value="-0.25"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="1.00"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+
+  <group_state name="reach_front" group="left_arm">
+    <joint name="left_shoulder_pitch_joint" value="-0.90"/>
+    <joint name="left_shoulder_roll_joint" value="0.20"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="0.70"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="reach_front" group="right_arm">
+    <joint name="right_shoulder_pitch_joint" value="-0.90"/>
+    <joint name="right_shoulder_roll_joint" value="-0.20"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="0.70"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+  <group_state name="reach_front" group="both_arms">
+    <joint name="left_shoulder_pitch_joint" value="-0.90"/>
+    <joint name="left_shoulder_roll_joint" value="0.20"/>
+    <joint name="left_shoulder_yaw_joint" value="0.00"/>
+    <joint name="left_elbow_joint" value="0.70"/>
+    <joint name="left_wrist_roll_joint" value="0.00"/>
+    <joint name="left_wrist_pitch_joint" value="0.00"/>
+    <joint name="left_wrist_yaw_joint" value="0.00"/>
+    <joint name="right_shoulder_pitch_joint" value="-0.90"/>
+    <joint name="right_shoulder_roll_joint" value="-0.20"/>
+    <joint name="right_shoulder_yaw_joint" value="0.00"/>
+    <joint name="right_elbow_joint" value="0.70"/>
+    <joint name="right_wrist_roll_joint" value="0.00"/>
+    <joint name="right_wrist_pitch_joint" value="0.00"/>
+    <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
 
   <!-- Generated, 2026-08-05. Everything above is hand-written; this block is not.
 

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -3,15 +3,19 @@
   <!-- Hand-authored, against urdf/g1_arm_sdk.urdf.xacro in g1_description. Only the
        disable_collisions block at the bottom is generated; see README.md for the command.
 
+       Note for editors: XML forbids a double hyphen inside a comment, so the prose here uses
+       commas and colons where the rest of this repo would use a dash. A stray double hyphen
+       makes the whole file unparseable and move_group fails at launch, not at lint.
+
        No virtual joint. The vendored URDF's floating_base_joint is commented out upstream, so
        the model root is `pelvis` and MoveIt plans in that frame. Correct while the robot stands
        still to manipulate. Scene objects fixed in `odom`, or reaching while walking, need a
-       floating joint to `odom` instead -- 6 more DoF and a TF dependency, so it is a decision
-       to make when there is something to fix it against. -->
+       floating joint to `odom` instead: 6 more DoF and a TF dependency, so it is a decision to
+       make when there is something to fix it against. -->
 
   <!-- base_link is torso_link, not pelvis: the three waist joints belong to the onboard
        controller (docs/CONTROL_MODES.md), and a group that spans them would plan motion we
-       cannot command. Their state still matters -- it is what places torso_link under pelvis --
+       cannot command. Their state still matters, it is what places torso_link under pelvis,
        which is why motion_service_sim has to publish it.
 
        tip_link is the palm rather than wrist_yaw_link. The palm joint is fixed, so both give
@@ -25,9 +29,9 @@
   </group>
 
   <!-- Both arms as one 14-joint group, which is what makes coordinated two-handed motion a
-       plan rather than two plans run side by side. Only this group can collision-check the
-       left arm against the right one, and only this group can time a motion so the two hands
-       arrive together; sequencing the per-arm groups can do neither.
+       plan rather than two plans run side by side. Only this group collision-checks the left
+       arm against the right one, and only this group can time a motion so the two hands arrive
+       together; sequencing the per-arm groups does neither.
 
        Composed from the two subgroups rather than restating the joints, so there is one
        definition of what an arm is. That is also what every published dual-arm config does
@@ -39,7 +43,7 @@
        is a two-branch tree. MoveIt's answer is the subgroup solver map: it is built only for
        groups that have no solver of their own, and it routes a pose goal per hand to that
        arm's own pick_ik. Naming this group in kinematics.yaml suppresses that map and leaves
-       nothing to solve with -- the single most-copied mistake in dual-arm configs. -->
+       nothing to solve with, which is the single most-copied mistake in dual-arm configs. -->
   <group name="both_arms">
     <group name="left_arm"/>
     <group name="right_arm"/>
@@ -47,15 +51,16 @@
 
   <!-- Deliberately absent, so the next reader does not think they were forgotten:
 
-       Hand groups and <end_effector>. The hand is a separate controllable group with its own
-       API (docs/CONTROL_MODES.md), and today it has no controller, no state source and no
-       actuator in the sim model. attachObject takes explicit touch links, so nothing here
-       needs an end-effector definition yet.
+       Hand groups and end_effector definitions. The hand is a separate controllable group with
+       its own API (docs/CONTROL_MODES.md), and today it has no controller, no state source and
+       no actuator in the sim model. attachObject takes explicit touch links, so nothing here
+       needs an end effector yet. SRDF has no notion of a two-tip end effector in any case, so
+       both_arms could not have one.
 
-       <group_state> named poses. Zero is a guess, and an arms-down posture may well self
+       group_state named poses. Zero is a guess, and an arms-down posture may well self
        collide. Derive them from a posture observed in sim when a skill needs one.
 
-       <passive_joint>. It would document that the legs, waist and hands are not ours, but it
+       passive_joint. It would document that the legs, waist and hands are not ours, but it
        reads as if it does more: MoveIt's CurrentStateMonitor counts every active joint, and
        the flag does not exempt one. This comment carries the same information honestly. -->
 </robot>

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -50,17 +50,47 @@
     <group name="right_arm"/>
   </group>
 
-  <!-- Deliberately absent, so the next reader does not think they were forgotten:
+  <!-- The Dex3 hands, one group each. Joints and not a chain, because the three fingers branch
+       off the palm and a chain cannot express that. Order is the Dex3 wire order, which is what
+       g1_bringup's controllers and the hardware component both use.
 
-       Hand groups and end_effector definitions. The hand is a separate controllable group with
-       its own API (docs/CONTROL_MODES.md), and today it has no controller, no state source and
-       no actuator in the sim model. attachObject takes explicit touch links, so nothing here
-       needs an end effector yet. SRDF has no notion of a two-tip end effector in any case, so
-       both_arms could not have one.
+       Kept out of every arm group on purpose, and test_robot_model pins that: an arm plan must
+       never command the fingers, because the arm and the hand are separate devices with
+       separate authority (docs/CONTROL_MODES.md) reached over separate topics. -->
+  <group name="left_hand">
+    <joint name="left_hand_thumb_0_joint"/>
+    <joint name="left_hand_thumb_1_joint"/>
+    <joint name="left_hand_thumb_2_joint"/>
+    <joint name="left_hand_middle_0_joint"/>
+    <joint name="left_hand_middle_1_joint"/>
+    <joint name="left_hand_index_0_joint"/>
+    <joint name="left_hand_index_1_joint"/>
+  </group>
+  <group name="right_hand">
+    <joint name="right_hand_thumb_0_joint"/>
+    <joint name="right_hand_thumb_1_joint"/>
+    <joint name="right_hand_thumb_2_joint"/>
+    <joint name="right_hand_middle_0_joint"/>
+    <joint name="right_hand_middle_1_joint"/>
+    <joint name="right_hand_index_0_joint"/>
+    <joint name="right_hand_index_1_joint"/>
+  </group>
 
-       passive_joint. It would document that the legs, waist and hands are not ours, but it
-       reads as if it does more: MoveIt's CurrentStateMonitor counts every active joint, and
-       the flag does not exempt one. This comment carries the same information honestly. -->
+  <!-- What makes attachObject/detachObject work without naming touch links by hand, and what
+       lets RViz offer the hand as the arm's end effector rather than as an unrelated group.
+
+       both_arms still has none: SRDF has no notion of a two-tip end effector. A two-handed
+       grasp attaches to one arm and lists the other hand's links as touch links. -->
+  <end_effector name="left_gripper" parent_link="left_hand_palm_link"
+                group="left_hand" parent_group="left_arm"/>
+  <end_effector name="right_gripper" parent_link="right_hand_palm_link"
+                group="right_hand" parent_group="right_arm"/>
+
+  <!-- Deliberately absent, so the next reader does not think it was forgotten:
+
+       passive_joint. It would document that the legs and waist are not ours, but it reads as
+       if it does more: MoveIt's CurrentStateMonitor counts every active joint, and the flag
+       does not exempt one. This comment carries the same information honestly. -->
 
 
   <!-- Named postures. Every value below was collision-checked against a running move_group
@@ -251,6 +281,53 @@
     <joint name="right_wrist_roll_joint" value="0.00"/>
     <joint name="right_wrist_pitch_joint" value="0.00"/>
     <joint name="right_wrist_yaw_joint" value="0.00"/>
+  </group_state>
+
+  <!-- Hand postures. Two per hand is the whole vocabulary a pick and place needs: reach with
+       the hand open, close on the object, attach it, move, place, open, detach.
+
+       `open` is the URDF zero, which puts the fingers straight and the thumb mid-range. Not an
+       arbitrary choice: every finger joint's range ends at zero on the extended side.
+
+       `closed` is a power grasp, curled short of the joint limits so the fingers can still
+       press into an object rather than resting against their own end stops. The two hands
+       mirror by sign, as the URDF's own limits do on all seven joints. Collision-checked
+       against a running move_group before being written here, same as the arm poses. -->
+  <group_state name="open" group="left_hand">
+    <joint name="left_hand_thumb_0_joint" value="0.00"/>
+    <joint name="left_hand_thumb_1_joint" value="0.00"/>
+    <joint name="left_hand_thumb_2_joint" value="0.00"/>
+    <joint name="left_hand_middle_0_joint" value="0.00"/>
+    <joint name="left_hand_middle_1_joint" value="0.00"/>
+    <joint name="left_hand_index_0_joint" value="0.00"/>
+    <joint name="left_hand_index_1_joint" value="0.00"/>
+  </group_state>
+  <group_state name="closed" group="left_hand">
+    <joint name="left_hand_thumb_0_joint" value="-0.30"/>
+    <joint name="left_hand_thumb_1_joint" value="-0.50"/>
+    <joint name="left_hand_thumb_2_joint" value="1.20"/>
+    <joint name="left_hand_middle_0_joint" value="-1.20"/>
+    <joint name="left_hand_middle_1_joint" value="-1.40"/>
+    <joint name="left_hand_index_0_joint" value="-1.20"/>
+    <joint name="left_hand_index_1_joint" value="-1.40"/>
+  </group_state>
+  <group_state name="open" group="right_hand">
+    <joint name="right_hand_thumb_0_joint" value="0.00"/>
+    <joint name="right_hand_thumb_1_joint" value="0.00"/>
+    <joint name="right_hand_thumb_2_joint" value="0.00"/>
+    <joint name="right_hand_middle_0_joint" value="0.00"/>
+    <joint name="right_hand_middle_1_joint" value="0.00"/>
+    <joint name="right_hand_index_0_joint" value="0.00"/>
+    <joint name="right_hand_index_1_joint" value="0.00"/>
+  </group_state>
+  <group_state name="closed" group="right_hand">
+    <joint name="right_hand_thumb_0_joint" value="0.30"/>
+    <joint name="right_hand_thumb_1_joint" value="0.50"/>
+    <joint name="right_hand_thumb_2_joint" value="-1.20"/>
+    <joint name="right_hand_middle_0_joint" value="1.20"/>
+    <joint name="right_hand_middle_1_joint" value="1.40"/>
+    <joint name="right_hand_index_0_joint" value="1.20"/>
+    <joint name="right_hand_index_1_joint" value="1.40"/>
   </group_state>
 
   <!-- Generated, 2026-08-05. Everything above is hand-written; this block is not.

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -95,8 +95,14 @@
 
   <!-- Named postures. Every value below was collision-checked against a running move_group
        (/check_state_validity, both_arms) before being written here, not chosen on a diagram.
-       `home` is the posture the simulator actually holds the arms at, measured, with the few
-       hundredths of measurement noise zeroed.
+       `home` is the posture the simulator holds the arms at, and the arrow points this way
+       round: g1_motion_service_sim's `arm_hold_rad` is set from these values, and the drift
+       test pins the pair. It used to be the other way, a measurement of wherever the arms
+       happened to fall at startup, which is how it ended up a few hundredths from putting the
+       palm against the thigh once the hands had their real mass.
+
+       The small shoulder roll is what buys that margin: it swings each arm off the torso so
+       neither the sag nor a heavier hand closes the gap. See docs/notes/hand-mass-rest-pose.md.
 
        An earlier version of this file said zero "may well self collide" and left these out on
        that suspicion. It does not: checked, valid. The suspicion was wrong.
@@ -110,7 +116,7 @@
 
   <group_state name="home" group="left_arm">
     <joint name="left_shoulder_pitch_joint" value="-0.70"/>
-    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_roll_joint" value="0.15"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.50"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
@@ -119,7 +125,7 @@
   </group_state>
   <group_state name="home" group="right_arm">
     <joint name="right_shoulder_pitch_joint" value="-0.70"/>
-    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_roll_joint" value="-0.15"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.50"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>
@@ -128,14 +134,14 @@
   </group_state>
   <group_state name="home" group="both_arms">
     <joint name="left_shoulder_pitch_joint" value="-0.70"/>
-    <joint name="left_shoulder_roll_joint" value="0.00"/>
+    <joint name="left_shoulder_roll_joint" value="0.15"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.50"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
     <joint name="left_wrist_pitch_joint" value="0.00"/>
     <joint name="left_wrist_yaw_joint" value="0.00"/>
     <joint name="right_shoulder_pitch_joint" value="-0.70"/>
-    <joint name="right_shoulder_roll_joint" value="0.00"/>
+    <joint name="right_shoulder_roll_joint" value="-0.15"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.50"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<robot name="g1_29dof_with_hand_rev_1_0">
+  <!-- Hand-authored, against urdf/g1_arm_sdk.urdf.xacro in g1_description. Only the
+       disable_collisions block at the bottom is generated; see README.md for the command.
+
+       No virtual joint. The vendored URDF's floating_base_joint is commented out upstream, so
+       the model root is `pelvis` and MoveIt plans in that frame. Correct while the robot stands
+       still to manipulate. Scene objects fixed in `odom`, or reaching while walking, need a
+       floating joint to `odom` instead -- 6 more DoF and a TF dependency, so it is a decision
+       to make when there is something to fix it against. -->
+
+  <!-- base_link is torso_link, not pelvis: the three waist joints belong to the onboard
+       controller (docs/CONTROL_MODES.md), and a group that spans them would plan motion we
+       cannot command. Their state still matters -- it is what places torso_link under pelvis --
+       which is why motion_service_sim has to publish it.
+
+       tip_link is the palm rather than wrist_yaw_link. The palm joint is fixed, so both give
+       the same 7 joints and differ only in where a pose goal is measured; the palm is where a
+       grasp is naturally expressed, and it keeps the finger joints outside the group. -->
+  <group name="left_arm">
+    <chain base_link="torso_link" tip_link="left_hand_palm_link"/>
+  </group>
+  <group name="right_arm">
+    <chain base_link="torso_link" tip_link="right_hand_palm_link"/>
+  </group>
+
+  <!-- Both arms as one 14-joint group, which is what makes coordinated two-handed motion a
+       plan rather than two plans run side by side. Only this group can collision-check the
+       left arm against the right one, and only this group can time a motion so the two hands
+       arrive together; sequencing the per-arm groups can do neither.
+
+       Composed from the two subgroups rather than restating the joints, so there is one
+       definition of what an arm is. That is also what every published dual-arm config does
+       (PR2, Baxter, Talos, TIAGo++). The per-arm groups stay because single-arm motion is
+       still the common case and a 7-DoF search is much cheaper than a 14-DoF one.
+
+       This group deliberately has NO kinematics.yaml entry, and adding one breaks it. pick_ik,
+       like KDL and TRAC-IK, rejects any group that is not a chain, and two arms off one torso
+       is a two-branch tree. MoveIt's answer is the subgroup solver map: it is built only for
+       groups that have no solver of their own, and it routes a pose goal per hand to that
+       arm's own pick_ik. Naming this group in kinematics.yaml suppresses that map and leaves
+       nothing to solve with -- the single most-copied mistake in dual-arm configs. -->
+  <group name="both_arms">
+    <group name="left_arm"/>
+    <group name="right_arm"/>
+  </group>
+
+  <!-- Deliberately absent, so the next reader does not think they were forgotten:
+
+       Hand groups and <end_effector>. The hand is a separate controllable group with its own
+       API (docs/CONTROL_MODES.md), and today it has no controller, no state source and no
+       actuator in the sim model. attachObject takes explicit touch links, so nothing here
+       needs an end-effector definition yet.
+
+       <group_state> named poses. Zero is a guess, and an arms-down posture may well self
+       collide. Derive them from a posture observed in sim when a skill needs one.
+
+       <passive_joint>. It would document that the legs, waist and hands are not ours, but it
+       reads as if it does more: MoveIt's CurrentStateMonitor counts every active joint, and
+       the flag does not exempt one. This comment carries the same information honestly. -->
+</robot>

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <robot name="g1_29dof_with_hand_rev_1_0">
   <!-- Hand-authored, against urdf/g1_arm_sdk.urdf.xacro in g1_description. Only the
-       disable_collisions block at the bottom is generated; see README.md for the command.
+       disable_collisions block at the bottom is generated; that block carries its own note
+       on how, and README.md has the command.
 
        Note for editors: XML forbids a double hyphen inside a comment, so the prose here uses
        commas and colons where the rest of this repo would use a dash. A stray double hyphen
@@ -63,4 +64,77 @@
        passive_joint. It would document that the legs, waist and hands are not ours, but it
        reads as if it does more: MoveIt's CurrentStateMonitor counts every active joint, and
        the flag does not exempt one. This comment carries the same information honestly. -->
+
+  <!-- Generated, 2026-08-05. Everything above is hand-written; this block is not.
+
+       Two categories, both safe to disable and nothing beyond them: links joined by a joint
+       (reason Adjacent), and links found touching in the robot's own rest pose (reason
+       Default), read from move_group's /check_state_validity contacts. Without these, MoveIt
+       reports the robot as colliding with itself before it has moved, and RRTConnect refuses
+       to seed its tree: "Skipping invalid start state".
+
+       Deliberately NOT generated: the "never in collision" pairs the Setup Assistant's
+       collisions_updater finds by random sampling. Those are a planning-speed optimisation,
+       not a correctness requirement, and on this model the sampling does not finish in a
+       usable time: the URDF's collision geometry is its full visual meshes, about 525k
+       triangles, and runs at 10000, 1000 and 1 trials all failed to complete in over an hour.
+       Simplifying the collision geometry is the fix, and it is its own change. README.md has
+       the regeneration command for when that lands.
+
+       No cross-arm pair appears here, and none should: both_arms exists to collision-check one
+       arm against the other, and test_robot_model asserts the reaching links stay checked. -->
+  <disable_collisions link1="d435_link" link2="camera_color_optical_frame" reason="Adjacent"/>
+  <disable_collisions link1="d435_link" link2="camera_depth_optical_frame" reason="Adjacent"/>
+  <disable_collisions link1="head_link" link2="torso_link" reason="Default"/>
+  <disable_collisions link1="left_ankle_pitch_link" link2="left_ankle_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="left_ankle_pitch_link" link2="left_knee_link" reason="Default"/>
+  <disable_collisions link1="left_elbow_link" link2="left_shoulder_yaw_link" reason="Default"/>
+  <disable_collisions link1="left_elbow_link" link2="left_wrist_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hand_index_0_link" link2="left_hand_index_1_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hand_index_0_link" link2="left_hand_palm_link" reason="Default"/>
+  <disable_collisions link1="left_hand_middle_0_link" link2="left_hand_middle_1_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hand_middle_0_link" link2="left_hand_palm_link" reason="Default"/>
+  <disable_collisions link1="left_hand_palm_link" link2="left_hand_thumb_0_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hand_palm_link" link2="left_wrist_yaw_link" reason="Default"/>
+  <disable_collisions link1="left_hand_thumb_0_link" link2="left_hand_thumb_1_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hand_thumb_1_link" link2="left_hand_thumb_2_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hip_pitch_link" link2="left_hip_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hip_roll_link" link2="left_hip_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="left_hip_yaw_link" link2="left_knee_link" reason="Adjacent"/>
+  <disable_collisions link1="left_shoulder_pitch_link" link2="left_shoulder_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="left_shoulder_roll_link" link2="left_shoulder_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="left_wrist_pitch_link" link2="left_wrist_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="left_wrist_roll_link" link2="left_wrist_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="logo_link" link2="torso_link" reason="Default"/>
+  <disable_collisions link1="pelvis" link2="imu_in_pelvis" reason="Adjacent"/>
+  <disable_collisions link1="pelvis" link2="left_hip_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="pelvis" link2="pelvis_contour_link" reason="Adjacent"/>
+  <disable_collisions link1="pelvis" link2="right_hip_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="pelvis" link2="waist_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="right_ankle_pitch_link" link2="right_ankle_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="right_ankle_pitch_link" link2="right_knee_link" reason="Default"/>
+  <disable_collisions link1="right_elbow_link" link2="right_shoulder_yaw_link" reason="Default"/>
+  <disable_collisions link1="right_elbow_link" link2="right_wrist_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hand_index_0_link" link2="right_hand_index_1_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hand_index_0_link" link2="right_hand_palm_link" reason="Default"/>
+  <disable_collisions link1="right_hand_middle_0_link" link2="right_hand_middle_1_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hand_middle_0_link" link2="right_hand_palm_link" reason="Default"/>
+  <disable_collisions link1="right_hand_palm_link" link2="right_hand_thumb_0_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hand_palm_link" link2="right_wrist_yaw_link" reason="Default"/>
+  <disable_collisions link1="right_hand_thumb_0_link" link2="right_hand_thumb_1_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hand_thumb_1_link" link2="right_hand_thumb_2_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hip_pitch_link" link2="right_hip_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hip_roll_link" link2="right_hip_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="right_hip_yaw_link" link2="right_knee_link" reason="Adjacent"/>
+  <disable_collisions link1="right_shoulder_pitch_link" link2="right_shoulder_roll_link" reason="Adjacent"/>
+  <disable_collisions link1="right_shoulder_roll_link" link2="right_shoulder_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="right_wrist_pitch_link" link2="right_wrist_yaw_link" reason="Adjacent"/>
+  <disable_collisions link1="right_wrist_roll_link" link2="right_wrist_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="torso_link" link2="d435_link" reason="Adjacent"/>
+  <disable_collisions link1="torso_link" link2="imu_in_torso" reason="Adjacent"/>
+  <disable_collisions link1="torso_link" link2="left_shoulder_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="torso_link" link2="mid360_link" reason="Adjacent"/>
+  <disable_collisions link1="torso_link" link2="right_shoulder_pitch_link" reason="Adjacent"/>
+  <disable_collisions link1="waist_roll_link" link2="torso_link" reason="Adjacent"/>
+  <disable_collisions link1="waist_yaw_link" link2="waist_roll_link" reason="Adjacent"/>
 </robot>

--- a/workspace/src/g1_moveit_config/config/g1_moveit.rviz
+++ b/workspace/src/g1_moveit_config/config/g1_moveit.rviz
@@ -98,3 +98,9 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
+  # Not a plugin, which is why it cannot appear under Panels: the MotionPlanning display
+  # constructs this pane itself and registers it through addPane(), naming it after the
+  # display. So the key has to track the display's Name above, and the pane only exists while
+  # that display does. Every upstream config does it this way (turtlebot3, tiago).
+  MotionPlanning - Trajectory Slider:
+    collapsed: false

--- a/workspace/src/g1_moveit_config/config/g1_moveit.rviz
+++ b/workspace/src/g1_moveit_config/config/g1_moveit.rviz
@@ -18,8 +18,6 @@ Panels:
     Tree Height: 700
   - Class: rviz_common/Views
     Name: Views
-  - Class: moveit_rviz_plugin/MotionPlanning - Trajectory Slider
-    Name: Trajectory Slider
 Visualization Manager:
   Class: ""
   Name: root
@@ -99,6 +97,4 @@ Window Geometry:
   Displays:
     collapsed: false
   Views:
-    collapsed: false
-  Trajectory Slider:
     collapsed: false

--- a/workspace/src/g1_moveit_config/config/g1_moveit.rviz
+++ b/workspace/src/g1_moveit_config/config/g1_moveit.rviz
@@ -1,0 +1,104 @@
+# RViz for interactive arm planning.
+#   ros2 launch g1_moveit_config moveit_rviz.launch.py
+#
+# Fixed Frame is pelvis, not odom: moveit_sim.launch.py runs without the sensor track, so
+# g1_state_estimation is not publishing odom -> base_footprint and odom does not exist. pelvis
+# is also MoveIt's planning frame here (g1.srdf declares no virtual joint), so what the
+# MotionPlanning panel reports and what this view shows are the same frame.
+#
+# Planning Group starts on both_arms. The single-arm groups are one dropdown away, and starting
+# on the coordinated group is the reminder that it exists.
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /MotionPlanning1
+      Splitter Ratio: 0.5
+    Tree Height: 700
+  - Class: rviz_common/Views
+    Name: Views
+  - Class: moveit_rviz_plugin/MotionPlanning - Trajectory Slider
+    Name: Trajectory Slider
+Visualization Manager:
+  Class: ""
+  Name: root
+  Displays:
+    - Class: rviz_default_plugins/Grid
+      Name: Grid
+      Enabled: true
+      Cell Size: 1
+      Plane Cell Count: 10
+      Color: 160; 160; 164
+    - Class: rviz_default_plugins/TF
+      Name: TF
+      Enabled: false
+      Marker Scale: 0.3
+      Show Arrows: false
+      Show Axes: true
+      Show Names: true
+    - Class: moveit_rviz_plugin/MotionPlanning
+      Name: MotionPlanning
+      Enabled: true
+      Move Group Namespace: ""
+      Robot Description: robot_description
+      Planning Scene Topic: /monitored_planning_scene
+      Planning Request:
+        Planning Group: both_arms
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0.15
+        Query Goal State: true
+        Query Start State: false
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planned Path:
+        Trajectory Topic: /display_planned_path
+        Loop Animation: false
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 0.05 s
+        Interrupt Display: false
+      Scene Geometry:
+        Scene Alpha: 0.9
+        Show Scene Geometry: true
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Robot Alpha: 0.5
+        Show Robot Collision: false
+        Show Robot Visual: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: pelvis
+    Frame Rate: 30
+  Tools:
+    - Class: rviz_default_plugins/Interact
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Name: Current View
+      Distance: 2.5
+      Focal Point:
+        X: 0.2
+        Y: 0
+        Z: 0.3
+      Pitch: 0.35
+      Yaw: 3.6
+      Target Frame: <Fixed Frame>
+      Near Clip Distance: 0.01
+Window Geometry:
+  Height: 900
+  Width: 1400
+  Displays:
+    collapsed: false
+  Views:
+    collapsed: false
+  Trajectory Slider:
+    collapsed: false

--- a/workspace/src/g1_moveit_config/config/joint_limits.yaml
+++ b/workspace/src/g1_moveit_config/config/joint_limits.yaml
@@ -92,3 +92,79 @@ joint_limits:
     max_velocity: 0.8
     has_acceleration_limits: true
     max_acceleration: 2.0
+
+  # The hands run against a different clamp: g1_hand_interface slews at 3.0 rad/s
+  # (g1_description/config/dex3_params.yaml), so 2.0 leaves the same backstop margin 0.8 leaves
+  # the arm's 1.0. Acceleration is higher than the arm's because a finger is a few grams on a
+  # short lever and moving one does not shift the centre of mass of a balancing robot; 2.0 here
+  # would make every grasp take a second for no reason.
+  left_hand_thumb_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_thumb_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_thumb_2_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_middle_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_middle_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_index_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_hand_index_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_thumb_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_thumb_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_thumb_2_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_middle_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_middle_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_index_0_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_hand_index_1_joint:
+    has_velocity_limits: true
+    max_velocity: 2.0
+    has_acceleration_limits: true
+    max_acceleration: 5.0

--- a/workspace/src/g1_moveit_config/config/joint_limits.yaml
+++ b/workspace/src/g1_moveit_config/config/joint_limits.yaml
@@ -1,0 +1,94 @@
+# Velocity and acceleration limits MoveIt times its trajectories against.
+#
+# These are NOT the URDF's limits, and the difference is the point. The URDF says 22 to 37 rad/s,
+# which is the motor; the arm reaches the robot through g1_hardware_interface, which slew-clamps
+# every joint at max_joint_velocity_rad_s = 1.0 rad/s (g1_description/config/arm_sdk_params.yaml).
+# Time a trajectory against the motor and the bridge stretches it by a factor of thirty-odd,
+# which surfaces as the controller aborting on a goal-time tolerance that looks unrelated to
+# speed. 0.8 leaves the clamp as a backstop rather than a controller in the loop: JTC
+# interpolation and the 200 Hz controller_manager against a 100 Hz publish rate can push
+# instantaneous command deltas above the nominal.
+#
+# g1_moveit_config's drift test asserts every value here stays under that clamp.
+#
+# Acceleration has no URDF equivalent at all -- the vendored file declares none -- and
+# time-optimal parameterization needs one. Without it a plan comes back "successful" carrying
+# zero timestamps and only fails at execution. 2.0 rad/s^2 reaches full speed in 0.4 s; arm
+# acceleration shifts the centre of mass on a robot that is balancing itself, so it starts
+# conservative and moves when there is a measurement to move it against.
+#
+# Uniform across all 14 rather than per-joint: every URDF limit is far above the clamp, so the
+# clamp is what binds on every joint and per-joint tuning would encode a distinction that does
+# not exist yet.
+
+joint_limits:
+  left_shoulder_pitch_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_shoulder_roll_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_shoulder_yaw_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_elbow_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_wrist_roll_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_wrist_pitch_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  left_wrist_yaw_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_shoulder_pitch_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_shoulder_roll_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_shoulder_yaw_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_elbow_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_wrist_roll_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_wrist_pitch_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0
+  right_wrist_yaw_joint:
+    has_velocity_limits: true
+    max_velocity: 0.8
+    has_acceleration_limits: true
+    max_acceleration: 2.0

--- a/workspace/src/g1_moveit_config/config/kinematics.yaml
+++ b/workspace/src/g1_moveit_config/config/kinematics.yaml
@@ -1,0 +1,46 @@
+# Inverse kinematics for the two arm chains.
+#
+# pick_ik rather than the default KDL. Each arm is 7 joints against a 6-DoF pose, so there is a
+# null space of solutions and the solver's choice within it is the whole question. KDL is a
+# pseudo-inverse Jacobian with random restarts: it wanders that null space, clamps at joint
+# limits instead of avoiding them, and gives no continuity between nearby targets, which shows
+# up as the elbow flipping between two poses a few centimetres apart. pick_ik optimises against
+# a cost function, so the redundancy is spent on something chosen rather than incidental.
+#
+# TRAC-IK was the other candidate and is not packaged for Humble; building it from source to get
+# what pick_ik already provides is not worth the pin. Swapping back to KDL is one line:
+#   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+#
+# both_arms has no entry here ON PURPOSE, and adding one breaks dual-arm IK. See g1.srdf.
+
+left_arm:
+  kinematics_solver: pick_ik/PickIkPlugin
+  kinematics_solver_timeout: 0.05
+
+  # global runs the memetic search, which finds a solution from a seed far from the goal --
+  # the plan-to-pose case. local is gradient descent from the seed and is the right choice for
+  # servoing or a Cartesian path, where the seed is already close.
+  mode: global
+
+  # Stop at the first solution that satisfies the thresholds rather than polishing it. Planning
+  # calls IK many times per motion, so solve time matters more than solution quality here.
+  stop_optimization_on_valid_solution: true
+
+  # 1 mm and ~0.6 deg. Tighter than the arm can actually track under the arm_sdk gains, so the
+  # solver is not the limiting factor in where the hand ends up.
+  position_threshold: 0.001
+  orientation_threshold: 0.01
+
+  # Left at zero until there is a measurement to tune against: the cost terms are additive, so
+  # raising this also moves what cost_threshold means. This is the knob for elbow-flip
+  # continuity between nearby targets if that shows up.
+  minimal_displacement_weight: 0.0
+
+right_arm:
+  kinematics_solver: pick_ik/PickIkPlugin
+  kinematics_solver_timeout: 0.05
+  mode: global
+  stop_optimization_on_valid_solution: true
+  position_threshold: 0.001
+  orientation_threshold: 0.01
+  minimal_displacement_weight: 0.0

--- a/workspace/src/g1_moveit_config/config/moveit_controllers.yaml
+++ b/workspace/src/g1_moveit_config/config/moveit_controllers.yaml
@@ -1,0 +1,59 @@
+# How move_group hands a planned trajectory to the controller that already exists.
+#
+# arm_trajectory_controller is the JointTrajectoryController g1_bringup has run since the arm
+# bridge landed; MoveIt becomes another client of its action, not a second command path. The
+# ownership chain is unchanged: JTC -> G1ArmSdkSystem -> /arm_sdk, still the only writer.
+#
+# One controller covering all 14 joints, rather than the two per-arm controllers most published
+# dual-arm configs use. Those robots have two independent arm controllers in hardware; we have
+# one. It is also the better fit for coordinated motion: MoveIt looks for the smallest set of
+# controllers covering the trajectory's joints and finds this one on the first try, so a
+# both_arms plan executes as a single trajectory. Two controllers would mean splitting it and
+# leaving the two halves to stay in step on their own.
+
+moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
+
+# MoveIt must never activate or switch controllers. Acquiring the arm is an ordered,
+# safety-critical step -- the hardware component first, then the controller -- and it lives in
+# g1_bringup/scripts/activate_arm. Planning works whether or not the arm is active; execution
+# is refused by the JTC until it is, which is the intended failure.
+moveit_manage_controllers: false
+
+moveit_simple_controller_manager:
+  controller_names:
+    - arm_trajectory_controller
+
+  arm_trajectory_controller:
+    type: FollowJointTrajectory
+    action_ns: follow_joint_trajectory
+    default: true
+    # Same list, same order as g1_bringup/config/controllers.yaml. The drift test compares them;
+    # the JTC itself remaps by name, so order is for readers rather than for correctness.
+    joints:
+      - left_shoulder_pitch_joint
+      - left_shoulder_roll_joint
+      - left_shoulder_yaw_joint
+      - left_elbow_joint
+      - left_wrist_roll_joint
+      - left_wrist_pitch_joint
+      - left_wrist_yaw_joint
+      - right_shoulder_pitch_joint
+      - right_shoulder_roll_joint
+      - right_shoulder_yaw_joint
+      - right_elbow_joint
+      - right_wrist_roll_joint
+      - right_wrist_pitch_joint
+      - right_wrist_yaw_joint
+
+trajectory_execution:
+  # The arm_sdk gains are soft (kp 25-40), so the measured pose trails the commanded one by a
+  # few hundredths of a radian even at rest. MoveIt's 0.01 default reads that as "the robot is
+  # not where the plan starts" and refuses to execute. Never set this to 0, which disables the
+  # check rather than relaxing it.
+  allowed_start_tolerance: 0.05
+
+  execution_duration_monitoring: true
+  allowed_execution_duration_scaling: 2.0
+  # Matches the JTC's own goal_time: 5.0, so the two layers agree on how late is too late.
+  allowed_goal_duration_margin: 5.0
+  wait_for_trajectory_completion: true

--- a/workspace/src/g1_moveit_config/config/moveit_controllers.yaml
+++ b/workspace/src/g1_moveit_config/config/moveit_controllers.yaml
@@ -22,6 +22,8 @@ moveit_manage_controllers: false
 moveit_simple_controller_manager:
   controller_names:
     - arm_trajectory_controller
+    - left_hand_controller
+    - right_hand_controller
 
   arm_trajectory_controller:
     type: FollowJointTrajectory
@@ -44,6 +46,38 @@ moveit_simple_controller_manager:
       - right_wrist_roll_joint
       - right_wrist_pitch_joint
       - right_wrist_yaw_joint
+
+  # FollowJointTrajectory and not GripperCommand. MoveIt's GripperCommand path carries a single
+  # scalar and expects ros2_control's GripperActionController, which drives one joint plus a
+  # URDF mimic: a parallel-jaw gripper. A Dex3 has seven independent finger joints, so it is
+  # driven the way every multi-finger hand in MoveIt is, as a planning group with named
+  # postures. `default: false` because these are not the arm groups' fallback; MoveIt picks
+  # them by joint coverage when the plan is for left_hand or right_hand.
+  left_hand_controller:
+    type: FollowJointTrajectory
+    action_ns: follow_joint_trajectory
+    default: false
+    joints:
+      - left_hand_thumb_0_joint
+      - left_hand_thumb_1_joint
+      - left_hand_thumb_2_joint
+      - left_hand_middle_0_joint
+      - left_hand_middle_1_joint
+      - left_hand_index_0_joint
+      - left_hand_index_1_joint
+
+  right_hand_controller:
+    type: FollowJointTrajectory
+    action_ns: follow_joint_trajectory
+    default: false
+    joints:
+      - right_hand_thumb_0_joint
+      - right_hand_thumb_1_joint
+      - right_hand_thumb_2_joint
+      - right_hand_middle_0_joint
+      - right_hand_middle_1_joint
+      - right_hand_index_0_joint
+      - right_hand_index_1_joint
 
 trajectory_execution:
   # The arm_sdk gains are soft (kp 25-40), so the measured pose trails the commanded one by a

--- a/workspace/src/g1_moveit_config/config/ompl_planning.yaml
+++ b/workspace/src/g1_moveit_config/config/ompl_planning.yaml
@@ -1,0 +1,40 @@
+# OMPL planning pipeline. Hand-authored and short, rather than the ~200-line dump the Setup
+# Assistant emits listing every planner OMPL ships.
+
+planning_plugin: ompl_interface/OMPLPlanner
+
+request_adapters: >-
+  default_planner_request_adapters/AddTimeOptimalParameterization
+  default_planner_request_adapters/ResolveConstraintFrames
+  default_planner_request_adapters/FixWorkspaceBounds
+  default_planner_request_adapters/FixStartStateBounds
+  default_planner_request_adapters/FixStartStateCollision
+  default_planner_request_adapters/FixStartStatePathConstraints
+
+start_state_max_bounds_error: 0.1
+
+planner_configs:
+  RRTConnect:
+    type: geometric::RRTConnect
+    range: 0.0   # 0 lets OMPL pick from the state space extent
+
+left_arm:
+  planner_configs:
+    - RRTConnect
+  # Tighter than the 0.01 default: motion is validated by sampling along each segment, and the
+  # things these arms reach around are thin enough to pass between two validated states.
+  longest_valid_segment_fraction: 0.005
+
+right_arm:
+  planner_configs:
+    - RRTConnect
+  longest_valid_segment_fraction: 0.005
+
+both_arms:
+  planner_configs:
+    - RRTConnect
+  longest_valid_segment_fraction: 0.005
+  # One joint from each arm. RRTConnect does not use the projection, but OMPL warns and
+  # substitutes a random one when it is missing, and every published dual-arm config that
+  # skipped this ended up with a projection naming only one of the two arms.
+  projection_evaluator: joints(left_shoulder_pitch_joint,right_shoulder_pitch_joint)

--- a/workspace/src/g1_moveit_config/config/sensors_3d.yaml
+++ b/workspace/src/g1_moveit_config/config/sensors_3d.yaml
@@ -1,0 +1,67 @@
+# The 3D LiDAR into the planning scene, so move_group plans around what the robot can see.
+#
+# octomap_resolution is read at the NODE root, not inside a sensor block -- move_group's
+# to_dict() flat-merges this whole file into its parameters, which is the only reason a
+# top-level key here becomes a node parameter. Without it move_group logs "Resolution not
+# specified for Octomap. Assuming resolution = 0.1".
+#
+# octomap_frame is deliberately absent because it does nothing. startWorldGeometryMonitor()
+# constructs the monitor with scene_->getPlanningFrame(), which is never empty, so the branch
+# that would read octomap_frame is unreachable. The octomap always lands in the planning frame,
+# `pelvis` for us. That is correct while the pelvis is pinned or the robot stands still; a
+# walking pelvis drags the voxel grid with it and the map smears. The fix when that matters is
+# an SRDF virtual joint to odom, argued in g1.srdf, not a setting here.
+octomap_resolution: 0.025
+
+# `sensors` is a flat list of NAMES, each a sibling top-level key below. It is NOT a list of
+# dicts -- ROS 2 parameters cannot represent that, which is why the Humble perception tutorial
+# (still an unmigrated ROS 1 page, its source begins ":moveit1:") cannot be copied.
+sensors:
+  - mid360_cloud
+
+# PointCloudOctomapUpdater rather than DepthImageOctomapUpdater, and not by preference.
+# On 2.5.9 the depth-image plugin's initialize() runs BEFORE setParams()
+# (occupancy_map_monitor.cpp L97 then L100), and initialize() is where the clipping planes,
+# shadow threshold and padding are pushed into the mesh filter -- so none of its YAML ever
+# applies. Padding IS the self-filter, and an untunable self-filter is not usable. That plugin
+# also links OpenGL, which a CPU-only machine cannot load.
+#
+# Every key below is mandatory: setParams() ANDs all seven, and dropping one skips the sensor
+# with nothing but an error log. Keep the decimal points -- an int where a double is expected
+# throws out of the monitor constructor.
+mid360_cloud:
+  sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
+
+  # The LiDAR, not the depth camera, and that was not the first choice. The camera publishes a
+  # depth IMAGE, and turning it into a cloud needs depth_image_proc, whose point_cloud_xyz node
+  # would not receive from our relay: the relay publishes SensorDataQoS (best effort) and that
+  # node's image_transport subscription is reliable, so it sat silent with the image publishing
+  # at 10 Hz beside it. Remapping was correct (verified with `ros2 node info`) and a
+  # qos_overrides parameter did not take either -- the node does not enable QoS overriding on
+  # those subscriptions.
+  #
+  # The LiDAR sidesteps all of it: already a PointCloud2, and the octomap updater subscribes
+  # with rmw_qos_profile_sensor_data, which matches the relay. No converter node at all.
+  # docs/notes/moveit-depth-octomap-plan.md has what was tried on the camera path.
+  point_cloud_topic: /livox/lidar
+
+  # Past this a ray is carved as free space instead of marking an endpoint. The arms reach
+  # about 0.7 m, so this covers the workspace and a little beyond without mapping the far wall.
+  max_range: 2.5
+
+  # Every other point. The octomap resolution is 25 mm and the D435 returns far more points
+  # than that needs at these ranges.
+  point_subsample: 2
+
+  # Self-filter padding, applied to the robot's own URDF collision geometry. Generous on the
+  # multiplier because those meshes become convex hulls, and a hull of the rubber hand is
+  # already a fat blob -- nothing between the fingers will ever be mapped regardless.
+  padding_offset: 0.02
+  padding_scale: 1.2
+
+  # The planner does not need a 30 Hz map, and every update walks the shape mask.
+  max_update_rate: 5.0
+
+  # The self-filtered cloud, for seeing what the filter actually removed. Empty would simply
+  # skip the publisher.
+  filtered_cloud_topic: filtered_cloud

--- a/workspace/src/g1_moveit_config/launch/move_group.launch.py
+++ b/workspace/src/g1_moveit_config/launch/move_group.launch.py
@@ -41,6 +41,10 @@ def generate_launch_description():
             file_path=os.path.join(config_share, "config", "moveit_controllers.yaml")
         )
         .planning_pipelines(pipelines=["ompl"], default_planning_pipeline="ompl")
+        # Explicit, though the builder would find config/sensors_3d.yaml on its own: it guards
+        # the load with `if sensors_path.exists()`, so a wrong path is a silent no-op with no
+        # warning and no octomap. Naming it means a rename fails visibly instead.
+        .sensors_3d(file_path=os.path.join(config_share, "config", "sensors_3d.yaml"))
         .to_moveit_configs()
     )
 

--- a/workspace/src/g1_moveit_config/launch/move_group.launch.py
+++ b/workspace/src/g1_moveit_config/launch/move_group.launch.py
@@ -1,0 +1,60 @@
+"""move_group on its own: planning, no simulator.
+
+The control.launch.py analogue for manipulation -- nothing here is sim-specific, so this file is
+what carries over to hardware unchanged. moveit_sim.launch.py composes it with the simulator.
+
+move_group starts whether or not the arm is active. Planning only needs joint states, which
+joint_state_broadcaster publishes from the moment bring-up runs; executing needs the hardware
+component and the controller, which g1_bringup/scripts/activate_arm acquires in that order.
+Nothing in this file activates anything, and moveit_controllers.yaml sets
+moveit_manage_controllers: false so MoveIt will not either.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    # Every path is passed explicitly. MoveItConfigsBuilder will otherwise guess file names from
+    # the robot name and silently carry on when one is missing, which surfaces much later as an
+    # empty planning pipeline rather than as an error here.
+    description_share = get_package_share_directory("g1_description")
+    config_share = get_package_share_directory("g1_moveit_config")
+
+    moveit_config = (
+        MoveItConfigsBuilder("g1", package_name="g1_moveit_config")
+        # The same xacro control.launch.py feeds robot_state_publisher, so move_group plans
+        # against exactly the model the rest of the stack is running.
+        .robot_description(
+            file_path=os.path.join(description_share, "urdf", "g1_arm_sdk.urdf.xacro")
+        )
+        .robot_description_semantic(file_path=os.path.join(config_share, "config", "g1.srdf"))
+        .robot_description_kinematics(
+            file_path=os.path.join(config_share, "config", "kinematics.yaml")
+        )
+        .joint_limits(file_path=os.path.join(config_share, "config", "joint_limits.yaml"))
+        .trajectory_execution(
+            file_path=os.path.join(config_share, "config", "moveit_controllers.yaml")
+        )
+        .planning_pipelines(pipelines=["ompl"], default_planning_pipeline="ompl")
+        .to_moveit_configs()
+    )
+
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        name="move_group",
+        output="screen",
+        parameters=[
+            moveit_config.to_dict(),
+            # Publishes the SRDF on a topic, so RViz's MotionPlanning display picks it up
+            # instead of every consumer having to be handed the same parameter.
+            {"publish_robot_description_semantic": True},
+        ],
+    )
+
+    return LaunchDescription([move_group_node])

--- a/workspace/src/g1_moveit_config/launch/moveit_rviz.launch.py
+++ b/workspace/src/g1_moveit_config/launch/moveit_rviz.launch.py
@@ -1,0 +1,73 @@
+"""RViz with the MotionPlanning panel, for dragging the arms around by hand.
+
+A dedicated launcher rather than g1_bringup's rviz.launch.py, which takes only an rviz_config
+and passes no parameters. RViz resolves robot_description from robot_state_publisher's latched
+topic, but robot_description_semantic and robot_description_kinematics have no publisher
+anywhere -- move_group holds them as its own parameters. Without them the MotionPlanning panel
+loads and then sits there with no planning groups, which reads as a broken install rather than
+as missing configuration. So this file hands RViz the same config move_group got.
+
+Run it alongside a stack that is already up:
+
+    ros2 launch g1_moveit_config moveit_sim.launch.py pin_pelvis:=true headless:=false
+    ros2 launch g1_moveit_config moveit_rviz.launch.py
+
+Planning works immediately. Executing needs the arm acquired first, which is a separate,
+deliberate step:
+
+    ros2 launch g1_bringup activate_arm.launch.py
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+    description_share = get_package_share_directory("g1_description")
+    config_share = get_package_share_directory("g1_moveit_config")
+
+    # Same builder call as move_group.launch.py. RViz needs the semantic and kinematics
+    # descriptions; it does not need the controller or planning-pipeline configuration.
+    moveit_config = (
+        MoveItConfigsBuilder("g1", package_name="g1_moveit_config")
+        .robot_description(
+            file_path=os.path.join(description_share, "urdf", "g1_arm_sdk.urdf.xacro")
+        )
+        .robot_description_semantic(file_path=os.path.join(config_share, "config", "g1.srdf"))
+        .robot_description_kinematics(
+            file_path=os.path.join(config_share, "config", "kinematics.yaml")
+        )
+        .joint_limits(file_path=os.path.join(config_share, "config", "joint_limits.yaml"))
+        .planning_pipelines(pipelines=["ompl"], default_planning_pipeline="ompl")
+        .to_moveit_configs()
+    )
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2_moveit",
+        output="screen",
+        arguments=["-d", LaunchConfiguration("rviz_config")],
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics,
+            moveit_config.joint_limits,
+            moveit_config.planning_pipelines,
+        ],
+    )
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "rviz_config",
+            default_value=os.path.join(config_share, "config", "g1_moveit.rviz"),
+            description="RViz config to open. The default starts on the both_arms group.",
+        ),
+        rviz_node,
+    ])

--- a/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
+++ b/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
@@ -1,0 +1,88 @@
+"""The simulator plus move_group: one command for arm planning in sim.
+
+Includes g1_bringup rather than the other way round, the same direction as g1_navigation's
+nav_sim.launch.py. Manipulation sits above bring-up, and a moveit:=true argument on
+sim.launch.py would give g1_bringup a dependency on all of MoveIt.
+
+Every argument is forwarded EXPLICITLY, including ones whose values match this file's own
+defaults. An included launch file inherits the parent's configurations, so a child's
+DeclareLaunchArgument default never fires for anything declared here -- relying on it is how
+this stack has already shipped two silent bugs.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def _setup(context, *args, **kwargs):
+    bringup_launch = os.path.join(
+        get_package_share_directory("g1_bringup"), "launch", "sim.launch.py"
+    )
+    moveit_launch = os.path.join(
+        get_package_share_directory("g1_moveit_config"), "launch", "move_group.launch.py"
+    )
+
+    return [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(bringup_launch),
+            launch_arguments={
+                # Not optional. MoveIt refuses to plan until every active joint has a state,
+                # and the arms hang off three waist joints joint_state_broadcaster does not
+                # own -- so without this the model has no idea where the torso is pointing.
+                "non_arm_joint_states": "true",
+                # The LiDAR is not needed to plan, and g1_bringup's README records that
+                # sensors:=true cost test_arm_command its slew-limited convergence window.
+                # Manipulation executes the same kind of trajectory.
+                "sensors": "false",
+                "headless": LaunchConfiguration("headless"),
+                "world": LaunchConfiguration("world"),
+                "pin_pelvis": LaunchConfiguration("pin_pelvis"),
+                "waist_hold_rad": LaunchConfiguration("waist_hold_rad"),
+                "sim_start_delay_s": LaunchConfiguration("sim_start_delay_s"),
+                "rviz": "false",
+            }.items(),
+        ),
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(moveit_launch)),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "headless",
+            default_value="true",
+            description="false shows the MuJoCo viewer.",
+        ),
+        DeclareLaunchArgument(
+            "world",
+            default_value="navigation",
+            description="Which scene to stage. Only matters for what the robot can bump into; "
+            "nothing here reads the map.",
+        ),
+        DeclareLaunchArgument(
+            "pin_pelvis",
+            default_value="false",
+            description="SIM-ONLY: weld the pelvis and disable the walking policy, so the arms "
+            "can be exercised with nothing driving the legs. Worth it for planning work -- a "
+            "balancing robot sways, and the arm chain hangs off that.",
+        ),
+        DeclareLaunchArgument(
+            "waist_hold_rad",
+            default_value="",
+            description="SIM-ONLY: three comma-separated radians (yaw,roll,pitch) to stand the "
+            "waist at. Requires pin_pelvis:=true. Use it to check arm planning against a torso "
+            "that is not square to the pelvis.",
+        ),
+        DeclareLaunchArgument(
+            "sim_start_delay_s",
+            default_value="4.0",
+            description="Seconds to delay the simulator's start. Higher than sim.launch.py's "
+            "own default because move_group starts alongside and the machine is busier.",
+        ),
+        OpaqueFunction(function=_setup),
+    ])

--- a/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
+++ b/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
@@ -35,10 +35,11 @@ def _setup(context, *args, **kwargs):
                 # and the arms hang off three waist joints joint_state_broadcaster does not
                 # own -- so without this the model has no idea where the torso is pointing.
                 "non_arm_joint_states": "true",
-                # The LiDAR is not needed to plan, and g1_bringup's README records that
-                # sensors:=true cost test_arm_command its slew-limited convergence window.
-                # Manipulation executes the same kind of trajectory.
-                "sensors": "false",
+                # Off by default for the same reason as ever: g1_bringup's README records that
+                # sensors:=true cost test_arm_command its slew-limited convergence window, and
+                # manipulation executes the same kind of trajectory. Turning it on is what feeds
+                # the octomap -- there is no depth image without it.
+                "sensors": LaunchConfiguration("sensors"),
                 "headless": LaunchConfiguration("headless"),
                 "world": LaunchConfiguration("world"),
                 "pin_pelvis": LaunchConfiguration("pin_pelvis"),
@@ -48,6 +49,10 @@ def _setup(context, *args, **kwargs):
             }.items(),
         ),
         IncludeLaunchDescription(PythonLaunchDescriptionSource(moveit_launch)),
+        # No depth-to-cloud converter here. The octomap consumes /livox/lidar directly, which
+        # is already a PointCloud2 with QoS the updater matches; the camera path needs
+        # depth_image_proc and that node cannot receive from our best-effort relay. See
+        # config/sensors_3d.yaml.
     ]
 
 
@@ -63,6 +68,13 @@ def generate_launch_description():
             default_value="navigation",
             description="Which scene to stage. Only matters for what the robot can bump into; "
             "nothing here reads the map.",
+        ),
+        DeclareLaunchArgument(
+            "sensors",
+            default_value="false",
+            description="LiDAR, camera and the odom chain. Required for the octomap: without a "
+            "depth image there is nothing to build a planning scene from. Off by default "
+            "because it costs sim performance and manipulation does not otherwise need it.",
         ),
         DeclareLaunchArgument(
             "pin_pelvis",

--- a/workspace/src/g1_moveit_config/package.xml
+++ b/workspace/src/g1_moveit_config/package.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_moveit_config</name>
+  <version>0.1.0</version>
+  <description>
+    MoveIt 2 planning for the G1's two 7-DoF arms, layered on the arm_trajectory_controller
+    that already drives rt/arm_sdk. Configuration and launch only -- the nodes are upstream.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>g1_bringup</exec_depend>
+  <exec_depend>g1_description</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>moveit_configs_utils</exec_depend>
+  <exec_depend>moveit_kinematics</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <!-- The kinematics plugin both arm groups load; see config/kinematics.yaml for why not KDL. -->
+  <exec_depend>pick_ik</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <!-- ament_lint_common intentionally not used to avoid ruff conflicts. -->
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>control_msgs</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>moveit_core</test_depend>
+  <test_depend>moveit_msgs</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>tf2_ros</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_moveit_config/test/test_launch_threading.py
+++ b/workspace/src/g1_moveit_config/test/test_launch_threading.py
@@ -1,0 +1,218 @@
+"""Arguments must survive the include boundary bringup.launch.py's moveit branch introduces.
+
+The same failure mode g1_navigation's test_launch_threading exists for: an included launch
+file inherits the parent's configurations, so a wrong value arrives quietly and the launch
+looks successful. This file covers the half that one cannot.
+
+The split is forced, not stylistic. bringup's moveit branch calls
+get_package_share_directory("g1_moveit_config"), so those assertions cannot live in
+g1_navigation -- a workspace built without this package would hit the actionable RuntimeError
+instead of the assertion. The reverse holds for the navigation branch, which is why that
+package keeps its own copy.
+
+_run_setup / _includes / _included_path below are copied from
+g1_navigation/test/test_launch_threading.py rather than shared. They are test-only, they reach
+into launch internals that move only on a distro bump, and each file uses its own copy, so a
+drift between them cannot mislead anyone. Extracting them would mean giving g1_bringup a
+Python package it does not otherwise have, to save sixty lines once. If a third consumer
+appears, that trade flips: move them into an installed module in g1_bringup then.
+"""
+
+import importlib.util
+import os
+
+import pytest
+from ament_index_python.packages import PackageNotFoundError
+from launch import LaunchContext
+from launch.actions import IncludeLaunchDescription
+from launch.utilities import normalize_to_list_of_substitutions, perform_substitutions
+
+BRINGUP_LAUNCH_DIR = os.environ["G1_BRINGUP_LAUNCH_DIR"]
+MOVEIT_LAUNCH_DIR = os.environ["G1_MOVEIT_LAUNCH_DIR"]
+
+
+def _load(launch_dir, name):
+    path = os.path.join(launch_dir, name)
+    spec = importlib.util.spec_from_file_location(name.replace(".", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_setup(module, **configurations):
+    """Execute a launch file's OpaqueFunction body with the given arguments already set."""
+    context = LaunchContext()
+    for key, value in configurations.items():
+        context.launch_configurations[key] = value
+    for action in module.generate_launch_description().entities:
+        name = getattr(action, "name", None)
+        if name is not None and name not in context.launch_configurations:
+            default = getattr(action, "default_value", None)
+            if default is not None:
+                context.launch_configurations[name] = perform_substitutions(context, default)
+    return module._setup(context), context
+
+
+def _resolve(context, value):
+    if isinstance(value, str):
+        return value
+    return perform_substitutions(context, normalize_to_list_of_substitutions(value))
+
+
+def _included_path(context, action):
+    """The path an include points at, without loading it."""
+    subs = action.launch_description_source._LaunchDescriptionSource__location
+    return perform_substitutions(context, subs)
+
+
+def _includes(setup_result):
+    """Every IncludeLaunchDescription in a _run_setup result as (basename, {arg: value})."""
+    actions, context = setup_result
+    found = []
+    for action in actions:
+        if not isinstance(action, IncludeLaunchDescription):
+            continue
+        args = {
+            _resolve(context, k): _resolve(context, v) for k, v in action.launch_arguments
+        }
+        found.append((os.path.basename(_included_path(context, action)), args))
+    return found
+
+
+@pytest.fixture(scope="module")
+def bringup():
+    return _load(BRINGUP_LAUNCH_DIR, "bringup.launch.py")
+
+
+@pytest.fixture(scope="module")
+def moveit_sim():
+    return _load(MOVEIT_LAUNCH_DIR, "moveit_sim.launch.py")
+
+
+# --- bringup's moveit branch ----------------------------------------------------------
+
+
+def test_the_moveit_branch_stages_a_simulator_and_move_group(bringup):
+    names = [name for name, _ in _includes(_run_setup(bringup, mode="none", moveit="true"))]
+    assert names == ["sim.launch.py", "move_group.launch.py"]
+
+
+def test_moveit_demands_non_arm_joint_states(bringup):
+    """The coupling pin.
+
+    move_group refuses to plan until every active joint has a state, and the arms hang off
+    three waist joints joint_state_broadcaster does not own. Without this the stack comes up
+    looking healthy and every plan fails.
+    """
+    sim = dict(_includes(_run_setup(bringup, mode="none", moveit="true")))["sim.launch.py"]
+    assert sim["non_arm_joint_states"] == "true"
+
+
+def test_the_flag_is_not_offered_to_the_operator(bringup):
+    """moveit:=true cannot be talked out of the joint states it needs.
+
+    Declaring the name here would allow moveit:=true non_arm_joint_states:=false, which is a
+    move_group that starts healthy and then never plans. A bare launch still leaves the
+    decision to sim.launch.py's own default.
+    """
+    declared = [
+        name
+        for name in (
+            getattr(entity, "name", None)
+            for entity in bringup.generate_launch_description().entities
+        )
+        if name
+    ]
+    assert "moveit" in declared, "sanity: this is how the other assertion reads the arguments"
+    assert "non_arm_joint_states" not in declared
+
+    bare = dict(_includes(_run_setup(bringup, mode="none")))["sim.launch.py"]
+    assert "non_arm_joint_states" not in bare
+
+
+@pytest.mark.parametrize("mode", ["none", "localization"])
+def test_moveit_gets_the_loaded_start_delay(bringup, mode):
+    # move_group starts alongside the simulator, so even mode:=none is no longer a bare launch.
+    sim = dict(_includes(_run_setup(bringup, mode=mode, moveit="true")))["sim.launch.py"]
+    assert sim["sim_start_delay_s"] == "4.0"
+
+
+def test_moveit_rviz_wins_wherever_both_are_asked_for(bringup):
+    """Measured 2026-08-06, not chosen on taste.
+
+    Substituting g1_navigation.rviz into moveit_rviz.launch.py launches cleanly and leaves the
+    MotionPlanning panel absent -- the panel comes from the config's display list, and the nav
+    config has none. `ros2 node info` on that RViz showed no planning-scene subscription at
+    all. So MoveIt's own config is what runs, in every mode.
+    """
+    for mode in ("none", "localization"):
+        rviz = [
+            (name, args)
+            for name, args in _includes(
+                _run_setup(bringup, mode=mode, moveit="true", nav="false", rviz="true")
+            )
+            if "rviz" in name
+        ]
+        assert len(rviz) == 1, mode
+        assert rviz[0][0] == "moveit_rviz.launch.py", mode
+        # No rviz_config: bringup never declares that name, so the child's own default is the
+        # MoveIt config and there is nothing to inherit from.
+        assert rviz[0][1] == {}, mode
+
+
+def test_the_mode_config_still_wins_without_moveit(bringup):
+    rviz = dict(_includes(_run_setup(bringup, mode="localization", rviz="true")))
+    assert "rviz.launch.py" in rviz
+    assert rviz["rviz.launch.py"]["rviz_config"].endswith("g1_navigation/config/g1_navigation.rviz")
+
+
+def test_the_arm_development_combination_is_not_blocked(bringup):
+    """pin_pelvis is refused on the navigation modes but must stay available with MoveIt: a
+    balancing robot sways, and the whole arm chain hangs off the pelvis."""
+    sim = dict(
+        _includes(
+            _run_setup(
+                bringup,
+                mode="none",
+                moveit="true",
+                pin_pelvis="true",
+                waist_hold_rad="0.35,0.0,0.0",
+            )
+        )
+    )["sim.launch.py"]
+    assert sim["pin_pelvis"] == "true"
+    assert sim["waist_hold_rad"] == "0.35,0.0,0.0"
+
+
+def test_no_moveit_means_g1_moveit_config_is_never_named(bringup):
+    """Keeps a workspace without this package launchable, which is what the undeclared
+    dependency buys and what _moveit_share() would otherwise refuse."""
+    for mode in ("none", "localization"):
+        actions, context = _run_setup(bringup, mode=mode, rviz="true")
+        for action in actions:
+            if isinstance(action, IncludeLaunchDescription):
+                assert "g1_moveit_config" not in _included_path(context, action)
+
+
+def test_a_missing_package_is_reported_actionably(bringup, monkeypatch):
+    def absent(name):
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(bringup, "get_package_share_directory", absent)
+    with pytest.raises(RuntimeError, match="colcon build --packages-select g1_moveit_config"):
+        bringup._moveit_share()
+
+
+# --- the standalone wrapper, which this refactor must leave alone ---------------------
+
+
+def test_moveit_sim_still_composes_the_same_two_pieces(moveit_sim):
+    includes = _includes(_run_setup(moveit_sim))
+    assert [name for name, _ in includes] == ["sim.launch.py", "move_group.launch.py"]
+
+    sim = dict(includes)["sim.launch.py"]
+    assert sim["non_arm_joint_states"] == "true"
+    # The other copy of each fact bringup states; if these drift, one path plans and the other
+    # silently does not.
+    assert sim["sensors"] == "false"
+    assert sim["rviz"] == "false"

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -1,0 +1,163 @@
+"""Numbers that must agree across packages, where neither package's own tests can see the pair.
+
+Same blind spot test_gait_coupling and test_rviz_configs exist for: MoveIt's idea of the arm
+lives here, the controller's lives in g1_bringup, and the bridge's speed clamp lives in
+g1_description. Nothing but a test that reads all three notices when they drift apart.
+
+No simulator, no ROS graph.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+import yaml
+
+MOVEIT_CONFIG_DIR = os.environ["G1_MOVEIT_CONFIG_DIR"]
+BRINGUP_CONFIG_DIR = os.environ["G1_BRINGUP_CONFIG_DIR"]
+DESCRIPTION_CONFIG_DIR = os.environ["G1_DESCRIPTION_CONFIG_DIR"]
+
+ARM_JOINTS = [
+    f"{side}_{joint}_joint"
+    for side in ("left", "right")
+    for joint in (
+        "shoulder_pitch", "shoulder_roll", "shoulder_yaw", "elbow",
+        "wrist_roll", "wrist_pitch", "wrist_yaw",
+    )
+]
+
+
+def _load(directory, name):
+    with open(os.path.join(directory, name)) as handle:
+        return yaml.safe_load(handle)
+
+
+@pytest.fixture(scope="module")
+def moveit_controllers():
+    return _load(MOVEIT_CONFIG_DIR, "moveit_controllers.yaml")
+
+
+@pytest.fixture(scope="module")
+def controllers():
+    return _load(BRINGUP_CONFIG_DIR, "controllers.yaml")
+
+
+@pytest.fixture(scope="module")
+def joint_limits():
+    return _load(MOVEIT_CONFIG_DIR, "joint_limits.yaml")["joint_limits"]
+
+
+@pytest.fixture(scope="module")
+def kinematics():
+    return _load(MOVEIT_CONFIG_DIR, "kinematics.yaml")
+
+
+@pytest.fixture(scope="module")
+def srdf():
+    return ET.parse(os.path.join(MOVEIT_CONFIG_DIR, "g1.srdf")).getroot()
+
+
+def test_the_srdf_is_well_formed_xml(srdf):
+    """It has already been unparseable once.
+
+    XML forbids a double hyphen inside a comment, the SRDF is comment-heavy, and no linter in
+    this workspace reads .srdf -- ament_xmllint only looks at .xml. The failure surfaces as
+    move_group dying at launch with a column number.
+    """
+    assert srdf.tag == "robot"
+
+
+def test_moveit_drives_the_controller_bringup_actually_runs(moveit_controllers, controllers):
+    mine = moveit_controllers["moveit_simple_controller_manager"]["arm_trajectory_controller"]
+    theirs = controllers["arm_trajectory_controller"]["ros__parameters"]
+    assert mine["joints"] == theirs["joints"], (
+        "g1_moveit_config and g1_bringup disagree about which joints arm_trajectory_controller "
+        "owns; MoveIt would plan for joints the controller will refuse"
+    )
+
+
+def test_moveit_never_manages_controllers(moveit_controllers):
+    """Acquiring the arm is ordered and safety-critical; it belongs to activate_arm alone."""
+    assert moveit_controllers["moveit_manage_controllers"] is False
+
+
+def test_partial_joint_goals_stay_enabled(controllers):
+    """The single-arm groups are 7 joints; the controller has 14.
+
+    With this false the JTC rejects any goal that does not name all of them, so every left_arm
+    or right_arm plan fails at execution.
+    """
+    params = controllers["arm_trajectory_controller"]["ros__parameters"]
+    assert params["allow_partial_joints_goal"] is True
+
+
+def test_planned_speed_stays_under_the_bridge_clamp(joint_limits):
+    """The clamp is a backstop, not a controller in the loop.
+
+    g1_hardware_interface slew-clamps every joint; plan faster than that and the motion is
+    silently stretched until the controller aborts on a goal-time tolerance instead.
+    """
+    arm_sdk = _load(DESCRIPTION_CONFIG_DIR, "arm_sdk_params.yaml")
+    clamp = arm_sdk["system"]["max_joint_velocity_rad_s"]
+    for joint, limits in joint_limits.items():
+        assert limits["has_velocity_limits"] is True, joint
+        assert limits["max_velocity"] < clamp, (
+            f"{joint} plans at {limits['max_velocity']} rad/s against a {clamp} rad/s clamp"
+        )
+
+
+def test_every_arm_joint_has_an_acceleration_limit(joint_limits):
+    """The URDF declares none, and time parameterization fails without them.
+
+    The plan comes back successful carrying zero timestamps, and only execution notices.
+    """
+    for joint, limits in joint_limits.items():
+        assert limits["has_acceleration_limits"] is True, joint
+        assert limits["max_acceleration"] > 0.0, joint
+
+
+def test_joint_limits_cover_exactly_the_arm(joint_limits):
+    assert sorted(joint_limits) == sorted(ARM_JOINTS)
+
+
+def test_chain_groups_have_a_solver_and_the_composite_one_does_not(srdf, kinematics):
+    """The composite group must NOT appear in kinematics.yaml.
+
+    pick_ik rejects any group that is not a chain, and MoveIt only builds the per-subgroup
+    solver map for groups that have no solver of their own. Naming both_arms here suppresses
+    that map, which is what breaks dual-arm pose goals. It is the most-copied mistake in
+    published dual-arm configs, so it is asserted rather than left to a comment.
+    """
+    for group in srdf.findall("group"):
+        name = group.get("name")
+        if group.find("chain") is not None:
+            assert name in kinematics, f"chain group {name} has no kinematics solver"
+        if group.find("group") is not None:
+            assert name not in kinematics, (
+                f"composite group {name} has a kinematics.yaml entry; that suppresses the "
+                "subgroup solver map and breaks its IK"
+            )
+
+
+def test_the_dual_arm_group_spans_both_arms(srdf):
+    composite = [g for g in srdf.findall("group") if g.find("group") is not None]
+    assert len(composite) == 1, "expected exactly one composite group"
+    members = {g.get("name") for g in composite[0].findall("group")}
+    assert members == {"left_arm", "right_arm"}
+
+
+def test_no_config_here_claims_simulated_time():
+    """There is no /clock on this track: the simulator links no ROS.
+
+    Same trap g1_navigation/test/test_no_sim_time.py exists for. A node given use_sim_time gets
+    a clock that never advances, which surfaces as TF lookups failing somewhere unrelated.
+    """
+    offenders = []
+    for name in os.listdir(MOVEIT_CONFIG_DIR):
+        if not name.endswith((".yaml", ".rviz")):
+            continue
+        with open(os.path.join(MOVEIT_CONFIG_DIR, name)) as handle:
+            for number, line in enumerate(handle, start=1):
+                if "use_sim_time" in line and "true" in line.lower():
+                    offenders.append(f"{name}:{number}")
+    assert not offenders, f"use_sim_time enabled in {offenders}"

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -161,3 +161,81 @@ def test_no_config_here_claims_simulated_time():
                 if "use_sim_time" in line and "true" in line.lower():
                     offenders.append(f"{name}:{number}")
     assert not offenders, f"use_sim_time enabled in {offenders}"
+
+
+# --- sensors_3d.yaml -------------------------------------------------------------------
+#
+# The octomap updater fails quietly in more ways than most MoveIt config. setParams() ANDs its
+# seven required keys and skips the sensor with only an error log if one is missing; a wrong
+# type throws out of the monitor constructor; and MoveItConfigsBuilder guards the whole file
+# with `if sensors_path.exists()`, so a rename is a silent no-op. None of that shows up as a
+# failed launch -- you get a stack that comes up healthy and never builds a map.
+
+POINTCLOUD_PLUGIN = "occupancy_map_monitor/PointCloudOctomapUpdater"
+DEPTH_IMAGE_PLUGIN = "occupancy_map_monitor/DepthImageOctomapUpdater"
+
+# Every one is mandatory: setParams() returns false without it and the sensor is dropped.
+REQUIRED_POINTCLOUD_KEYS = {
+    "sensor_plugin", "point_cloud_topic", "max_range", "point_subsample",
+    "padding_offset", "padding_scale", "max_update_rate", "filtered_cloud_topic",
+}
+# Written as YAML floats. An int here throws InvalidParameterTypeException out of the
+# OccupancyMapMonitor constructor, which reads as a launch crash with no mention of this file.
+MUST_BE_FLOAT = ("max_range", "padding_offset", "padding_scale", "max_update_rate")
+
+
+@pytest.fixture(scope="module")
+def sensors_3d():
+    return _load(MOVEIT_CONFIG_DIR, "sensors_3d.yaml")
+
+
+def test_the_octomap_resolution_is_set_at_the_top_level(sensors_3d):
+    """move_group reads it as a node parameter, which only works because to_dict() flat-merges
+    this file. Unset, it silently assumes 0.1 m and logs a warning most people scroll past."""
+    assert isinstance(sensors_3d.get("octomap_resolution"), float)
+    assert 0.0 < sensors_3d["octomap_resolution"] < 0.5
+
+
+def test_octomap_frame_is_not_set(sensors_3d):
+    """It would be inert and therefore misleading. startWorldGeometryMonitor() constructs the
+    monitor with the planning frame, which is never empty, so the branch reading octomap_frame
+    is unreachable. Anyone setting it would think they had moved the map."""
+    assert "octomap_frame" not in sensors_3d
+
+
+def test_sensors_is_a_flat_list_of_names(sensors_3d):
+    """Not a list of dicts. ROS 2 parameters cannot represent that, which is what makes the
+    Humble perception tutorial (an unmigrated ROS 1 page) impossible to copy."""
+    names = sensors_3d.get("sensors")
+    assert isinstance(names, list) and names
+    for name in names:
+        assert isinstance(name, str) and name, f"{name!r} is not a sensor name"
+        assert isinstance(sensors_3d.get(name), dict), f"no top-level block for sensor {name!r}"
+
+
+def test_every_sensor_block_is_fully_specified(sensors_3d):
+    for name in sensors_3d["sensors"]:
+        block = sensors_3d[name]
+        plugin = block.get("sensor_plugin")
+        assert plugin in (POINTCLOUD_PLUGIN, DEPTH_IMAGE_PLUGIN), f"{name}: {plugin!r}"
+        assert plugin != DEPTH_IMAGE_PLUGIN, (
+            f"{name} uses the depth-image updater. On 2.5.9 its initialize() runs before "
+            "setParams(), so the clipping planes, shadow threshold and padding never reach the "
+            "mesh filter -- and padding is the self-filter."
+        )
+        missing = REQUIRED_POINTCLOUD_KEYS - set(block)
+        assert not missing, f"{name} is missing {sorted(missing)}; the sensor is skipped silently"
+        for key in MUST_BE_FLOAT:
+            assert isinstance(block[key], float), (
+                f"{name}.{key} is {type(block[key]).__name__}, not float -- write it with a "
+                "decimal point or the monitor constructor throws"
+            )
+        assert block["point_cloud_topic"].startswith("/"), f"{name}: topic must be absolute"
+
+
+def test_the_self_filter_padding_is_not_disabled(sensors_3d):
+    """Padding IS the self-filter margin. At zero the robot's own arms get mapped as obstacles
+    the moment a link's TF is a little late."""
+    for name in sensors_3d["sensors"]:
+        assert sensors_3d[name]["padding_scale"] >= 1.0, f"{name} shrinks the robot's own shapes"
+        assert sensors_3d[name]["padding_offset"] >= 0.0

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -26,6 +26,17 @@ ARM_JOINTS = [
     )
 ]
 
+# Dex3 wire order. HandCmd.motor_cmd is a positional array, so this order is the contract and
+# not a convention: the SRDF group, the controller and the hardware component must all agree.
+HAND_JOINTS = {
+    side: [
+        f"{side}_hand_{joint}_joint"
+        for joint in ("thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1",
+                      "index_0", "index_1")
+    ]
+    for side in ("left", "right")
+}
+
 
 def _load(directory, name):
     with open(os.path.join(directory, name)) as handle:
@@ -91,15 +102,23 @@ def test_partial_joint_goals_stay_enabled(controllers):
     assert params["allow_partial_joints_goal"] is True
 
 
-def test_planned_speed_stays_under_the_bridge_clamp(joint_limits):
+@pytest.mark.parametrize(
+    ("params_file", "joints"),
+    [
+        ("arm_sdk_params.yaml", ARM_JOINTS),
+        ("dex3_params.yaml", HAND_JOINTS["left"] + HAND_JOINTS["right"]),
+    ],
+)
+def test_planned_speed_stays_under_the_bridge_clamp(joint_limits, params_file, joints):
     """The clamp is a backstop, not a controller in the loop.
 
-    g1_hardware_interface slew-clamps every joint; plan faster than that and the motion is
-    silently stretched until the controller aborts on a goal-time tolerance instead.
+    Both hardware components slew-clamp every joint they own; plan faster than that and the
+    motion is silently stretched until the controller aborts on a goal-time tolerance instead.
+    The arm and the hands clamp at different speeds, so each is checked against its own.
     """
-    arm_sdk = _load(DESCRIPTION_CONFIG_DIR, "arm_sdk_params.yaml")
-    clamp = arm_sdk["system"]["max_joint_velocity_rad_s"]
-    for joint, limits in joint_limits.items():
+    clamp = _load(DESCRIPTION_CONFIG_DIR, params_file)["system"]["max_joint_velocity_rad_s"]
+    for joint in joints:
+        limits = joint_limits[joint]
         assert limits["has_velocity_limits"] is True, joint
         assert limits["max_velocity"] < clamp, (
             f"{joint} plans at {limits['max_velocity']} rad/s against a {clamp} rad/s clamp"
@@ -116,8 +135,61 @@ def test_every_arm_joint_has_an_acceleration_limit(joint_limits):
         assert limits["max_acceleration"] > 0.0, joint
 
 
-def test_joint_limits_cover_exactly_the_arm(joint_limits):
-    assert sorted(joint_limits) == sorted(ARM_JOINTS)
+def test_joint_limits_cover_exactly_what_we_command(joint_limits):
+    """Everything we own and nothing we do not: the arms plus both hands.
+
+    A joint missing here is timed against no limit at all; a leg or waist joint appearing here
+    would claim a limit on something the onboard controller owns.
+    """
+    expected = ARM_JOINTS + HAND_JOINTS["left"] + HAND_JOINTS["right"]
+    assert sorted(joint_limits) == sorted(expected)
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_the_hand_agrees_across_srdf_controller_and_moveit(
+    side, srdf, controllers, moveit_controllers
+):
+    """Four files have to name the same seven joints in the same order.
+
+    The JTC itself remaps by name, but G1Dex3System does not: it writes HandCmd.motor_cmd
+    positionally and refuses to init on a mismatch, so a reordering here would either fail
+    loudly at startup or, if the guard were ever relaxed, close the wrong fingers.
+    """
+    group = next(g for g in srdf.findall("group") if g.get("name") == f"{side}_hand")
+    controller = f"{side}_hand_controller"
+
+    assert [j.get("name") for j in group.findall("joint")] == HAND_JOINTS[side]
+    assert controllers[controller]["ros__parameters"]["joints"] == HAND_JOINTS[side]
+    assert (
+        moveit_controllers["moveit_simple_controller_manager"][controller]["joints"]
+        == HAND_JOINTS[side]
+    )
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_the_hand_is_driven_as_a_trajectory_not_a_gripper_command(side, moveit_controllers):
+    """GripperCommand carries one scalar and expects a one-joint controller.
+
+    A Dex3 has seven independent finger joints, so it is driven as a planning group with named
+    postures. Switching this to GripperCommand would leave six of them uncommanded.
+    """
+    entry = moveit_controllers["moveit_simple_controller_manager"][f"{side}_hand_controller"]
+    assert entry["type"] == "FollowJointTrajectory"
+    assert entry["default"] is False
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_each_hand_has_an_open_and_a_closed_posture(side, srdf):
+    """The whole vocabulary a pick and place needs, and both must name all seven joints."""
+    states = {
+        s.get("name"): s
+        for s in srdf.findall("group_state")
+        if s.get("group") == f"{side}_hand"
+    }
+    assert set(states) == {"open", "closed"}
+    for name, state in states.items():
+        named = {j.get("name") for j in state.findall("joint")}
+        assert named == set(HAND_JOINTS[side]), f"{side} {name} does not cover the hand"
 
 
 def test_chain_groups_have_a_solver_and_the_composite_one_does_not(srdf, kinematics):

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -16,6 +16,7 @@ import yaml
 MOVEIT_CONFIG_DIR = os.environ["G1_MOVEIT_CONFIG_DIR"]
 BRINGUP_CONFIG_DIR = os.environ["G1_BRINGUP_CONFIG_DIR"]
 DESCRIPTION_CONFIG_DIR = os.environ["G1_DESCRIPTION_CONFIG_DIR"]
+SIM_CONFIG_DIR = os.environ["G1_SIM_CONFIG_DIR"]
 
 ARM_JOINTS = [
     f"{side}_{joint}_joint"
@@ -194,6 +195,30 @@ def test_each_hand_has_an_open_and_a_closed_posture(side, srdf):
     for name, state in states.items():
         named = {j.get("name") for j in state.findall("joint")}
         assert named == set(HAND_JOINTS[side]), f"{side} {name} does not cover the hand"
+
+
+def test_the_simulator_holds_the_arms_at_home(srdf):
+    """`home` claims to be where the simulator holds the arms. This is what makes it true.
+
+    The claim used to run the other way, `home` being a measurement of wherever the arms fell
+    at startup, and that is how it drifted to within hundredths of putting the palm against the
+    thigh once the hands had their real mass. Now motion_service_sim is told the posture and
+    this pins the pair. See docs/notes/hand-mass-rest-pose.md.
+    """
+    sim = _load(SIM_CONFIG_DIR, "motion_service_sim.yaml")["/**"]["ros__parameters"]
+    home = next(
+        s for s in srdf.findall("group_state")
+        if s.get("name") == "home" and s.get("group") == "both_arms"
+    )
+    expected = [float(j.get("value")) for j in home.findall("joint")]
+    assert [j.get("name") for j in home.findall("joint")] == ARM_JOINTS, (
+        "the both_arms `home` state no longer lists the joints in motor order, so comparing it "
+        "positionally against arm_hold_rad would compare the wrong pairs"
+    )
+    assert sim["arm_hold_rad"] == pytest.approx(expected), (
+        "motion_service_sim holds the arms somewhere other than `home`; the simulator's resting "
+        "posture and the pose MoveIt calls home have drifted apart"
+    )
 
 
 def test_chain_groups_have_a_solver_and_the_composite_one_does_not(srdf, kinematics):

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -149,11 +149,15 @@ def test_joint_limits_cover_exactly_what_we_command(joint_limits):
 def test_the_hand_agrees_across_srdf_controller_and_moveit(
     side, srdf, controllers, moveit_controllers
 ):
-    """Four files have to name the same seven joints in the same order.
+    """Three files have to name the same seven joints in the same order.
 
     The JTC itself remaps by name, but G1Dex3System does not: it writes HandCmd.motor_cmd
     positionally and refuses to init on a mismatch, so a reordering here would either fail
     loudly at startup or, if the guard were ever relaxed, close the wrong fingers.
+
+    MoveIt's own RobotModel sorts a joint-list group alphabetically and will not report this
+    order back; see test_robot_model. That is what makes reading it from the files the only
+    way to pin it.
     """
     group = next(g for g in srdf.findall("group") if g.get("name") == f"{side}_hand")
     controller = f"{side}_hand_controller"

--- a/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
@@ -169,8 +169,9 @@ class TestMoveItPlanExecute(unittest.TestCase):
         for name in BOTH_ARMS:
             self.assertIn(name, self.joint_state)
         self.assertIn("waist_yaw_joint", self.joint_state)
-        # The hands have no motor and no controller; they are published at zero precisely so
-        # MoveIt's state monitor sees a complete robot.
+        # Finger state comes from the hand components via joint_state_broadcaster, which
+        # publishes them while they are merely configured. MoveIt will not plan until every
+        # active joint has a state, so this is a precondition, not a detail.
         self.assertIn("left_hand_index_0_joint", self.joint_state)
 
     # 2. The precondition for every waist assertion below. Without it the waist tests would

--- a/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
@@ -46,6 +46,14 @@ LEFT_ARM = [
 RIGHT_ARM = [name.replace("left_", "right_") for name in LEFT_ARM]
 BOTH_ARMS = LEFT_ARM + RIGHT_ARM
 
+LEFT_HAND = [
+    f"left_hand_{suffix}_joint"
+    for suffix in ("thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1", "index_0", "index_1")
+]
+# The `closed` group state from g1.srdf, restated rather than read out of it: a test that took
+# its expectation from the file under test would pass no matter what that file said.
+LEFT_HAND_CLOSED = dict(zip(LEFT_HAND, [-0.30, -0.50, 1.20, -1.20, -1.40, -1.20, -1.40]))
+
 # g1_description/config/arm_sdk_params.yaml. joint_limits.yaml plans under this; the test proves
 # the cap actually binds rather than trusting the two files agree.
 MAX_JOINT_VELOCITY_RAD_S = 1.0
@@ -146,6 +154,13 @@ class TestMoveItPlanExecute(unittest.TestCase):
             constraint.weight = 1.0
             constraints.joint_constraints.append(constraint)
         goal.request.goal_constraints = [constraints]
+        return goal
+
+    def _absolute_joint_goal(self, group, targets):
+        """Same goal, but to a named posture rather than a nudge away from where we are."""
+        goal = self._joint_goal(group, list(targets), 0.0)
+        for constraint in goal.request.goal_constraints[0].joint_constraints:
+            constraint.position = targets[constraint.joint_name]
         return goal
 
     def _send_move_goal(self, goal, timeout_s=90.0):
@@ -287,7 +302,40 @@ class TestMoveItPlanExecute(unittest.TestCase):
                 "torso_link and the model at pelvis; this is the waist transform disagreeing.",
             )
 
-    # 7. Release, so the suite leaves the channel as it found it.
-    def test_08_the_arm_releases_cleanly(self):
+    # 7. The gripper, through the same plan-and-execute path the arm uses.
+    def test_08_the_hand_closes_and_opens_through_moveit(self):
+        """A Dex3 is seven joints, so MoveIt drives it as a group, not as a GripperCommand.
+
+        The whole chain is under test here and only the last hop differs on hardware:
+        move_group plans, left_hand_controller executes, G1Dex3System publishes HandCmd, and
+        the fingers that come back on /joint_states are the ones the simulator actually moved.
+        """
+        before = {name: self.joint_state[name] for name in LEFT_HAND}
+
+        result = self._send_move_goal(self._absolute_joint_goal("left_hand", LEFT_HAND_CLOSED))
+        self.assertIsNotNone(result, "left_hand closed goal was rejected")
+        self.assertEqual(
+            result.error_code.val, 1,
+            f"closing the left hand failed with error_code {result.error_code.val}",
+        )
+        self._spin(2.0)
+
+        for name, target in LEFT_HAND_CLOSED.items():
+            self.assertAlmostEqual(
+                self.joint_state[name], target, delta=0.05,
+                msg=f"{name} is at {self.joint_state[name]:.3f}, commanded {target:.3f}",
+            )
+        moved = max(abs(self.joint_state[n] - before[n]) for n in LEFT_HAND)
+        self.assertGreater(moved, 0.1, "no finger moved; the grasp was a no-op")
+
+        # Back to open, so the hand is left where the rest of the suite found it.
+        result = self._send_move_goal(
+            self._absolute_joint_goal("left_hand", dict.fromkeys(LEFT_HAND, 0.0))
+        )
+        self.assertIsNotNone(result, "left_hand open goal was rejected")
+        self.assertEqual(result.error_code.val, 1, "opening the left hand failed")
+
+    # 8. Release, so the suite leaves the channel as it found it.
+    def test_09_the_arm_releases_cleanly(self):
         self._run_ros2_run("deactivate_arm")
         self._spin(3.0)

--- a/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
@@ -1,0 +1,292 @@
+"""Headless sim integration test: planning and executing through move_group.
+
+Covers the properties that only exist once every layer is running together, and that no config
+test can see: that MoveIt refuses to execute before the arm is acquired, that a coordinated
+14-joint both_arms plan reaches the controller as one trajectory, that planned motion respects
+the bridge's speed clamp, and that the arm chain is placed correctly when the waist is NOT at
+zero -- the case a robot standing square hides completely.
+
+Run via `colcon test --packages-select g1_moveit_config`.
+"""
+
+import math
+import os
+import subprocess
+import time
+import unittest
+
+import launch_testing.actions
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from moveit_msgs.action import MoveGroup
+from moveit_msgs.msg import Constraints, JointConstraint, RobotState
+from moveit_msgs.srv import GetPositionFK
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from tf2_ros import Buffer, TransformListener
+
+# Same reasoning as g1_bringup's suites: under launch_testing's hardcoded 15 s process-startup
+# deadline. move_group needs longer than the bridge alone, so the sim start is delayed further
+# by moveit_sim.launch.py rather than by raising this.
+SIM_SETTLE_S = 12.0
+
+# Held by motion_service_sim's stiff-hold, not commanded by anything in this stack. Large enough
+# that ignoring it would displace the hands by roughly 10 cm, far outside the tolerances below.
+WAIST_HOLD_YAW_RAD = 0.35
+
+LEFT_ARM = [
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint", "left_shoulder_yaw_joint",
+    "left_elbow_joint", "left_wrist_roll_joint", "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+]
+RIGHT_ARM = [name.replace("left_", "right_") for name in LEFT_ARM]
+BOTH_ARMS = LEFT_ARM + RIGHT_ARM
+
+# g1_description/config/arm_sdk_params.yaml. joint_limits.yaml plans under this; the test proves
+# the cap actually binds rather than trusting the two files agree.
+MAX_JOINT_VELOCITY_RAD_S = 1.0
+
+# The full robot: 12 legs + 3 waist + 14 arms + 14 hand joints.
+EXPECTED_JOINT_COUNT = 43
+
+
+def generate_test_description():
+    return LaunchDescription([
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory("g1_moveit_config"),
+                    "launch",
+                    "moveit_sim.launch.py",
+                )
+            ),
+            launch_arguments={
+                # Pinned so the arm is exercised against a base that is not swaying.
+                "pin_pelvis": "true",
+                "waist_hold_rad": f"{WAIST_HOLD_YAW_RAD},0.0,0.0",
+            }.items(),
+        ),
+        TimerAction(period=SIM_SETTLE_S, actions=[launch_testing.actions.ReadyToTest()]),
+    ])
+
+
+class TestMoveItPlanExecute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_moveit_plan_execute")
+        cls.joint_state = {}
+        cls.peak_velocity = 0.0
+        cls.node.create_subscription(JointState, "/joint_states", cls._joint_cb, 20)
+        cls.tf_buffer = Buffer()
+        cls.tf_listener = TransformListener(cls.tf_buffer, cls.node)
+        cls.move_client = ActionClient(cls.node, MoveGroup, "/move_action")
+        cls.fk_client = cls.node.create_client(GetPositionFK, "/compute_fk")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def _joint_cb(cls, msg):
+        for name, position in zip(msg.name, msg.position, strict=False):
+            cls.joint_state[name] = position
+        # Velocity is shorter than name on some publishers, so this must not be strict.
+        for name, velocity in zip(msg.name, msg.velocity, strict=False):
+            if name in BOTH_ARMS:
+                cls.peak_velocity = max(cls.peak_velocity, abs(velocity))
+
+    def _spin(self, seconds):
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def _spin_until(self, predicate, timeout_s, message):
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if predicate():
+                return
+        self.fail(message)
+
+    def _run_ros2_run(self, executable, timeout_s=40.0):
+        proc = subprocess.Popen(
+            ["ros2", "run", "g1_bringup", executable],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        deadline = time.monotonic() + timeout_s
+        while proc.poll() is None and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+        stdout, stderr = proc.communicate(timeout=10.0)
+        self.assertEqual(proc.returncode, 0, f"{executable} failed:\n{stdout}\n{stderr}")
+
+    def _joint_goal(self, group, joints, offset):
+        goal = MoveGroup.Goal()
+        goal.request.group_name = group
+        goal.request.num_planning_attempts = 5
+        goal.request.allowed_planning_time = 10.0
+        # Under the joint_limits.yaml caps, which are themselves under the bridge clamp.
+        goal.request.max_velocity_scaling_factor = 0.5
+        goal.request.max_acceleration_scaling_factor = 0.5
+        goal.request.start_state = RobotState()
+        goal.request.start_state.is_diff = True
+
+        constraints = Constraints()
+        for name in joints:
+            constraint = JointConstraint()
+            constraint.joint_name = name
+            constraint.position = self.joint_state[name] + offset
+            constraint.tolerance_above = 0.02
+            constraint.tolerance_below = 0.02
+            constraint.weight = 1.0
+            constraints.joint_constraints.append(constraint)
+        goal.request.goal_constraints = [constraints]
+        return goal
+
+    def _send_move_goal(self, goal, timeout_s=90.0):
+        send = self.move_client.send_goal_async(goal)
+        self._spin_until(send.done, 20.0, "move_group never answered the goal request")
+        handle = send.result()
+        if handle is None or not handle.accepted:
+            return None
+        result = handle.get_result_async()
+        self._spin_until(result.done, timeout_s, "move_group never returned a result")
+        return result.result().result
+
+    # 1. The stack is up and the robot state is complete.
+    def test_01_every_joint_has_a_state(self):
+        self._spin_until(
+            lambda: len(self.joint_state) >= EXPECTED_JOINT_COUNT,
+            60.0,
+            f"only {len(self.joint_state)} joints on /joint_states; MoveIt will not plan until "
+            f"every active joint has a state (expected {EXPECTED_JOINT_COUNT})",
+        )
+        for name in BOTH_ARMS:
+            self.assertIn(name, self.joint_state)
+        self.assertIn("waist_yaw_joint", self.joint_state)
+        # The hands have no motor and no controller; they are published at zero precisely so
+        # MoveIt's state monitor sees a complete robot.
+        self.assertIn("left_hand_index_0_joint", self.joint_state)
+
+    # 2. The precondition for every waist assertion below. Without it the waist tests would
+    #    still pass while proving nothing.
+    def test_02_the_waist_is_actually_turned(self):
+        self._spin(2.0)
+        waist = self.joint_state["waist_yaw_joint"]
+        self.assertGreater(
+            abs(waist), 0.2,
+            f"waist_yaw is {waist:.3f} rad; the torso is square to the pelvis and the frame "
+            "assertions below would hold even if MoveIt ignored the waist entirely",
+        )
+
+    def test_03_move_group_is_serving(self):
+        self.assertTrue(
+            self.move_client.wait_for_server(timeout_sec=30.0), "no /move_action server"
+        )
+        self.assertTrue(
+            self.fk_client.wait_for_service(timeout_sec=30.0), "no /compute_fk service"
+        )
+
+    # 3. The safety property: nothing executes until the arm is deliberately acquired.
+    def test_04_execution_is_refused_before_the_arm_is_acquired(self):
+        result = self._send_move_goal(self._joint_goal("left_arm", LEFT_ARM, 0.05))
+        self.assertIsNotNone(result, "move_group rejected the goal outright")
+        # 1 is SUCCESS. Anything else is the controller refusing, which is what should happen
+        # while G1ArmSdkSystem is inactive and the JTC is not running.
+        self.assertNotEqual(
+            result.error_code.val, 1,
+            "MoveIt executed a trajectory before activate_arm; the acquire step is the whole "
+            "safety model for this arm",
+        )
+
+    # 4. Coordinated dual-arm motion: one plan, one trajectory, both arms.
+    def test_05_both_arms_plan_and_execute_together(self):
+        self._run_ros2_run("activate_arm")
+        self._spin(3.0)
+        self.peak_velocity = 0.0
+
+        before = {name: self.joint_state[name] for name in BOTH_ARMS}
+        result = self._send_move_goal(self._joint_goal("both_arms", BOTH_ARMS, 0.08))
+        self.assertIsNotNone(result, "both_arms goal was rejected")
+        self.assertEqual(
+            result.error_code.val, 1,
+            f"both_arms plan+execute failed with error_code {result.error_code.val}",
+        )
+        self._spin(2.0)
+
+        # Both arms moved, which is what separates this from a single-arm plan that happened to
+        # be accepted by a 14-joint controller.
+        for side, joints in (("left", LEFT_ARM), ("right", RIGHT_ARM)):
+            moved = max(abs(self.joint_state[n] - before[n]) for n in joints)
+            self.assertGreater(moved, 0.02, f"{side} arm did not move during a both_arms plan")
+
+    # 5. The cross-package coupling this milestone introduces.
+    def test_06_planned_motion_respects_the_bridge_clamp(self):
+        # Well above the jitter a stiff-held arm shows at rest, so this cannot pass on noise
+        # while the plan above quietly failed to execute.
+        self.assertGreater(
+            self.peak_velocity, 0.05,
+            "no real arm motion was observed; the velocity bound below would pass vacuously",
+        )
+        self.assertLess(
+            self.peak_velocity, MAX_JOINT_VELOCITY_RAD_S,
+            f"peak commanded arm velocity {self.peak_velocity:.3f} rad/s reached the "
+            f"{MAX_JOINT_VELOCITY_RAD_S} rad/s slew clamp; joint_limits.yaml is not binding and "
+            "the bridge is silently stretching the trajectory",
+        )
+
+    # 6. The waist test proper: MoveIt's own kinematics against TF's, with the torso turned.
+    def test_07_moveit_places_the_hands_where_tf_does_with_the_waist_turned(self):
+        """The pelvis-rooted model and the torso-rooted groups have to agree about the waist.
+
+        MoveIt roots its model at pelvis and its arm groups at torso_link, with three waist
+        joints in between that nothing here commands. If it did not fold the live waist state
+        into that transform, its idea of where a hand is would be wrong by roughly the arm
+        reach times sin(waist), about 10 cm at this angle. robot_state_publisher computes the
+        same transform through an entirely separate KDL path, so agreement is the check.
+        """
+        self._spin(2.0)
+        state = JointState()
+        for name, position in self.joint_state.items():
+            state.name.append(name)
+            state.position.append(position)
+
+        for link in ("left_hand_palm_link", "right_hand_palm_link"):
+            request = GetPositionFK.Request()
+            request.header.frame_id = "pelvis"
+            request.fk_link_names = [link]
+            request.robot_state.joint_state = state
+
+            future = self.fk_client.call_async(request)
+            self._spin_until(future.done, 20.0, f"/compute_fk never answered for {link}")
+            response = future.result()
+            self.assertEqual(
+                response.error_code.val, 1, f"/compute_fk failed for {link}"
+            )
+            self.assertEqual(len(response.pose_stamped), 1)
+            moveit_pose = response.pose_stamped[0].pose.position
+
+            transform = self.tf_buffer.lookup_transform(
+                "pelvis", link, rclpy.time.Time()
+            ).transform.translation
+
+            distance = math.dist(
+                (moveit_pose.x, moveit_pose.y, moveit_pose.z),
+                (transform.x, transform.y, transform.z),
+            )
+            self.assertLess(
+                distance, 0.005,
+                f"MoveIt puts {link} {distance * 100:.1f} cm from where TF does, with the waist "
+                f"at {self.joint_state['waist_yaw_joint']:.3f} rad. The arm groups are rooted at "
+                "torso_link and the model at pelvis; this is the waist transform disagreeing.",
+            )
+
+    # 7. Release, so the suite leaves the channel as it found it.
+    def test_08_the_arm_releases_cleanly(self):
+        self._run_ros2_run("deactivate_arm")
+        self._spin(3.0)

--- a/workspace/src/g1_moveit_config/test/test_octomap_blocks_a_plan.launch.py
+++ b/workspace/src/g1_moveit_config/test/test_octomap_blocks_a_plan.launch.py
@@ -1,0 +1,213 @@
+"""The octomap has to actually stop a plan, not merely exist.
+
+A non-empty octomap proves the sensor is wired up. It does not prove MoveIt is collision
+checking against it, and those are separate failures: the updater can be filling a map that the
+planning scene never consults, and everything looks healthy.
+
+So this drives a hand at `reach_obstacle`, the box g1_bringup's perception scene puts 0.42 m in
+front of the chest, and asserts the state is rejected as colliding -- then asserts the same
+state is fine with sensors off, which is the control. Without that second half the test would
+pass just as well against a pose that self-collides.
+
+pin_pelvis because the octomap lands in the planning frame, `pelvis`, and a pelvis that moves
+drags the voxel grid with it (config/sensors_3d.yaml). Pinned, the map is stationary and the
+result is deterministic.
+"""
+
+import os
+import sys
+import unittest
+
+import launch_testing
+import pytest
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from moveit_msgs.msg import PlanningSceneComponents, RobotState
+from moveit_msgs.srv import GetPlanningScene, GetPositionFK, GetStateValidity
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+# Matches test_moveit_plan_execute. Longer than this and launch_testing's own startup timeout
+# fires first -- it kills the whole launch with "Timed out waiting for processes to start up"
+# and every test reports "Launch stopped before the active tests finished", which looks like a
+# stack failure and is not one. The octomap needs far longer than 12 s to fill; that wait
+# belongs inside the tests, where the timeout is ours to choose.
+SIM_SETTLE_S = 12.0
+ARM_JOINTS = [
+    f"{side}_{joint}"
+    for side in ("left", "right")
+    for joint in (
+        "shoulder_pitch_joint", "shoulder_roll_joint", "shoulder_yaw_joint", "elbow_joint",
+        "wrist_roll_joint", "wrist_pitch_joint", "wrist_yaw_joint",
+    )
+]
+
+# Reaches the right hand forward into where reach_obstacle sits. Chosen by measurement, not by
+# eye: test_octomap_blocks_a_plan fails loudly if it turns out to be self-colliding with
+# sensors off, which is exactly what the control assertion is for.
+REACH_INTO_BOX = {
+    "right_shoulder_pitch_joint": -1.45,
+    "right_shoulder_roll_joint": -0.10,
+    "right_shoulder_yaw_joint": 0.0,
+    "right_elbow_joint": 0.10,
+}
+
+
+def _stack(sensors):
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("g1_moveit_config"), "launch", "moveit_sim.launch.py"
+            )
+        ),
+        launch_arguments={
+            "sensors": sensors,
+            "pin_pelvis": "true",
+            "world": "perception",
+            "headless": "true",
+        }.items(),
+    )
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    return LaunchDescription([
+        _stack("true"),
+        TimerAction(period=SIM_SETTLE_S, actions=[launch_testing.actions.ReadyToTest()]),
+    ])
+
+
+class TestOctomapBlocksAPlan(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("octomap_block_probe")
+        cls.joints = {}
+        cls.node.create_subscription(JointState, "/joint_states", cls._joints_cb, 20)
+        cls.validity = cls.node.create_client(GetStateValidity, "/check_state_validity")
+        cls.scene = cls.node.create_client(GetPlanningScene, "/get_planning_scene")
+        cls.fk = cls.node.create_client(GetPositionFK, "/compute_fk")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def _joints_cb(cls, msg):
+        for name, position in zip(msg.name, msg.position, strict=False):
+            cls.joints[name] = position
+
+    def _spin_until(self, predicate, timeout_s, message):
+        end = self.node.get_clock().now().nanoseconds + int(timeout_s * 1e9)
+        while self.node.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if predicate():
+                return
+        self.fail(message)
+
+    def _validity(self, overrides):
+        state = JointState()
+        for name, position in self.joints.items():
+            state.name.append(name)
+            state.position.append(overrides.get(name, position))
+        request = GetStateValidity.Request()
+        request.robot_state = RobotState()
+        request.robot_state.joint_state = state
+        request.robot_state.is_diff = False
+        request.group_name = "right_arm"
+        future = self.validity.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=30.0)
+        self.assertIsNotNone(future.result(), "/check_state_validity never answered")
+        return future.result()
+
+    def test_01_the_octomap_is_populated(self):
+        self._spin_until(lambda: len(self.joints) >= 43, 90.0, "joint states never arrived")
+        self.assertTrue(self.scene.wait_for_service(timeout_sec=60.0))
+        self.assertTrue(self.validity.wait_for_service(timeout_sec=60.0))
+
+        def has_octomap():
+            request = GetPlanningScene.Request()
+            request.components.components = PlanningSceneComponents.OCTOMAP
+            future = self.scene.call_async(request)
+            rclpy.spin_until_future_complete(self.node, future, timeout_sec=15.0)
+            result = future.result()
+            if result is None:
+                return False
+            octomap = result.scene.world.octomap
+            if not octomap.octomap.data:
+                return False
+            # The frame is the planning frame, never octomap_frame -- pinned here because a
+            # change would silently move every voxel relative to the robot.
+            self.assertEqual(octomap.header.frame_id, "pelvis")
+            return True
+
+        self._spin_until(has_octomap, 120.0, "the octomap never filled from /livox/lidar")
+
+    def _palm_in_pelvis(self, overrides):
+        state = JointState()
+        for name, position in self.joints.items():
+            state.name.append(name)
+            state.position.append(overrides.get(name, position))
+        request = GetPositionFK.Request()
+        request.header.frame_id = "pelvis"
+        request.fk_link_names = ["right_hand_palm_link"]
+        request.robot_state.joint_state = state
+        future = self.fk.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=20.0)
+        result = future.result()
+        if result is None or not result.pose_stamped:
+            return None
+        return result.pose_stamped[0].pose.position
+
+    def test_02_reaching_into_the_mapped_box_is_rejected(self):
+        # Where the palm actually ends up, so a failure says whether the pose missed the slab
+        # or the octomap is simply not being checked. reach_obstacle is x 0.28 +/- 0.10 and
+        # z 1.25 +/- 0.25 in world; the pelvis is pinned near 0.755, so in this frame that is
+        # x 0.18 to 0.38 and z 0.245 to 0.745.
+        self.assertTrue(self.fk.wait_for_service(timeout_sec=30.0))
+        palm = self._palm_in_pelvis(REACH_INTO_BOX)
+        self.assertIsNotNone(palm, "/compute_fk gave no pose")
+        inside = 0.18 <= palm.x <= 0.38 and abs(palm.y) <= 0.45 and 0.245 <= palm.z <= 0.745
+        self.node.get_logger().info(
+            f"PALM AT x={palm.x:.3f} y={palm.y:.3f} z={palm.z:.3f} inside_slab={inside}"
+        )
+        self.assertTrue(
+            inside,
+            f"the test pose puts the palm at ({palm.x:.3f}, {palm.y:.3f}, {palm.z:.3f}), which is "
+            "outside reach_obstacle -- fix the pose or the scene, this says nothing about the "
+            "octomap",
+        )
+
+        result = self._validity(REACH_INTO_BOX)
+        self.assertFalse(
+            result.valid,
+            "reaching into reach_obstacle was accepted -- the octomap exists but the planning "
+            "scene is not collision checking against it",
+        )
+        # An octomap collision names <octomap> as one body; a self-collision names two links.
+        # Without this the test would pass on a pose that merely self-collides.
+        bodies = {c.contact_body_1 for c in result.contacts} | {
+            c.contact_body_2 for c in result.contacts
+        }
+        self.assertIn(
+            "<octomap>", bodies, f"rejected, but not by the octomap; contacts were {bodies}"
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestCleanShutdown(unittest.TestCase):
+    def test_no_process_died_badly(self, proc_info):
+        # 130 is SIGINT through the shell wrapper control.launch.py uses; -11 is move_group's
+        # own teardown segfault in MoveItCpp's destructor, which happens after every run and is
+        # not this test's business.
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, 130, -2, -6, -9, -11, -15]
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -119,9 +119,10 @@ TEST_F(RobotModelTest, TheDualArmGroupIsNotAChainAndHasBothArmsAsSubgroups)
 
 TEST_F(RobotModelTest, NoArmGroupCommandsTheHand)
 {
-    // The hand is a separate controllable group with its own API (docs/CONTROL_MODES.md), and
-    // nothing in this stack can command a finger. A group that reached into one would plan
-    // motion that silently never executes.
+    // The hand is a separate device on its own topics with its own authority
+    // (docs/CONTROL_MODES.md), and it has its own group and its own controller. An arm group
+    // that reached into one would plan a trajectory no single controller can execute, so
+    // MoveIt would either split it or refuse it.
     for (const auto* name : { "left_arm", "right_arm", "both_arms" })
     {
         const auto* group = model_->getJointModelGroup(name);
@@ -156,10 +157,16 @@ TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
     const auto& states = srdf_->getGroupStates();
     ASSERT_FALSE(states.empty()) << "no named poses in g1.srdf";
 
+    const std::set<std::string> arm_groups = { "left_arm", "right_arm", "both_arms" };
+
     std::map<std::string, std::map<std::string, double>> by_pose;
     std::map<std::string, int>                           group_count;
     for (const auto& state : states)
     {
+        if (arm_groups.count(state.group_) == 0)
+        {
+            continue;  // the hand postures are two groups, not three; see below
+        }
         group_count[state.name_]++;
         for (const auto& [joint, values] : state.joint_values_)
         {
@@ -178,6 +185,73 @@ TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
         EXPECT_EQ(count, 3) << "pose '" << pose << "' should exist for left_arm, right_arm and "
                             << "both_arms";
         EXPECT_EQ(by_pose[pose].size(), 14u) << "pose '" << pose << "' should name all 14 joints";
+    }
+}
+
+TEST_F(RobotModelTest, EachHandIsExactlyItsSevenFingerJoints)
+{
+    // A SET, not a sequence, and that is the point worth recording: a group declared as a joint
+    // list comes back SORTED, not in document order, where a chain group keeps chain order. So
+    // left_hand reads index, middle, thumb here while the wire, the URDF component and the
+    // controller all say thumb, middle, index.
+    //
+    // Harmless as long as nothing lines a MoveIt trajectory up against HandCmd positionally:
+    // the JTC remaps by name, and G1Dex3System takes its order from the URDF. The wire order
+    // itself is pinned in g1_description's xacro test and in test_moveit_config_drift.
+    for (const auto* side : { "left", "right" })
+    {
+        const auto* hand = model_->getJointModelGroup(std::string(side) + "_hand");
+        ASSERT_NE(hand, nullptr) << side;
+
+        std::set<std::string> expected;
+        for (const auto* suffix :
+             { "thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1", "index_0", "index_1" })
+        {
+            expected.insert(std::string(side) + "_hand_" + suffix + "_joint");
+        }
+        const auto& actual = hand->getActiveJointModelNames();
+        EXPECT_EQ(std::set<std::string>(actual.begin(), actual.end()), expected);
+    }
+}
+
+TEST_F(RobotModelTest, EachHandIsItsArmsEndEffector)
+{
+    // What lets attachObject work out its own touch links, and what makes RViz offer the hand
+    // as the arm's gripper rather than as an unrelated group.
+    std::map<std::string, srdf::Model::EndEffector> by_group;
+    for (const auto& effector : srdf_->getEndEffectors())
+    {
+        by_group.emplace(effector.component_group_, effector);
+    }
+    ASSERT_EQ(by_group.size(), 2u) << "expected one end effector per hand";
+
+    for (const auto* side : { "left", "right" })
+    {
+        const auto it = by_group.find(std::string(side) + "_hand");
+        ASSERT_NE(it, by_group.end()) << side;
+        EXPECT_EQ(it->second.parent_link_, std::string(side) + "_hand_palm_link");
+        EXPECT_EQ(it->second.parent_group_, std::string(side) + "_arm");
+    }
+}
+
+TEST_F(RobotModelTest, EachHandHasAnOpenAndAClosedPosture)
+{
+    // Two per hand, and each must name all seven joints: a posture that leaves a finger out
+    // moves the rest and leaves that one wherever it happened to be.
+    std::map<std::string, std::set<std::string>> poses_by_group;
+    for (const auto& state : srdf_->getGroupStates())
+    {
+        if (state.group_ == "left_hand" || state.group_ == "right_hand")
+        {
+            poses_by_group[state.group_].insert(state.name_);
+            EXPECT_EQ(state.joint_values_.size(), 7u)
+                << state.group_ << " posture '" << state.name_ << "' does not cover the hand";
+        }
+    }
+    for (const auto* side : { "left", "right" })
+    {
+        EXPECT_EQ(poses_by_group[std::string(side) + "_hand"],
+                  (std::set<std::string>{ "open", "closed" }));
     }
 }
 

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -231,6 +231,17 @@ TEST_F(RobotModelTest, AdjacentLinksAreDisabled)
         {
             continue;
         }
+        // Only pairs that can actually collide need disabling. The sensor bodies added in
+        // g1_arm_sdk.urdf.xacro are visual-only on purpose, so they carry no collision shapes
+        // and MoveIt never checks them; requiring them here would pad the matrix with entries
+        // that mean nothing.
+        const auto* parent_link = model_->getLinkModel(parent);
+        const auto* child_link  = model_->getLinkModel(child);
+        if (parent_link == nullptr || child_link == nullptr || parent_link->getShapes().empty() ||
+            child_link->getShapes().empty())
+        {
+            continue;
+        }
         // Links joined by a joint touch by construction. This is the category a careless hand
         // edit drops, and dropping it makes every plan start in collision.
         EXPECT_TRUE(disabled.count({ parent, child }) > 0)

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -7,16 +7,17 @@
  */
 
 #include <gmock/gmock.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <srdfdom/model.h>
+#include <urdf_parser/urdf_parser.h>
 
 #include <fstream>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
-
-#include <moveit/robot_model/robot_model.h>
-#include <srdfdom/model.h>
-#include <urdf_parser/urdf_parser.h>
 
 using ::testing::ElementsAreArray;
 
@@ -58,8 +59,8 @@ protected:
         ASSERT_TRUE(model_);
     }
 
-    std::shared_ptr<srdf::Model>                  srdf_;
-    std::shared_ptr<moveit::core::RobotModel>     model_;
+    std::shared_ptr<srdf::Model>              srdf_;
+    std::shared_ptr<moveit::core::RobotModel> model_;
 };
 
 TEST_F(RobotModelTest, PlansInThePelvisFrame)
@@ -72,7 +73,7 @@ TEST_F(RobotModelTest, PlansInThePelvisFrame)
 
 TEST_F(RobotModelTest, EachArmIsSevenJointsInOrder)
 {
-    const auto* left = model_->getJointModelGroup("left_arm");
+    const auto* left  = model_->getJointModelGroup("left_arm");
     const auto* right = model_->getJointModelGroup("right_arm");
     ASSERT_NE(left, nullptr);
     ASSERT_NE(right, nullptr);
@@ -148,6 +149,61 @@ TEST_F(RobotModelTest, ArmsAreRootedAtTheTorsoNotThePelvis)
     }
 }
 
+TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
+{
+    // SRDF group states belong to one group, so each pose is written three times. A skill that
+    // sends left_arm to "ready" and one that sends both_arms there must reach the same place.
+    const auto& states = srdf_->getGroupStates();
+    ASSERT_FALSE(states.empty()) << "no named poses in g1.srdf";
+
+    std::map<std::string, std::map<std::string, double>> by_pose;
+    std::map<std::string, int>                           group_count;
+    for (const auto& state : states)
+    {
+        group_count[state.name_]++;
+        for (const auto& [joint, values] : state.joint_values_)
+        {
+            ASSERT_EQ(values.size(), 1u) << joint << " in " << state.name_;
+            auto [it, fresh] = by_pose[state.name_].emplace(joint, values.front());
+            if (!fresh)
+            {
+                EXPECT_DOUBLE_EQ(it->second, values.front())
+                    << "pose '" << state.name_ << "' sets " << joint << " differently in group '"
+                    << state.group_ << "' than in another group -- the copies have drifted";
+            }
+        }
+    }
+    for (const auto& [pose, count] : group_count)
+    {
+        EXPECT_EQ(count, 3) << "pose '" << pose << "' should exist for left_arm, right_arm and "
+                            << "both_arms";
+        EXPECT_EQ(by_pose[pose].size(), 14u) << "pose '" << pose << "' should name all 14 joints";
+    }
+}
+
+TEST_F(RobotModelTest, TheNamedPosesAreWithinJointLimits)
+{
+    // Collision-freedom was checked live against move_group before these were written down;
+    // limits are checkable here, and a pose outside them is a plan that fails at request time.
+    const auto* both = model_->getJointModelGroup("both_arms");
+    ASSERT_NE(both, nullptr);
+    moveit::core::RobotState state(model_);
+    for (const auto& srdf_state : srdf_->getGroupStates())
+    {
+        if (srdf_state.group_ != "both_arms")
+        {
+            continue;
+        }
+        state.setToDefaultValues();
+        for (const auto& [joint, values] : srdf_state.joint_values_)
+        {
+            state.setJointPositions(joint, values);
+        }
+        EXPECT_TRUE(state.satisfiesBounds(both))
+            << "named pose '" << srdf_state.name_ << "' is outside the joint limits";
+    }
+}
+
 TEST_F(RobotModelTest, TheCollisionMatrixExists)
 {
     // Deliberately a conservative matrix: adjacent pairs plus what touches at rest, and nothing
@@ -170,7 +226,7 @@ TEST_F(RobotModelTest, AdjacentLinksAreDisabled)
     {
         (void)name;
         const auto& parent = joint->parent_link_name;
-        const auto& child = joint->child_link_name;
+        const auto& child  = joint->child_link_name;
         if (parent.empty() || child.empty())
         {
             continue;
@@ -203,8 +259,8 @@ TEST_F(RobotModelTest, TheArmsCanStillCollideWithEachOther)
             const bool one = pair.link1_.find(reaching) != std::string::npos;
             const bool two = pair.link2_.find(reaching) != std::string::npos;
             EXPECT_FALSE(one && two)
-                << "cross-arm collision disabled between " << pair.link1_ << " and "
-                << pair.link2_ << ", which dual-arm planning depends on";
+                << "cross-arm collision disabled between " << pair.link1_ << " and " << pair.link2_
+                << ", which dual-arm planning depends on";
         }
     }
 }

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -1,0 +1,211 @@
+/**
+ * @file test_robot_model.cpp
+ * @brief Loads the URDF and SRDF the way move_group does and asserts what the groups came out as.
+ *
+ * No simulator, no ROS graph. The SRDF is prose plus a generated block, and both are easy to
+ * break in ways that only show up as a plan quietly failing much later.
+ */
+
+#include <gmock/gmock.h>
+
+#include <fstream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <moveit/robot_model/robot_model.h>
+#include <srdfdom/model.h>
+#include <urdf_parser/urdf_parser.h>
+
+using ::testing::ElementsAreArray;
+
+namespace
+{
+constexpr const char* kUrdfPath = G1_TEST_URDF_PATH;
+constexpr const char* kSrdfPath = G1_TEST_SRDF_PATH;
+
+const std::vector<std::string> kLeftArm = {
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint", "left_shoulder_yaw_joint",
+    "left_elbow_joint",          "left_wrist_roll_joint",    "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+};
+
+const std::vector<std::string> kRightArm = {
+    "right_shoulder_pitch_joint", "right_shoulder_roll_joint", "right_shoulder_yaw_joint",
+    "right_elbow_joint",          "right_wrist_roll_joint",    "right_wrist_pitch_joint",
+    "right_wrist_yaw_joint",
+};
+
+/// The links that can actually reach each other. Their cross-arm collision pairs are the whole
+/// reason the both_arms group exists, so they must never end up disabled.
+const std::vector<std::string> kReachingLinks = {
+    "elbow_link", "wrist_roll_link", "wrist_pitch_link", "wrist_yaw_link", "hand_palm_link",
+};
+
+class RobotModelTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        auto urdf = urdf::parseURDFFile(kUrdfPath);
+        ASSERT_TRUE(urdf) << "could not parse " << kUrdfPath;
+
+        srdf_ = std::make_shared<srdf::Model>();
+        ASSERT_TRUE(srdf_->initFile(*urdf, kSrdfPath)) << "could not parse " << kSrdfPath;
+
+        model_ = std::make_shared<moveit::core::RobotModel>(urdf, srdf_);
+        ASSERT_TRUE(model_);
+    }
+
+    std::shared_ptr<srdf::Model>                  srdf_;
+    std::shared_ptr<moveit::core::RobotModel>     model_;
+};
+
+TEST_F(RobotModelTest, PlansInThePelvisFrame)
+{
+    // The vendored URDF's floating_base_joint is commented out and g1.srdf declares no virtual
+    // joint, so the model root is the pelvis. Pinned because adding a virtual joint later moves
+    // every pose goal without any other visible change.
+    EXPECT_EQ(model_->getModelFrame(), "pelvis");
+}
+
+TEST_F(RobotModelTest, EachArmIsSevenJointsInOrder)
+{
+    const auto* left = model_->getJointModelGroup("left_arm");
+    const auto* right = model_->getJointModelGroup("right_arm");
+    ASSERT_NE(left, nullptr);
+    ASSERT_NE(right, nullptr);
+    EXPECT_THAT(left->getActiveJointModelNames(), ElementsAreArray(kLeftArm));
+    EXPECT_THAT(right->getActiveJointModelNames(), ElementsAreArray(kRightArm));
+}
+
+TEST_F(RobotModelTest, TheDualArmGroupIsBothArmsTogether)
+{
+    const auto* both = model_->getJointModelGroup("both_arms");
+    ASSERT_NE(both, nullptr);
+
+    std::vector<std::string> expected = kLeftArm;
+    expected.insert(expected.end(), kRightArm.begin(), kRightArm.end());
+    // Order is the URDF's depth-first joint order, which puts the left arm first. Asserted
+    // rather than assumed: a trajectory is matched to the controller by name, but anything
+    // reading joint values positionally depends on this.
+    EXPECT_THAT(both->getActiveJointModelNames(), ElementsAreArray(expected));
+}
+
+TEST_F(RobotModelTest, TheDualArmGroupIsNotAChainAndHasBothArmsAsSubgroups)
+{
+    const auto* both = model_->getJointModelGroup("both_arms");
+    ASSERT_NE(both, nullptr);
+
+    // This is the root reason both_arms must stay out of kinematics.yaml: every chain solver,
+    // pick_ik included, refuses a group that is not a chain, and MoveIt only builds the
+    // per-subgroup solver map for groups that have no solver of their own.
+    EXPECT_FALSE(both->isChain()) << "both_arms is a chain, so the subgroup IK story is wrong";
+
+    // The map is keyed on subgroups, so there have to be exactly the two arms to key it on.
+    // Whether the map itself was populated needs a plugin loader and a live node, so it is
+    // asserted in test_moveit_config_drift (the YAML rule) and against a running move_group.
+    std::vector<const moveit::core::JointModelGroup*> sub_groups;
+    both->getSubgroups(sub_groups);
+    std::set<std::string> subgroups;
+    for (const auto* subgroup : sub_groups)
+    {
+        subgroups.insert(subgroup->getName());
+    }
+    EXPECT_EQ(subgroups, (std::set<std::string>{ "left_arm", "right_arm" }));
+}
+
+TEST_F(RobotModelTest, NoArmGroupCommandsTheHand)
+{
+    // The hand is a separate controllable group with its own API (docs/CONTROL_MODES.md), and
+    // nothing in this stack can command a finger. A group that reached into one would plan
+    // motion that silently never executes.
+    for (const auto* name : { "left_arm", "right_arm", "both_arms" })
+    {
+        const auto* group = model_->getJointModelGroup(name);
+        ASSERT_NE(group, nullptr) << name;
+        for (const auto& joint : group->getActiveJointModelNames())
+        {
+            EXPECT_EQ(joint.find("_hand_"), std::string::npos)
+                << name << " contains the hand joint " << joint;
+        }
+    }
+}
+
+TEST_F(RobotModelTest, ArmsAreRootedAtTheTorsoNotThePelvis)
+{
+    // Spanning the waist would plan motion the onboard controller owns.
+    for (const auto* name : { "left_arm", "right_arm" })
+    {
+        const auto* group = model_->getJointModelGroup(name);
+        ASSERT_NE(group, nullptr) << name;
+        for (const auto& joint : group->getActiveJointModelNames())
+        {
+            EXPECT_EQ(joint.find("waist"), std::string::npos)
+                << name << " spans the waist joint " << joint;
+        }
+    }
+}
+
+TEST_F(RobotModelTest, TheCollisionMatrixExists)
+{
+    // Deliberately a conservative matrix: adjacent pairs plus what touches at rest, and nothing
+    // found by random sampling. Enough that the robot is not in collision before it moves, which
+    // is what RRTConnect needs to seed. The bound is a floor, not a target.
+    EXPECT_GT(srdf_->getDisabledCollisionPairs().size(), 40u)
+        << "g1.srdf carries no generated collision matrix; see the package README";
+}
+
+TEST_F(RobotModelTest, AdjacentLinksAreDisabled)
+{
+    std::set<std::pair<std::string, std::string>> disabled;
+    for (const auto& pair : srdf_->getDisabledCollisionPairs())
+    {
+        disabled.insert({ pair.link1_, pair.link2_ });
+        disabled.insert({ pair.link2_, pair.link1_ });
+    }
+
+    for (const auto& [name, joint] : model_->getURDF()->joints_)
+    {
+        (void)name;
+        const auto& parent = joint->parent_link_name;
+        const auto& child = joint->child_link_name;
+        if (parent.empty() || child.empty())
+        {
+            continue;
+        }
+        // Links joined by a joint touch by construction. This is the category a careless hand
+        // edit drops, and dropping it makes every plan start in collision.
+        EXPECT_TRUE(disabled.count({ parent, child }) > 0)
+            << "adjacent pair " << parent << " / " << child << " is not disabled";
+    }
+}
+
+TEST_F(RobotModelTest, TheArmsCanStillCollideWithEachOther)
+{
+    // The safety property that makes both_arms worth having. Proximal cross-arm pairs are
+    // legitimately disabled (two shoulders cannot reach each other), but anything from the
+    // elbow out must stay checked, or a coordinated plan can drive the hands through one
+    // another and report success.
+    for (const auto& pair : srdf_->getDisabledCollisionPairs())
+    {
+        const bool left_then_right =
+            pair.link1_.rfind("left_", 0) == 0 && pair.link2_.rfind("right_", 0) == 0;
+        const bool right_then_left =
+            pair.link1_.rfind("right_", 0) == 0 && pair.link2_.rfind("left_", 0) == 0;
+        if (!left_then_right && !right_then_left)
+        {
+            continue;
+        }
+        for (const auto& reaching : kReachingLinks)
+        {
+            const bool one = pair.link1_.find(reaching) != std::string::npos;
+            const bool two = pair.link2_.find(reaching) != std::string::npos;
+            EXPECT_FALSE(one && two)
+                << "cross-arm collision disabled between " << pair.link1_ << " and "
+                << pair.link2_ << ", which dual-arm planning depends on";
+        }
+    }
+}
+}  // namespace

--- a/workspace/src/g1_navigation/README.md
+++ b/workspace/src/g1_navigation/README.md
@@ -22,14 +22,22 @@ flowchart TB
 
 | File | Purpose |
 |---|---|
-| `nav_sim.launch.py` | This package's orchestrator. Composes the simulator, the scan pipeline, and either SLAM or localization. |
+| `nav_stack.launch.py` | The stack itself, with no simulator: the shared container, the scan pipeline, SLAM or localization, and Nav2 when asked. What `g1_bringup` includes. |
+| `nav_sim.launch.py` | Standalone wrapper: a simulator, `nav_stack.launch.py`, and RViz. What the integration suites launch. |
 | `scan.launch.py` | `pointcloud_to_laserscan`, flattening the LiDAR into the 2D scan SLAM and AMCL consume. |
 | `slam.launch.py` | `slam_toolbox` in online async mapping mode. |
 | `localization.launch.py` | `map_server` and AMCL against the committed map. |
-| `nav2.launch.py` | Nav2 itself: planner, controller, behaviours, BT navigator, lifecycle manager. |
+| `nav2.launch.py` | Nav2 itself: planner, controller, behaviours, BT navigator, lifecycle manager. One of the pieces `nav_stack.launch.py` composes, and only when `nav:=true`. |
 
-The operator entry point is `g1_bringup`'s, matching `nav2_bringup`. `nav_sim.launch.py` still runs
-directly if you want it.
+The operator entry point is `g1_bringup`'s, matching `nav2_bringup`. It stages the simulator itself
+and includes `nav_stack.launch.py` directly, so nothing here has to bundle a simulator on its
+behalf. `nav_sim.launch.py` is that same stack with a simulator and RViz attached, for running
+navigation on its own; it exposes `use_composition`, `container_name` and `map`, which the bring-up
+entry point does not.
+
+`nav_stack.launch.py` deliberately stages no simulator. Both callers stage exactly one, and a
+second would put two writers on `/lowcmd`; `test_launch_threading` asserts the absence rather than
+trusting it.
 
 ## Running
 
@@ -122,7 +130,7 @@ Nav2 dependency.
 | `test_scan_pipeline` | yes | The frame chain and the scan. |
 | `test_slam_map` | yes | slam_toolbox owning `map` to `odom`, and the map's geometry. |
 | `test_gait_coupling` | no | Spin's rotational limits against the shaper's engage threshold. |
-| `test_launch_threading` | no | Arguments surviving `bringup` to `nav_sim` to `sim`. |
+| `test_launch_threading` | no | Arguments surviving every include boundary, for both callers; `nav_stack.launch.py`'s include set, its single container, the uncomposed Nav2 pin, and that it stages no simulator. |
 | `test_rviz_configs` | no | The sensor display group not drifting between the two configs. |
 | `test_no_sim_time` | no | No shipped config enables `use_sim_time`. There is no `/clock` on this track. |
 

--- a/workspace/src/g1_navigation/launch/nav_sim.launch.py
+++ b/workspace/src/g1_navigation/launch/nav_sim.launch.py
@@ -1,8 +1,17 @@
-"""Top level: the simulator, the scan pipeline, and either SLAM or localization.
+"""Standalone wrapper: the simulator, the navigation stack, and optionally RViz.
+
+One command for running navigation on its own, which is what the integration suites launch and
+what a nav-only debugging session wants. The stack itself lives in nav_stack.launch.py; this
+file only stages a simulator under it and attaches a window.
 
 Includes g1_bringup rather than the other way round. Navigation sits above bring-up, so the
 higher layer composes the lower one; a nav:=true argument on sim.launch.py would give
 g1_bringup a dependency on Nav2 and slam_toolbox.
+
+g1_bringup's bringup.launch.py composes the same two pieces for the operator entry point. That
+leaves exactly one fact stated twice -- sensors:=true on the simulator -- because each file
+stages its own simulator and there is nowhere shared to put it. test_launch_threading asserts
+it on both.
 """
 
 import os
@@ -10,41 +19,18 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
-from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
-MODES = ("mapping", "localization")
-
-# Isolated rather than the plain container: each component keeps its own single-threaded
-# executor, so one blocking callback cannot stall the others.
-CONTAINER_EXECUTABLE = "component_container_isolated"
-
 
 def _setup(context, *args, **kwargs):
-    mode = LaunchConfiguration("mode").perform(context)
-    if mode not in MODES:
-        raise RuntimeError(
-            f"mode:={mode!r} is not a mode. 'mapping' builds a new map of the facility; "
-            f"'localization' runs against the committed one, which is what a repeatable "
-            f"goal pose needs."
-        )
     share = get_package_share_directory("g1_navigation")
     launch_dir = os.path.join(share, "launch")
     # Resolved BEFORE the sim include below, which sets rviz=false for its own scope and leaks
     # that back here -- without capturing it first, asking for rviz:=true silently gets you no
     # RViz at all. Same launch-configuration inheritance that bites use_composition.
     want_rviz = LaunchConfiguration("rviz").perform(context).lower() == "true"
-
-    def include(name, **launch_args):
-        return IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(os.path.join(launch_dir, name)),
-            launch_arguments=launch_args.items(),
-        )
-
-    use_composition = LaunchConfiguration("use_composition")
-    container_name = LaunchConfiguration("container_name")
 
     actions = [
         # sensors:=true is not optional: it gates the LiDAR sweep, the relay, the
@@ -69,52 +55,19 @@ def _setup(context, *args, **kwargs):
                 "rviz": "false",
             }.items(),
         ),
-        # The container has to exist before anything tries to load into it. Created here
-        # rather than in the leaf launches so one container serves all of them -- which is
-        # the point, and is what PR B's costmaps and controller will join.
-        Node(
-            condition=IfCondition(use_composition),
-            name=container_name,
-            package="rclcpp_components",
-            executable=CONTAINER_EXECUTABLE,
-            output="both",
-        ),
-        include(
-            "scan.launch.py",
-            use_composition=use_composition,
-            container_name=container_name,
+        # Every argument forwarded explicitly, including the ones whose values match this
+        # file's own defaults: the child's DeclareLaunchArgument default never fires for a name
+        # this file also declares.
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(os.path.join(launch_dir, "nav_stack.launch.py")),
+            launch_arguments={
+                "mode": LaunchConfiguration("mode"),
+                "nav": LaunchConfiguration("nav"),
+                "use_composition": LaunchConfiguration("use_composition"),
+                "container_name": LaunchConfiguration("container_name"),
+            }.items(),
         ),
     ]
-
-    if mode == "mapping":
-        # slam_toolbox stays out of the container even though it ships a component:
-        # nav2_bringup's own slam_launch.py runs it as a plain node, and its 40 MB stack
-        # requirement for map serialization is not something to hand a shared process.
-        actions.append(include("slam.launch.py"))
-    else:
-        actions.append(
-            include(
-                "localization.launch.py",
-                use_composition=use_composition,
-                container_name=container_name,
-            )
-        )
-
-    # Nav2 itself. Off by default so PR A's documented commands behave identically and the
-    # navigation invocation is explicit.
-    if LaunchConfiguration("nav").perform(context).lower() == "true":
-        if mode != "localization":
-            raise RuntimeError(
-                "nav:=true needs mode:=localization. Navigating against a map slam_toolbox is "
-                "still building means the goal pose moves under the planner."
-            )
-        # Passed explicitly as false, and it has to be explicit: an included launch file
-        # INHERITS the parent's launch configurations, so nav2.launch.py's own
-        # DeclareLaunchArgument default never applies against this file's use_composition.
-        # Nav2 must run uncomposed because composition does not deliver the nested costmap
-        # parameters; see nav2.launch.py's docstring. The scan and localization nodes above
-        # still compose, and still get theirs.
-        actions.append(include("nav2.launch.py", use_composition="false"))
 
     if want_rviz:
         actions.append(

--- a/workspace/src/g1_navigation/launch/nav_stack.launch.py
+++ b/workspace/src/g1_navigation/launch/nav_stack.launch.py
@@ -1,0 +1,132 @@
+"""The navigation stack without a simulator under it.
+
+The `control.launch.py` analogue for navigation: the shared component container, the scan
+pipeline, SLAM or localization, and optionally Nav2 itself. Nothing here is sim-specific, so
+this is the file that carries to hardware unchanged, and it is what a bring-up includes.
+
+Named for the stack, not for Nav2. `nav2.launch.py` is one of the pieces this file composes:
+the Nav2 servers alone, and only when nav:=true. This file is the assembly around them, and it
+runs a mapping session that never loads Nav2 at all.
+
+It stages NO simulator, deliberately. Both callers -- `nav_sim.launch.py` here and
+`g1_bringup`'s `bringup.launch.py` -- stage exactly one themselves. A simulator include in this
+file would give whichever caller already had one a second `motion_service_sim`, and that is two
+publishers on `/lowcmd` fighting for the same joints (docs/CONTROL_MODES.md). The robot would
+collapse with nothing in the logs to explain it, so `test_launch_threading` asserts the absence
+rather than trusting it.
+
+RViz is not here either. It is a per-operator choice about one window, not part of the stack,
+and both callers already own that decision.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+MODES = ("mapping", "localization")
+
+# Isolated rather than the plain container: each component keeps its own single-threaded
+# executor, so one blocking callback cannot stall the others.
+CONTAINER_EXECUTABLE = "component_container_isolated"
+
+
+def _setup(context, *args, **kwargs):
+    mode = LaunchConfiguration("mode").perform(context)
+    if mode not in MODES:
+        raise RuntimeError(
+            f"mode:={mode!r} is not a mode. 'mapping' builds a new map of the facility; "
+            f"'localization' runs against the committed one, which is what a repeatable "
+            f"goal pose needs."
+        )
+    launch_dir = os.path.join(get_package_share_directory("g1_navigation"), "launch")
+
+    def include(name, **launch_args):
+        return IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(os.path.join(launch_dir, name)),
+            launch_arguments=launch_args.items(),
+        )
+
+    use_composition = LaunchConfiguration("use_composition")
+    container_name = LaunchConfiguration("container_name")
+
+    actions = [
+        # The container has to exist before anything tries to load into it. Created here
+        # rather than in the leaf launches so one container serves all of them -- which is
+        # the point, and is what the costmaps and controller join.
+        Node(
+            condition=IfCondition(use_composition),
+            name=container_name,
+            package="rclcpp_components",
+            executable=CONTAINER_EXECUTABLE,
+            output="both",
+        ),
+        include(
+            "scan.launch.py",
+            use_composition=use_composition,
+            container_name=container_name,
+        ),
+    ]
+
+    if mode == "mapping":
+        # slam_toolbox stays out of the container even though it ships a component:
+        # nav2_bringup's own slam_launch.py runs it as a plain node, and its 40 MB stack
+        # requirement for map serialization is not something to hand a shared process.
+        actions.append(include("slam.launch.py"))
+    else:
+        actions.append(
+            include(
+                "localization.launch.py",
+                use_composition=use_composition,
+                container_name=container_name,
+            )
+        )
+
+    # Nav2 itself. Off by default so a mapping run starts nothing it does not need, and the
+    # navigation invocation stays explicit.
+    if LaunchConfiguration("nav").perform(context).lower() == "true":
+        if mode != "localization":
+            raise RuntimeError(
+                "nav:=true needs mode:=localization. Navigating against a map slam_toolbox is "
+                "still building means the goal pose moves under the planner."
+            )
+        # Passed explicitly as false, and it has to be explicit: an included launch file
+        # INHERITS the parent's launch configurations, so nav2.launch.py's own
+        # DeclareLaunchArgument default never applies against this file's use_composition.
+        # Nav2 must run uncomposed because composition does not deliver the nested costmap
+        # parameters; see nav2.launch.py's docstring. The scan and localization nodes above
+        # still compose, and still get theirs.
+        actions.append(include("nav2.launch.py", use_composition="false"))
+
+    return actions
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "mode",
+            default_value="mapping",
+            description="'mapping' builds a new map with slam_toolbox; 'localization' runs "
+            "map_server + AMCL against maps/facility.",
+        ),
+        DeclareLaunchArgument(
+            "nav",
+            default_value="false",
+            description="Start Nav2, the gait shaper and the locomotion authority bracket. "
+            "Requires mode:=localization. Off by default: mapping runs need none of it.",
+        ),
+        DeclareLaunchArgument(
+            "use_composition",
+            default_value="true",
+            description="Run the navigation nodes in one component container, each with its "
+            "own executor. Set false to get one process per node, which is what you want when "
+            "a single node is crashing and you need to see which.",
+        ),
+        DeclareLaunchArgument("container_name", default_value="nav2_container"),
+        OpaqueFunction(function=_setup),
+    ])

--- a/workspace/src/g1_navigation/test/test_launch_threading.py
+++ b/workspace/src/g1_navigation/test/test_launch_threading.py
@@ -6,9 +6,13 @@ anything the parent declared. Both previous instances -- a second RViz window on
 config, and use_composition silently ignoring its default -- looked like successful
 launches. Nothing crashed; the wrong value simply arrived.
 
-So this walks the chain rather than launching it: bringup.launch.py -> nav_sim.launch.py ->
-sim.launch.py, resolving what each layer actually forwards to the next. It needs no
-simulator and no DDS.
+So this walks the includes rather than launching them, resolving what each file actually
+forwards. It needs no simulator and no DDS.
+
+Two callers compose the same two pieces and both are checked here: bringup.launch.py stages a
+simulator and includes nav_stack.launch.py, and nav_sim.launch.py does the same for a nav-only
+session. nav_stack.launch.py itself is checked for staging no simulator at all, which is what
+makes including it next to one safe.
 
 Lives in g1_navigation because it reads both packages' launch files, and g1_bringup cannot
 depend on g1_navigation (colcon dependency cycle -- see bringup.launch.py's docstring).
@@ -175,7 +179,18 @@ def test_nav_stack_refuses_bad_input(nav_stack):
 # --- boundary 1: bringup.launch.py -> the stack below it ------------------------------
 
 
-def test_bare_mode_routes_to_sim_and_never_names_g1_navigation(bringup):
+def _sim_args(setup_result):
+    """The arguments bringup hands its one simulator, looked up by name.
+
+    By name rather than by index: bringup now emits several includes and their order is not
+    what any of these tests are about.
+    """
+    sims = [args for name, args in _includes(setup_result) if name == "sim.launch.py"]
+    assert len(sims) == 1, f"expected exactly one simulator, got {len(sims)}"
+    return sims[0]
+
+
+def test_bare_mode_stages_only_a_simulator_and_names_no_optional_package(bringup):
     result = _run_setup(bringup, mode="none")
     assert [name for name, _ in _includes(result)] == ["sim.launch.py"]
     # The whole point of the undeclared reference: this path must not touch the package.
@@ -185,39 +200,71 @@ def test_bare_mode_routes_to_sim_and_never_names_g1_navigation(bringup):
             assert "g1_navigation" not in _included_path(context, action)
 
 
-def test_navigation_modes_route_to_nav_sim(bringup):
+def test_navigation_modes_stage_the_simulator_then_the_stack(bringup):
     for mode in ("mapping", "localization"):
         includes = _includes(_run_setup(bringup, mode=mode))
-        assert [name for name, _ in includes] == ["nav_sim.launch.py"], mode
-        assert includes[0][1]["mode"] == mode
+        assert [name for name, _ in includes] == ["sim.launch.py", "nav_stack.launch.py"], mode
+        assert dict(includes)["nav_stack.launch.py"]["mode"] == mode
 
 
-@pytest.mark.parametrize("mode,expected", [("none", "2.0"), ("mapping", "4.0")])
+@pytest.mark.parametrize("mode", ["mapping", "localization"])
+def test_the_navigation_branch_forces_sensors_on(bringup, mode):
+    """Navigation needs the LiDAR, the relay and the odom chain, so an operator asking for
+    sensors:=false on a navigation mode gets them anyway rather than a stack that cannot see."""
+    args = _sim_args(_run_setup(bringup, mode=mode, sensors="false"))
+    assert args["sensors"] == "true"
+
+
+def test_the_bare_branch_leaves_sensors_to_the_operator(bringup):
+    assert _sim_args(_run_setup(bringup, mode="none", sensors="false"))["sensors"] == "false"
+    assert _sim_args(_run_setup(bringup, mode="none", sensors="true"))["sensors"] == "true"
+
+
+def test_the_nav_flag_reaches_the_stack(bringup):
+    includes = dict(_includes(_run_setup(bringup, mode="localization", nav="true")))
+    assert includes["nav_stack.launch.py"]["nav"] == "true"
+    includes = dict(_includes(_run_setup(bringup, mode="localization")))
+    assert includes["nav_stack.launch.py"]["nav"] == "false"
+
+
+def test_the_container_arguments_are_left_to_the_stacks_own_defaults(bringup):
+    # Not forwarded and not declared here, which is the safe case: inheritance only leaks
+    # through a name the parent also declares.
+    forwarded = dict(_includes(_run_setup(bringup, mode="localization")))["nav_stack.launch.py"]
+    assert "use_composition" not in forwarded
+    assert "container_name" not in forwarded
+
+
+@pytest.mark.parametrize(
+    "mode,expected", [("none", "2.0"), ("mapping", "4.0"), ("localization", "4.0")]
+)
 def test_each_branch_supplies_its_own_start_delay(bringup, mode, expected):
     # The child's own default can never fire, so the branch has to pick a concrete value.
     # Getting this wrong hands sim.launch.py an empty string and float() raises.
-    args = _includes(_run_setup(bringup, mode=mode))[0][1]
-    assert args["sim_start_delay_s"] == expected
+    assert _sim_args(_run_setup(bringup, mode=mode))["sim_start_delay_s"] == expected
 
 
 @pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
 def test_an_explicit_start_delay_beats_the_branch_default(bringup, mode):
-    args = _includes(_run_setup(bringup, mode=mode, sim_start_delay_s="9.5"))[0][1]
+    args = _sim_args(_run_setup(bringup, mode=mode, sim_start_delay_s="9.5"))
     assert args["sim_start_delay_s"] == "9.5"
 
 
 @pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
 def test_world_threads_through_unchanged(bringup, mode):
-    args = _includes(_run_setup(bringup, mode=mode, world="perception"))[0][1]
-    assert args["world"] == "perception"
+    assert _sim_args(_run_setup(bringup, mode=mode, world="perception"))["world"] == "perception"
 
 
 @pytest.mark.parametrize("mode", ["none", "mapping", "localization"])
-def test_rviz_is_always_suppressed_in_the_child(bringup, mode):
+def test_rviz_is_always_suppressed_in_the_simulator(bringup, mode):
     # The exact shape of the shipped bug: without an explicit false the child inherits
     # rviz:=true and opens a second window on the wrong config.
-    args = _includes(_run_setup(bringup, mode=mode, rviz="true"))[0][1]
-    assert args["rviz"] == "false"
+    assert _sim_args(_run_setup(bringup, mode=mode, rviz="true"))["rviz"] == "false"
+
+
+def test_pin_pelvis_threads_to_the_simulator(bringup):
+    assert _sim_args(_run_setup(bringup, mode="none", pin_pelvis="true"))["pin_pelvis"] == "true"
+    assert _sim_args(_run_setup(bringup, mode="none"))["pin_pelvis"] == "false"
 
 
 def test_rviz_config_is_chosen_per_mode(bringup):
@@ -239,22 +286,43 @@ def test_no_rviz_include_when_not_asked(bringup):
 # --- boundary 2: the value keeps its meaning all the way down to sim.launch.py --------
 
 
-def test_world_and_delay_survive_the_second_boundary(bringup, nav_sim):
-    """The end-to-end claim: what an operator types reaches the simulator."""
-    forwarded = _includes(
-        _run_setup(bringup, mode="localization", world="perception", sim_start_delay_s="9.5")
-    )[0][1]
+def test_nav_sim_composes_one_simulator_and_one_stack(nav_sim):
+    """nav_sim is no longer in bringup's path, so its own contract needs asserting directly."""
+    names = [name for name, _ in _includes(_run_setup(nav_sim, mode="localization"))]
+    assert names == ["sim.launch.py", "nav_stack.launch.py"]
 
-    # nav_sim.launch.py starts from exactly what bringup handed it, plus its own defaults.
-    downstream = _includes(_run_setup(nav_sim, **forwarded))
-    sim = [a for name, a in downstream if name == "sim.launch.py"]
-    assert len(sim) == 1, f"expected one sim.launch.py include, got {downstream}"
 
-    assert sim[0]["world"] == "perception"
-    assert sim[0]["sim_start_delay_s"] == "9.5"
-    assert sim[0]["rviz"] == "false"
-    # nav_sim forces this on regardless of what came from above, and must keep doing so.
-    assert sim[0]["sensors"] == "true"
+def test_nav_sim_forces_sensors_and_suppresses_rviz(nav_sim):
+    """The other half of the one fact stated in two files. bringup asserts its copy above; if
+    these two ever disagree, navigation silently loses its scan or gains a second RViz."""
+    sim = dict(_includes(_run_setup(nav_sim, mode="mapping")))["sim.launch.py"]
+    assert sim["sensors"] == "true"
+    assert sim["rviz"] == "false"
+
+
+def test_nav_sim_forwards_world_and_delay_to_the_simulator(nav_sim):
+    sim = dict(
+        _includes(_run_setup(nav_sim, mode="mapping", world="perception", sim_start_delay_s="9.5"))
+    )["sim.launch.py"]
+    assert sim["world"] == "perception"
+    assert sim["sim_start_delay_s"] == "9.5"
+
+
+def test_nav_sim_forwards_the_container_arguments_it_exposes(nav_sim):
+    # Unlike bringup, nav_sim declares these, so it must forward them explicitly or its own
+    # values would be the ones that never arrive.
+    stack = dict(_includes(_run_setup(nav_sim, mode="localization", use_composition="false")))[
+        "nav_stack.launch.py"
+    ]
+    assert stack["use_composition"] == "false"
+    assert stack["container_name"] == "nav2_container"
+
+
+def test_nav_sim_opens_rviz_only_when_asked(nav_sim):
+    """Pins the resolve-before-include ordering: the sim include sets rviz=false in this scope,
+    so reading rviz after it would find false and silently open no window at all."""
+    assert len(_nodes(_run_setup(nav_sim, mode="mapping", rviz="true"))) == 1
+    assert _nodes(_run_setup(nav_sim, mode="mapping", rviz="false")) == []
 
 
 # --- the guards ----------------------------------------------------------------------

--- a/workspace/src/g1_navigation/test/test_launch_threading.py
+++ b/workspace/src/g1_navigation/test/test_launch_threading.py
@@ -21,6 +21,7 @@ import pytest
 from launch import LaunchContext
 from launch.actions import IncludeLaunchDescription
 from launch.utilities import normalize_to_list_of_substitutions, perform_substitutions
+from launch_ros.actions import Node
 
 BRINGUP_LAUNCH_DIR = os.environ["G1_BRINGUP_LAUNCH_DIR"]
 NAVIGATION_LAUNCH_DIR = os.environ["G1_NAVIGATION_LAUNCH_DIR"]
@@ -95,6 +96,80 @@ def bringup():
 @pytest.fixture(scope="module")
 def nav_sim():
     return _load(NAVIGATION_LAUNCH_DIR, "nav_sim.launch.py")
+
+
+@pytest.fixture(scope="module")
+def nav_stack():
+    return _load(NAVIGATION_LAUNCH_DIR, "nav_stack.launch.py")
+
+
+def _nodes(setup_result):
+    """Every Node action, which is how the component container shows up."""
+    actions, _ = setup_result
+    return [a for a in actions if isinstance(a, Node)]
+
+
+# --- nav_stack.launch.py: the stack itself, with no simulator under it ----------------
+
+
+@pytest.mark.parametrize("mode", ["mapping", "localization"])
+def test_nav_stack_never_stages_a_simulator(nav_stack, mode):
+    """The safety pin.
+
+    Both callers stage their own simulator. A second one here would mean two
+    motion_service_sim processes publishing /lowcmd at once, which is the failure mode
+    CONTROL_MODES.md puts first: the robot collapses and nothing in the logs says why.
+    """
+    nav = "false" if mode == "mapping" else "true"
+    actions, context = _run_setup(nav_stack, mode=mode, nav=nav)
+    for action in actions:
+        if isinstance(action, IncludeLaunchDescription):
+            path = _included_path(context, action)
+            assert "sim.launch.py" not in path, path
+            assert "g1_bringup" not in path, path
+
+
+def test_nav_stack_includes_the_pipeline_for_each_mode(nav_stack):
+    mapping = [name for name, _ in _includes(_run_setup(nav_stack, mode="mapping"))]
+    assert mapping == ["scan.launch.py", "slam.launch.py"]
+
+    localization = [name for name, _ in _includes(_run_setup(nav_stack, mode="localization"))]
+    assert localization == ["scan.launch.py", "localization.launch.py"]
+
+    with_nav = [
+        name for name, _ in _includes(_run_setup(nav_stack, mode="localization", nav="true"))
+    ]
+    assert with_nav == ["scan.launch.py", "localization.launch.py", "nav2.launch.py"]
+
+
+def test_only_the_composable_pieces_are_told_about_the_container(nav_stack):
+    # slam_toolbox is deliberately left out of the container (40 MB serialization stack), so
+    # handing it a container name would be the visible half of a wrong decision.
+    includes = dict(_includes(_run_setup(nav_stack, mode="mapping")))
+    assert includes["scan.launch.py"]["container_name"] == "nav2_container"
+    assert includes["slam.launch.py"] == {}
+
+    localization = dict(_includes(_run_setup(nav_stack, mode="localization")))
+    assert localization["localization.launch.py"]["container_name"] == "nav2_container"
+
+
+def test_nav2_is_never_composed(nav_stack):
+    """Measured, not stylistic: composed, the costmaps silently fall back to Costmap2DROS's
+    built-in defaults and controller_server hangs in Activating forever."""
+    includes = dict(_includes(_run_setup(nav_stack, mode="localization", nav="true")))
+    assert includes["nav2.launch.py"]["use_composition"] == "false"
+
+
+@pytest.mark.parametrize("mode", ["mapping", "localization"])
+def test_exactly_one_container_is_created(nav_stack, mode):
+    assert len(_nodes(_run_setup(nav_stack, mode=mode))) == 1
+
+
+def test_nav_stack_refuses_bad_input(nav_stack):
+    with pytest.raises(RuntimeError, match="needs mode:=localization"):
+        _run_setup(nav_stack, mode="mapping", nav="true")
+    with pytest.raises(RuntimeError, match="is not a mode"):
+        _run_setup(nav_stack, mode="slam")
 
 
 # --- boundary 1: bringup.launch.py -> the stack below it ------------------------------

--- a/workspace/vendor/unitree_mujoco/dex3_handler.cc
+++ b/workspace/vendor/unitree_mujoco/dex3_handler.cc
@@ -143,8 +143,8 @@ void openChannels(Hand& hand)
     // as "nothing is touching the fingers", which is a different and wrong claim.
 }
 
-// One control tick for one hand. Applies the PD the real finger motor runs, into the
-// generalized-force channel.
+// Runs the PD the real finger motor runs, into the generalized-force channel rather than an
+// actuator, since the fingers deliberately have none.
 void driveHand(const mjModel* model, mjData* data, Hand& hand)
 {
     std::array<unitree_hg::msg::dds_::MotorCmd_, kNumJoints> command{};

--- a/workspace/vendor/unitree_mujoco/dex3_handler.cc
+++ b/workspace/vendor/unitree_mujoco/dex3_handler.cc
@@ -1,0 +1,319 @@
+#include "dex3_handler.h"
+
+#include <unitree/idl/hg/HandCmd_.hpp>
+#include <unitree/idl/hg/HandState_.hpp>
+#include <unitree/robot/channel/channel_publisher.hpp>
+#include <unitree/robot/channel/channel_subscriber.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace grove_g1
+{
+namespace
+{
+
+constexpr std::size_t kNumJoints = 7;
+
+// Dex3 wire order, identical for both hands. Looked up BY NAME, never by index: the joints
+// land contiguously in the current model, but Unitree's own tooling has a right-hand enum
+// that lists index before middle, and one reordered MJCF would close the wrong fingers.
+constexpr std::array<const char*, kNumJoints> kJointSuffixes = {
+    "thumb_0", "thumb_1", "thumb_2", "middle_0", "middle_1", "index_0", "index_1",
+};
+
+// Peak motor torque per joint, from the URDF's effort limits. Without this the simulated
+// finger is roughly three times stronger than the real one at full PD error, which would let
+// sim show grasps the robot cannot reproduce.
+constexpr std::array<double, kNumJoints> kEffortLimit = {
+    2.45, 1.4, 1.4, 1.4, 1.4, 1.4, 1.4,
+};
+
+constexpr int    kControlRateHz  = 1000;  // matches the SDK bridge's own tick
+constexpr int    kStatePublishHz = 100;   // real rate is undocumented; matches the cmd rate
+constexpr double kCommandTimeoutS = 1.0;  // Unitree's own timeout bit means ~1 s
+
+// Lock means "motor held", not "motor off". Undriven fingers therefore hold station instead
+// of hanging, which is what the hardware does and, more to the point, what MoveIt reads as
+// the start state. These are the hand's own nominal gains.
+constexpr double kHoldKp = 1.5;
+constexpr double kHoldKd = 0.2;
+
+// status lives in bits 4-6 of the packed mode byte; 1 = FOC (driven), 0 = Lock.
+constexpr std::uint8_t kStatusLock = 0x00;
+constexpr std::uint8_t kStatusFoc  = 0x01;
+
+std::uint8_t statusOf(std::uint8_t mode) { return (mode >> 4) & 0x07; }
+
+std::uint8_t packMode(std::size_t index, std::uint8_t status)
+{
+    return static_cast<std::uint8_t>((index & 0x0F) | ((status & 0x07) << 4));
+}
+
+using HandCmd   = unitree_hg::msg::dds_::HandCmd_;
+using HandState = unitree_hg::msg::dds_::HandState_;
+
+struct Hand
+{
+    std::string                          side;
+    std::array<int, kNumJoints>          qpos_adr{};
+    std::array<int, kNumJoints>          dof_adr{};
+    std::array<double, kNumJoints>       lower{};
+    std::array<double, kNumJoints>       upper{};
+
+    // Where an undriven finger is held. Tracks the measurement while driven, so releasing
+    // freezes the finger where it stopped rather than snapping it back.
+    std::array<double, kNumJoints> hold{};
+    std::array<bool, kNumJoints>   driven{};
+
+    std::mutex                                 mutex;
+    std::array<unitree_hg::msg::dds_::MotorCmd_, kNumJoints> command{};
+    bool                                       have_command{ false };
+    std::chrono::steady_clock::time_point      last_command{};
+
+    unitree::robot::ChannelSubscriberPtr<HandCmd>  sub;
+    unitree::robot::ChannelPublisherPtr<HandState> pub;
+    HandState                                      state;
+};
+
+struct State
+{
+    std::thread       thread;
+    std::atomic<bool> running{ false };
+    std::array<Hand, 2> hands;
+};
+
+State& state()
+{
+    // Deliberately leaked, for the same reason sensor_publisher leaks its own: the physics
+    // thread ends in exit(0), which runs static destructors while this thread may still be
+    // alive, and destroying a joinable std::thread calls std::terminate.
+    static State* s = new State();
+    return *s;
+}
+
+// Resolves the seven joints of one hand. False means this model has no such hand.
+bool resolveHand(const mjModel* model, Hand& hand)
+{
+    for (std::size_t i = 0; i < kNumJoints; ++i)
+    {
+        const std::string name = hand.side + "_hand_" + kJointSuffixes[i] + "_joint";
+        const int         id   = mj_name2id(model, mjOBJ_JOINT, name.c_str());
+        if (id < 0)
+        {
+            return false;
+        }
+        hand.qpos_adr[i] = model->jnt_qposadr[id];
+        hand.dof_adr[i]  = model->jnt_dofadr[id];
+        hand.lower[i]    = model->jnt_range[2 * id];
+        hand.upper[i]    = model->jnt_range[2 * id + 1];
+    }
+    return true;
+}
+
+void openChannels(Hand& hand)
+{
+    hand.sub.reset(new unitree::robot::ChannelSubscriber<HandCmd>("rt/dex3/" + hand.side + "/cmd"));
+    hand.sub->InitChannel(
+        [&hand](const void* message) {
+            const auto* msg = static_cast<const HandCmd*>(message);
+            if (msg->motor_cmd().size() < kNumJoints)
+            {
+                return;
+            }
+            std::lock_guard<std::mutex> lock(hand.mutex);
+            std::copy_n(msg->motor_cmd().begin(), kNumJoints, hand.command.begin());
+            hand.have_command = true;
+            hand.last_command = std::chrono::steady_clock::now();
+        },
+        1);
+
+    hand.pub.reset(
+        new unitree::robot::ChannelPublisher<HandState>("rt/dex3/" + hand.side + "/state"));
+    hand.pub->InitChannel();
+    hand.state.motor_state().resize(kNumJoints);
+    // press_sensor_state stays EMPTY on purpose. The hand has 9 tactile sensors we do not
+    // simulate, and an empty sequence reads as "no data" where nine zeroed sensors would read
+    // as "nothing is touching the fingers", which is a different and wrong claim.
+}
+
+// One control tick for one hand. Applies the PD the real finger motor runs, into the
+// generalized-force channel.
+void driveHand(const mjModel* model, mjData* data, Hand& hand)
+{
+    std::array<unitree_hg::msg::dds_::MotorCmd_, kNumJoints> command{};
+    bool                                                     driven = false;
+    {
+        std::lock_guard<std::mutex> lock(hand.mutex);
+        const auto elapsed = std::chrono::duration<double>(
+                                 std::chrono::steady_clock::now() - hand.last_command)
+                                 .count();
+        driven  = hand.have_command && elapsed < kCommandTimeoutS;
+        command = hand.command;
+    }
+
+    for (std::size_t i = 0; i < kNumJoints; ++i)
+    {
+        const double q  = data->qpos[hand.qpos_adr[i]];
+        const double dq = data->qvel[hand.dof_adr[i]];
+
+        hand.driven[i] = driven && statusOf(command[i].mode()) == kStatusFoc;
+
+        double tau;
+        if (hand.driven[i])
+        {
+            const double target =
+                std::clamp(static_cast<double>(command[i].q()), hand.lower[i], hand.upper[i]);
+            tau = static_cast<double>(command[i].tau()) +
+                  static_cast<double>(command[i].kp()) * (target - q) +
+                  static_cast<double>(command[i].kd()) *
+                      (static_cast<double>(command[i].dq()) - dq);
+            hand.hold[i] = q;
+        }
+        else
+        {
+            // Lock, timed out, or never commanded.
+            tau = kHoldKp * (hand.hold[i] - q) - kHoldKd * dq;
+        }
+        data->qfrc_applied[hand.dof_adr[i]] =
+            std::clamp(tau, -kEffortLimit[i], kEffortLimit[i]);
+    }
+}
+
+void publishState(const mjData* data, Hand& hand)
+{
+    for (std::size_t i = 0; i < kNumJoints; ++i)
+    {
+        auto& motor = hand.state.motor_state()[i];
+        motor.q()   = static_cast<float>(data->qpos[hand.qpos_adr[i]]);
+        motor.dq()  = static_cast<float>(data->qvel[hand.dof_adr[i]]);
+        // The applied torque IS what the motor produced here, so this is the real tau_est
+        // rather than a stand-in.
+        motor.tau_est() = static_cast<float>(data->qfrc_applied[hand.dof_adr[i]]);
+        motor.mode()    = packMode(i, hand.driven[i] ? kStatusFoc : kStatusLock);
+    }
+    hand.pub->Write(hand.state);
+}
+
+void run(mjModel** model, mjData** data)
+{
+    auto& s = state();
+
+    while (s.running && (*model == nullptr || *data == nullptr))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if (!s.running)
+    {
+        return;
+    }
+
+    for (auto& hand : s.hands)
+    {
+        if (!resolveHand(*model, hand))
+        {
+            std::fprintf(
+                stderr,
+                "[grove_g1] no %s Dex3 joints in this model; hand control is OFF\n",
+                hand.side.c_str());
+            s.running = false;
+            return;
+        }
+    }
+    for (auto& hand : s.hands)
+    {
+        openChannels(hand);
+    }
+    std::fprintf(stderr, "[grove_g1] Dex3 hands answering rt/dex3/{left,right}/{cmd,state}\n");
+
+    const auto control_period =
+        std::chrono::nanoseconds(std::chrono::seconds(1)) / kControlRateHz;
+    const int publish_every = kControlRateHz / kStatePublishHz;
+    int       tick          = 0;
+    auto      next          = std::chrono::steady_clock::now();
+
+    while (s.running)
+    {
+        // Raw mjData access without sim.mtx, exactly as the vendored SDK bridge does for
+        // ctrl[] and sensordata[]. Taking the lock at 1 kHz would contend with physics for
+        // no benefit: these are independent doubles and a torn read costs one stale tick.
+        mjModel* m = *model;
+        mjData*  d = *data;
+        if (m != nullptr && d != nullptr)
+        {
+            for (auto& hand : s.hands)
+            {
+                driveHand(m, d, hand);
+            }
+            if (tick % publish_every == 0)
+            {
+                for (auto& hand : s.hands)
+                {
+                    publishState(d, hand);
+                }
+            }
+        }
+        ++tick;
+        next += control_period;
+        std::this_thread::sleep_until(next);
+    }
+
+    // qfrc_applied is not cleared between steps, so a torque left behind here would be
+    // integrated forever.
+    if (*data != nullptr)
+    {
+        for (const auto& hand : s.hands)
+        {
+            for (const int dof : hand.dof_adr)
+            {
+                (*data)->qfrc_applied[dof] = 0.0;
+            }
+        }
+    }
+    for (auto& hand : s.hands)
+    {
+        if (hand.sub)
+        {
+            hand.sub->CloseChannel();
+        }
+        if (hand.pub)
+        {
+            hand.pub->CloseChannel();
+        }
+    }
+}
+
+}  // namespace
+
+void StartDex3Handler(mjModel** model, mjData** data)
+{
+    auto& s = state();
+    if (s.running)
+    {
+        return;
+    }
+    s.hands[0].side = "left";
+    s.hands[1].side = "right";
+    s.running       = true;
+    s.thread        = std::thread([model, data] { run(model, data); });
+}
+
+void StopDex3Handler()
+{
+    auto& s = state();
+    if (!s.thread.joinable())
+    {
+        s.running = false;
+        return;
+    }
+    s.running = false;
+    s.thread.join();
+}
+
+}  // namespace grove_g1

--- a/workspace/vendor/unitree_mujoco/dex3_handler.h
+++ b/workspace/vendor/unitree_mujoco/dex3_handler.h
@@ -1,0 +1,48 @@
+#ifndef GROVE_G1_DEX3_HANDLER_H_
+#define GROVE_G1_DEX3_HANDLER_H_
+
+// Answers the Dex3-1 hand's DDS contract inside unitree_mujoco, so the same ros2_control
+// component (g1_hand_interface) drives the fingers in sim and on the robot.
+//
+// Lives outside the vendored sources so the patch against them stays a few lines; see
+// workspace/patches/unitree_mujoco/README.md.
+//
+// Why this cannot be an ordinary ROS node: the fingers are driven by writing mjData, which
+// is process-local. Same reason sensor_publisher lives here.
+//
+// Why it does not go through the SDK bridge: that bridge sizes itself from mj_model_->nu and
+// indexes a fixed 35-slot LowCmd, so the 14 finger joints deliberately have no actuators and
+// nu stays 29. The fingers are driven through qfrc_applied instead, which is also the honest
+// model of the hardware -- the Dex3 is a separate device on its own topics, not motors 29-42
+// of the body (docs/CONTROL_MODES.md).
+//
+// A no-op on models without hands (the 23-DoF G1, the perception sandbox): the joint lookup
+// fails, it says so once, and nothing starts.
+
+#include <mujoco/mujoco.h>
+
+namespace grove_g1
+{
+
+// Starts the hand thread. Non-blocking.
+//
+// MUST be called after unitree_sdk2's ChannelFactory has been initialised -- it opens DDS
+// channels immediately -- which is why the call site is the bridge thread rather than main().
+//
+// model/data are the addresses of unitree_mujoco's globals, not their values: a model dropped
+// into the viewer reassigns both.
+void StartDex3Handler(mjModel** model, mjData** data);
+
+// Stops the hand thread and BLOCKS until it has terminated. Zeroes the torques it applied on
+// the way out, since qfrc_applied persists across steps and a stale finger torque would keep
+// being integrated forever. Safe to call when nothing is running.
+//
+// Must be called before mj_deleteModel on any path that replaces the model: the joint
+// addresses are resolved once and cached, so they outlive the model they came from. One-way,
+// like StopSensorPublisher -- a reload deliberately ends with the hands inert rather than
+// driving a model they were not resolved against.
+void StopDex3Handler();
+
+}  // namespace grove_g1
+
+#endif  // GROVE_G1_DEX3_HANDLER_H_


### PR DESCRIPTION
Adds MoveIt 2 planning for the arms and Dex3-1 gripper control, and restructures bringup so the
simulator is staged once and the navigation and manipulation stacks compose onto it.

## What's new

- **`g1_moveit_config`** — `left_arm`, `right_arm` and a composed `both_arms` group, plus
  `left_hand` and `right_hand`. `pick_ik` per arm; `both_arms` deliberately has no solver entry
  so MoveIt routes pose goals through the subgroup map. Named arm poses and `open`/`closed` hand
  postures, all collision-checked live before being written down.
- **`g1_hand_interface`** — `ros2_control` plugin for one Dex3-1 hand over `/dex3/<side>/{cmd,state}`.
  Real-hardware code; the simulator answers the same topics.
- **Octomap from the LiDAR** in the planning scene, with a test proving it actually blocks a plan.
- **Bringup composition** — `bringup.launch.py` stages exactly one simulator and includes the nav
  and MoveIt building blocks directly. The standalone wrappers still work.

## Simulator changes

The vendored MuJoCo model had fixed rubber hands with no finger joints, so the URDF and the
simulator disagreed about what was on the end of the wrist. Two new patches under
`workspace/patches/unitree_mujoco/` add the real Dex3 subtree, generated from the URDF, and a
handler that answers the hand's DDS contract.

The fingers have no MuJoCo actuators on purpose: the vendored SDK bridge sizes itself from
`mj_model_->nu` and indexes a fixed 35-slot `LowCmd`, so 29 body motors plus 14 fingers would run
it off the end of that array. They are driven through `qfrc_applied` instead, which also matches
the hardware, where the hand is a separate device on its own topics.

Two simulator-only deviations, both documented at the point of change:

- Hand mass is scaled to 0.170 kg per hand, what the stock model already lumped into each wrist.
  At the true 0.697 kg the sim's stand-in walking policy loses its balance. Hardware locomotion
  goes through `LocoClient` to Unitree's onboard controller, which never sees that policy.
- The arms are held at a configured posture rather than wherever they fall at startup, which had
  been putting the palm against the thigh once the hands had mass.

## Testing

414 tests across 12 packages, 0 failures. Live-sim suites were run one package at a time.

New coverage: config drift across the SRDF, controllers and speed clamps; robot-model group
composition and end effectors; the Dex3 wire format and plugin export; and a live test that a
`left_hand` goal plans, executes and actually moves the fingers in the simulator.
