### PR TITLE
Report object poses in the camera frame, and give AMCL a model that fits the robot

### DIFF
--- a/workspace/src/g1_manipulation/CMakeLists.txt
+++ b/workspace/src/g1_manipulation/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(g1_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
@@ -21,7 +22,7 @@ target_include_directories(g1_object_pose_source_node PUBLIC
 )
 target_compile_features(g1_object_pose_source_node PUBLIC cxx_std_20)
 ament_target_dependencies(g1_object_pose_source_node PUBLIC
-  rclcpp rclcpp_lifecycle vision_msgs geometry_msgs tf2 tf2_geometry_msgs tf2_ros)
+  rclcpp rclcpp_lifecycle vision_msgs visualization_msgs geometry_msgs tf2 tf2_geometry_msgs tf2_ros)
 
 add_executable(g1_object_pose_source src/g1_object_pose_source_main.cpp)
 target_link_libraries(g1_object_pose_source PUBLIC g1_object_pose_source_node)

--- a/workspace/src/g1_manipulation/CMakeLists.txt
+++ b/workspace/src/g1_manipulation/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(g1_object_pose_source_node PUBLIC
 )
 target_compile_features(g1_object_pose_source_node PUBLIC cxx_std_20)
 ament_target_dependencies(g1_object_pose_source_node PUBLIC
-  rclcpp rclcpp_lifecycle vision_msgs)
+  rclcpp rclcpp_lifecycle vision_msgs geometry_msgs tf2 tf2_geometry_msgs tf2_ros)
 
 add_executable(g1_object_pose_source src/g1_object_pose_source_main.cpp)
 target_link_libraries(g1_object_pose_source PUBLIC g1_object_pose_source_node)

--- a/workspace/src/g1_manipulation/README.md
+++ b/workspace/src/g1_manipulation/README.md
@@ -197,3 +197,24 @@ because it is a property of the Dex3 rather than of a task.
 ```bash
 colcon test --packages-select g1_manipulation
 ```
+
+### Object poses and frames
+
+The source subscribes to poses in the frame the detector measured from and transforms them into
+`output_frame_id` through TF. In simulation `g1_sensor_relay` reports in
+`camera_color_optical_frame`, which is what a real 6D-pose detector on the D435 produces, so the
+same path runs on the robot.
+
+It transforms rather than relabelling. Announcing an object directly in a fixed frame is correct
+only while that frame IS the world, which stops being true the moment odometry is an estimate:
+with `odometry:=fast_lio` the base approach chased a point 2 m from the cube until this was fixed.
+
+`publish_markers` (default true) adds `~/object_markers`, a box and a label per object built from
+the same message `/objects` carries, so rviz shows what a skill acts on. Both shipped rviz
+configs display it.
+
+| Parameter | Default | |
+|---|---|---|
+| `source_frame_id` | `camera_color_optical_frame` | The frame the detector measures in. |
+| `output_frame_id` | `odom` | Fixed, so MoveIt collision objects do not move with the robot. |
+| `publish_markers` | `true` | `~/object_markers` for rviz. |

--- a/workspace/src/g1_manipulation/config/g1_object_pose_source.yaml
+++ b/workspace/src/g1_manipulation/config/g1_object_pose_source.yaml
@@ -10,12 +10,15 @@ g1_object_pose_source:
     # gets the refusal, not a silent fallback to simulator ground truth.
     object_source: "sim_ground_truth"
 
-    # The frame the source publishes in, and the frame /objects is published in. Both odom on
-    # this track: the simulator's world origin IS odom, and sim.launch.py already configures
-    # g1_sensor_relay to stamp its ground truth that way, so this node verifies the frame
-    # rather than transforming it.
+    # In: the frame the detector measures from. Out: the frame /objects is published in, and
+    # the node transforms between them through TF.
     #
-    # They are two parameters rather than one because a real detector reports in a camera
-    # frame, and this is where that transform belongs when there is one to do.
-    source_frame_id: "odom"
+    # The camera frame is what a real 6D-pose detector reports, so this is the same pair the
+    # robot will use. It also has to be a measured frame rather than a fixed one: an object
+    # announced directly in odom is only correct while odom IS the world, which stops being
+    # true as soon as odometry is an estimate.
+    #
+    # Out stays odom, not a frame on the robot. MoveIt's collision objects need somewhere
+    # fixed to sit; expressed in pelvis they would slide along with every step.
+    source_frame_id: "camera_color_optical_frame"
     output_frame_id: "odom"

--- a/workspace/src/g1_manipulation/config/g1_object_pose_source.yaml
+++ b/workspace/src/g1_manipulation/config/g1_object_pose_source.yaml
@@ -22,3 +22,8 @@ g1_object_pose_source:
     # fixed to sit; expressed in pelvis they would slide along with every step.
     source_frame_id: "camera_color_optical_frame"
     output_frame_id: "odom"
+
+    # A box and a label per object on ~/object_markers, built from the same message /objects
+    # carries so rviz shows what a skill acts on rather than a second computation of it.
+    # On by default: the frames these poses live in are the thing most worth being able to see.
+    publish_markers: true

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
@@ -21,6 +21,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <vision_msgs/msg/detection3_d_array.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 namespace g1_manipulation
 {
@@ -51,8 +52,10 @@ public:
 private:
     bool readParameters();
     void onGroundTruth(const vision_msgs::msg::Detection3DArray::SharedPtr msg);
+    void publishMarkers(const vision_msgs::msg::Detection3DArray& objects);
 
     ObjectSource source_{ ObjectSource::Hardware };
+    bool         publish_markers_{ false };
     std::string  source_frame_id_;
     std::string  output_frame_id_;
 
@@ -64,6 +67,10 @@ private:
 
     rclcpp::Subscription<vision_msgs::msg::Detection3DArray>::SharedPtr                 source_sub_;
     rclcpp_lifecycle::LifecyclePublisher<vision_msgs::msg::Detection3DArray>::SharedPtr objects_pub_;
+    /// Only created when publish_markers is set: an rviz aid, not part of the interface, and
+    /// nothing should grow a dependency on it.
+    rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr
+        markers_pub_;
 };
 
 }  // namespace g1_manipulation

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
@@ -14,12 +14,13 @@
  * visibly rather than feed a grasp planner simulator ground truth.
  */
 
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <string>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 #include <vision_msgs/msg/detection3_d_array.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
@@ -18,6 +18,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <string>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <vision_msgs/msg/detection3_d_array.hpp>
 
 namespace g1_manipulation
@@ -53,6 +55,12 @@ private:
     ObjectSource source_{ ObjectSource::Hardware };
     std::string  source_frame_id_;
     std::string  output_frame_id_;
+
+    // A detector reports in the frame it measured from, which moves with the robot. Turning
+    // that into a fixed frame is a transform, not a relabel: the two differ by however far
+    // odom has drifted, which is the whole reason this node exists between the two.
+    std::unique_ptr<tf2_ros::Buffer>            tf_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
     rclcpp::Subscription<vision_msgs::msg::Detection3DArray>::SharedPtr                 source_sub_;
     rclcpp_lifecycle::LifecyclePublisher<vision_msgs::msg::Detection3DArray>::SharedPtr objects_pub_;

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
@@ -60,9 +60,6 @@ private:
     std::string  source_frame_id_;
     std::string  output_frame_id_;
 
-    // A detector reports in the frame it measured from, which moves with the robot. Turning
-    // that into a fixed frame is a transform, not a relabel: the two differ by however far
-    // odom has drifted, which is the whole reason this node exists between the two.
     std::unique_ptr<tf2_ros::Buffer>            tf_buffer_;
     std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 

--- a/workspace/src/g1_manipulation/launch/manipulation.launch.py
+++ b/workspace/src/g1_manipulation/launch/manipulation.launch.py
@@ -58,6 +58,7 @@ def generate_launch_description():
         remappings=[
             ("~/object_poses", "/g1_sensor_relay/object_poses"),
             ("~/objects", "/objects"),
+            ("~/object_markers", "/object_markers"),
         ],
     )
 

--- a/workspace/src/g1_manipulation/package.xml
+++ b/workspace/src/g1_manipulation/package.xml
@@ -19,6 +19,7 @@
   <depend>g1_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
+  <depend>visualization_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_msgs</depend>
   <depend>shape_msgs</depend>

--- a/workspace/src/g1_manipulation/package.xml
+++ b/workspace/src/g1_manipulation/package.xml
@@ -35,6 +35,7 @@
 
   <!-- ament_lint_common intentionally not used to avoid clang-format conflicts. -->
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>tf2_ros</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -146,6 +146,7 @@ void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray
     // Rebuilt every message, so a vanished object must not leave its marker on screen.
     visualization_msgs::msg::Marker clear;
     clear.action = visualization_msgs::msg::Marker::DELETEALL;
+    markers.markers.reserve(1 + 2 * objects.detections.size());
     markers.markers.push_back(clear);
 
     int id = 0;
@@ -225,8 +226,13 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
         return;
     }
 
-    vision_msgs::msg::Detection3DArray out = *msg;
-    out.header.frame_id                    = output_frame_id_;
+    // Mutated in place and moved out rather than copied: the array carries a vector of
+    // detections, each with its own vector of hypotheses and strings. Safe because this
+    // subscription is inter-process, so the callback owns the only reference -- if this node is
+    // ever composed with intra-process comms on, the message becomes shared and this must go
+    // back to a copy.
+    vision_msgs::msg::Detection3DArray& out = *msg;
+    out.header.frame_id                     = output_frame_id_;
     for (vision_msgs::msg::Detection3D& detection : out.detections)
     {
         detection.header.frame_id = output_frame_id_;

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -49,7 +49,7 @@ G1ObjectPoseSource::G1ObjectPoseSource(const rclcpp::NodeOptions& options)
     declare_parameter<std::string>("object_source", "hardware");
     declare_parameter<std::string>("source_frame_id", "odom");
     declare_parameter<std::string>("output_frame_id", "odom");
-    declare_parameter<bool>("publish_markers", false);
+    declare_parameter<bool>("publish_markers", true);
 }
 
 bool G1ObjectPoseSource::readParameters()
@@ -111,7 +111,7 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_configure(const rclcpp
             "~/object_markers",
             rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local());
     }
-    source_sub_  = create_subscription<vision_msgs::msg::Detection3DArray>(
+    source_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
         "~/object_poses",
         sourceQos(),
         std::bind(&G1ObjectPoseSource::onGroundTruth, this, std::placeholders::_1));
@@ -166,12 +166,12 @@ void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray
         markers.markers.push_back(box);
 
         visualization_msgs::msg::Marker label = box;
-        label.id    = id++;
-        label.ns    = "object_labels";
-        label.type  = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
-        label.text  = detection.id.empty() ? "object" : detection.id;
-        label.scale = geometry_msgs::msg::Vector3();
-        label.scale.z = 0.06;
+        label.id                              = id++;
+        label.ns                              = "object_labels";
+        label.type                            = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+        label.text                            = detection.id.empty() ? "object" : detection.id;
+        label.scale                           = geometry_msgs::msg::Vector3();
+        label.scale.z                         = 0.06;
         label.pose.position.z += 0.5 * detection.bbox.size.z + 0.05;
         label.color.a = 1.0f;
         markers.markers.push_back(label);
@@ -208,7 +208,10 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
         // was somewhere specific, and composing it with a newer transform moves the object by
         // however far the robot walked in between.
         source_to_output = tf_buffer_->lookupTransform(
-            output_frame_id_, msg->header.frame_id, msg->header.stamp, tf2::durationFromSec(0.2));
+            output_frame_id_,
+            msg->header.frame_id,
+            msg->header.stamp,
+            tf2::durationFromSec(0.2));
     }
     catch (const tf2::TransformException& ex)
     {

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -49,6 +49,7 @@ G1ObjectPoseSource::G1ObjectPoseSource(const rclcpp::NodeOptions& options)
     declare_parameter<std::string>("object_source", "hardware");
     declare_parameter<std::string>("source_frame_id", "odom");
     declare_parameter<std::string>("output_frame_id", "odom");
+    declare_parameter<bool>("publish_markers", false);
 }
 
 bool G1ObjectPoseSource::readParameters()
@@ -80,6 +81,7 @@ bool G1ObjectPoseSource::readParameters()
 
     source_frame_id_ = get_parameter("source_frame_id").as_string();
     output_frame_id_ = get_parameter("output_frame_id").as_string();
+    publish_markers_ = get_parameter("publish_markers").as_bool();
     if (source_frame_id_.empty() || output_frame_id_.empty())
     {
         RCLCPP_ERROR(get_logger(), "source_frame_id and output_frame_id must be non-empty");
@@ -101,6 +103,14 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_configure(const rclcpp
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
     objects_pub_ = create_publisher<vision_msgs::msg::Detection3DArray>("~/objects", outputQos());
+    if (publish_markers_)
+    {
+        // Transient local so rviz shows the markers when it connects late, which is the usual
+        // way of looking at them.
+        markers_pub_ = create_publisher<visualization_msgs::msg::MarkerArray>(
+            "~/object_markers",
+            rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local());
+    }
     source_sub_  = create_subscription<vision_msgs::msg::Detection3DArray>(
         "~/object_poses",
         sourceQos(),
@@ -122,9 +132,51 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_cleanup(const rclcpp_l
 {
     source_sub_.reset();
     objects_pub_.reset();
+    markers_pub_.reset();
     tf_listener_.reset();
     tf_buffer_.reset();
     return CallbackReturn::SUCCESS;
+}
+
+// A box at each object's pose and a label above it, drawn from the SAME message /objects
+// carries, so what rviz shows is what a skill acts on rather than a second computation of it.
+void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray& objects)
+{
+    visualization_msgs::msg::MarkerArray markers;
+    // Rebuilt every message, so a vanished object must not leave its marker on screen.
+    visualization_msgs::msg::Marker clear;
+    clear.action = visualization_msgs::msg::Marker::DELETEALL;
+    markers.markers.push_back(clear);
+
+    int id = 0;
+    for (const vision_msgs::msg::Detection3D& detection : objects.detections)
+    {
+        visualization_msgs::msg::Marker box;
+        box.header  = objects.header;
+        box.ns      = "objects";
+        box.id      = id++;
+        box.type    = visualization_msgs::msg::Marker::CUBE;
+        box.action  = visualization_msgs::msg::Marker::ADD;
+        box.pose    = detection.bbox.center;
+        box.scale   = detection.bbox.size;
+        box.color.r = 0.1f;
+        box.color.g = 0.8f;
+        box.color.b = 1.0f;
+        box.color.a = 0.6f;
+        markers.markers.push_back(box);
+
+        visualization_msgs::msg::Marker label = box;
+        label.id    = id++;
+        label.ns    = "object_labels";
+        label.type  = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+        label.text  = detection.id.empty() ? "object" : detection.id;
+        label.scale = geometry_msgs::msg::Vector3();
+        label.scale.z = 0.06;
+        label.pose.position.z += 0.5 * detection.bbox.size.z + 0.05;
+        label.color.a = 1.0f;
+        markers.markers.push_back(label);
+    }
+    markers_pub_->publish(std::move(markers));
 }
 
 void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray::SharedPtr msg)
@@ -185,6 +237,10 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
     // The stamp is carried through rather than refreshed. Restamping here would launder a
     // stale pose as a fresh one, and consumers judge freshness for themselves: only the skill
     // about to grasp knows how old is too old.
+    if (markers_pub_ && markers_pub_->is_activated())
+    {
+        publishMarkers(out);
+    }
     objects_pub_->publish(std::move(out));
 }
 

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -1,7 +1,9 @@
 #include "g1_manipulation/g1_object_pose_source_node.hpp"
 
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <memory>
 #include <string>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <utility>
 
 namespace g1_manipulation
@@ -95,6 +97,9 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_configure(const rclcpp
         return CallbackReturn::FAILURE;
     }
 
+    tf_buffer_   = std::make_unique<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
     objects_pub_ = create_publisher<vision_msgs::msg::Detection3DArray>("~/objects", outputQos());
     source_sub_  = create_subscription<vision_msgs::msg::Detection3DArray>(
         "~/object_poses",
@@ -117,6 +122,8 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_cleanup(const rclcpp_l
 {
     source_sub_.reset();
     objects_pub_.reset();
+    tf_listener_.reset();
+    tf_buffer_.reset();
     return CallbackReturn::SUCCESS;
 }
 
@@ -126,14 +133,10 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
     {
         return;
     }
-    // Verified, not transformed. On this track the source already publishes in odom, because
-    // the simulator's world origin IS odom and sim.launch.py configures g1_sensor_relay to
-    // say so. Silently accepting some other frame would place objects wherever the robot
-    // happens to be standing.
-    //
-    // This is where a real transform belongs when there is one to do: a detector reports in a
-    // camera frame, and this node would do a TF lookup rather than a check. The frames are
-    // separate parameters for that reason, even though today they hold the same value.
+    // The detector reports from the frame it measured in, which rides on the robot. Rewriting
+    // that label to a fixed frame is only correct while the two coincide, and they stop
+    // coinciding the moment odom is an estimate rather than ground truth -- an earlier version
+    // relabelled, and the base approach then chased a point 2 m from where the object was.
     if (msg->header.frame_id != source_frame_id_)
     {
         RCLCPP_WARN_THROTTLE(
@@ -146,11 +149,37 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
         return;
     }
 
+    geometry_msgs::msg::TransformStamped source_to_output;
+    try
+    {
+        // At the message's own stamp, not the latest: the pose was measured when the camera
+        // was somewhere specific, and composing it with a newer transform moves the object by
+        // however far the robot walked in between.
+        source_to_output = tf_buffer_->lookupTransform(
+            output_frame_id_, msg->header.frame_id, msg->header.stamp, tf2::durationFromSec(0.2));
+    }
+    catch (const tf2::TransformException& ex)
+    {
+        RCLCPP_WARN_THROTTLE(
+            get_logger(),
+            *get_clock(),
+            5000,
+            "Cannot place objects in '%s': %s",
+            output_frame_id_.c_str(),
+            ex.what());
+        return;
+    }
+
     vision_msgs::msg::Detection3DArray out = *msg;
     out.header.frame_id                    = output_frame_id_;
     for (vision_msgs::msg::Detection3D& detection : out.detections)
     {
         detection.header.frame_id = output_frame_id_;
+        tf2::doTransform(detection.bbox.center, detection.bbox.center, source_to_output);
+        for (vision_msgs::msg::ObjectHypothesisWithPose& hypothesis : detection.results)
+        {
+            tf2::doTransform(hypothesis.pose.pose, hypothesis.pose.pose, source_to_output);
+        }
     }
 
     // The stamp is carried through rather than refreshed. Restamping here would launder a

--- a/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
@@ -15,8 +15,10 @@
 #include <vector>
 
 #include "g1_manipulation/g1_object_pose_source_node.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/static_transform_broadcaster.h"
 #include "vision_msgs/msg/detection3_d_array.hpp"
 
 using g1_manipulation::G1ObjectPoseSource;
@@ -31,6 +33,18 @@ rclcpp::NodeOptions optionsWithSource(const std::string& source)
 {
     rclcpp::NodeOptions options;
     options.parameter_overrides({ rclcpp::Parameter("object_source", source) });
+    return options;
+}
+
+/// Source and output deliberately different, which is the real configuration: a detector
+/// measures in a camera frame and /objects is published in a fixed one.
+rclcpp::NodeOptions optionsWithFrames(const std::string& source, const std::string& output)
+{
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({ rclcpp::Parameter("object_source", "sim_ground_truth"),
+                                  rclcpp::Parameter("source_frame_id", source),
+                                  rclcpp::Parameter("output_frame_id", output),
+                                  rclcpp::Parameter("publish_markers", false) });
     return options;
 }
 
@@ -113,7 +127,71 @@ private:
     std::optional<vision_msgs::msg::Detection3DArray>                   last_;
 };
 
+/// Publishes one static edge so the node has a real transform to apply.
+std::shared_ptr<rclcpp::Node>
+staticTf(const std::string& parent, const std::string& child, double x, double y, double z)
+{
+    auto node   = std::make_shared<rclcpp::Node>("test_tf");
+    auto caster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+    geometry_msgs::msg::TransformStamped tf;
+    tf.header.stamp            = rclcpp::Time(0, 0);
+    tf.header.frame_id         = parent;
+    tf.child_frame_id          = child;
+    tf.transform.translation.x = x;
+    tf.transform.translation.y = y;
+    tf.transform.translation.z = z;
+    tf.transform.rotation.w    = 1.0;
+    caster->sendTransform(tf);
+    // Held alive by the returned node, which owns the latched publisher.
+    node->set_parameter(rclcpp::Parameter("use_sim_time", false));
+    static std::vector<std::shared_ptr<tf2_ros::StaticTransformBroadcaster>> keep;
+    keep.push_back(caster);
+    return node;
+}
+
 }  // namespace
+
+// The regression this whole change exists for. Before it, the node rewrote the frame label and
+// left the numbers alone, which is correct only while the two frames coincide -- and they stop
+// coinciding the moment odometry is an estimate. A relabel would leave x at 1.0 here.
+TEST(ObjectPoseSource, TransformsThePoseRatherThanRelabellingTheFrame)
+{
+    auto    tf_node = staticTf("odom", "camera_color_optical_frame", 2.0, -3.0, 0.5);
+    Harness harness{ optionsWithFrames("camera_color_optical_frame", "odom") };
+    ASSERT_EQ(harness.configure(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(harness.activate(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+    spinFor({ tf_node->get_node_base_interface() }, 300ms);
+
+    harness.publishAndSpin(
+        makeGroundTruth("camera_color_optical_frame", "red_cube", 1.0, 0.5, 0.25));
+
+    ASSERT_TRUE(harness.last().has_value());
+    const auto& out = *harness.last();
+    EXPECT_EQ(out.header.frame_id, "odom");
+    ASSERT_EQ(out.detections.size(), 1u);
+    const auto& pose = out.detections[0].results[0].pose.pose;
+    EXPECT_NEAR(pose.position.x, 3.0, 1e-6);
+    EXPECT_NEAR(pose.position.y, -2.5, 1e-6);
+    EXPECT_NEAR(pose.position.z, 0.75, 1e-6);
+    // The bbox carries the pose too, and a consumer that reads it instead of the hypothesis
+    // would otherwise get an untransformed one.
+    EXPECT_NEAR(out.detections[0].bbox.center.position.x, 3.0, 1e-6);
+}
+
+// No transform published for this frame, so there is nothing to place the object with.
+// Publishing it anyway, in whatever frame, would put an object somewhere no one measured.
+// A frame name no other test broadcasts: static transforms are transient local and outlive
+// the test that sent them, so reusing the camera frame here would find the earlier one.
+TEST(ObjectPoseSource, PublishesNothingWhenTheTransformIsMissing)
+{
+    Harness harness{ optionsWithFrames("unbroadcast_sensor_frame", "odom") };
+    ASSERT_EQ(harness.configure(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+    ASSERT_EQ(harness.activate(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    harness.publishAndSpin(makeGroundTruth("unbroadcast_sensor_frame", "red_cube", 1.0, 0.5, 0.25));
+
+    EXPECT_FALSE(harness.last().has_value());
+}
 
 TEST(ObjectSource, ParsesTheSourcesItKnowsAndRejectsTheRest)
 {

--- a/workspace/src/g1_moveit_config/config/g1_moveit.rviz
+++ b/workspace/src/g1_moveit_config/config/g1_moveit.rviz
@@ -1,83 +1,84 @@
-# RViz for interactive arm planning.
-#   ros2 launch g1_moveit_config moveit_rviz.launch.py
-#
-# Fixed Frame is pelvis, not odom: moveit_sim.launch.py runs without the sensor track, so
-# g1_state_estimation is not publishing odom -> base_footprint and odom does not exist. pelvis
-# is also MoveIt's planning frame here (g1.srdf declares no virtual joint), so what the
-# MotionPlanning panel reports and what this view shows are the same frame.
-#
-# Planning Group starts on both_arms. The single-arm groups are one dropdown away, and starting
-# on the coordinated group is the reminder that it exists.
 Panels:
-  - Class: rviz_common/Displays
-    Name: Displays
-    Property Tree Widget:
-      Expanded:
-        - /MotionPlanning1
-      Splitter Ratio: 0.5
-    Tree Height: 700
-  - Class: rviz_common/Views
-    Name: Views
+- Class: rviz_common/Displays
+  Name: Displays
+  Property Tree Widget:
+    Expanded:
+    - /MotionPlanning1
+    Splitter Ratio: 0.5
+  Tree Height: 700
+- Class: rviz_common/Views
+  Name: Views
 Visualization Manager:
-  Class: ""
+  Class: ''
   Name: root
   Displays:
-    - Class: rviz_default_plugins/Grid
-      Name: Grid
-      Enabled: true
-      Cell Size: 1
-      Plane Cell Count: 10
-      Color: 160; 160; 164
-    - Class: rviz_default_plugins/TF
-      Name: TF
-      Enabled: false
-      Marker Scale: 0.3
-      Show Arrows: false
-      Show Axes: true
-      Show Names: true
-    - Class: moveit_rviz_plugin/MotionPlanning
-      Name: MotionPlanning
-      Enabled: true
-      Move Group Namespace: ""
-      Robot Description: robot_description
-      Planning Scene Topic: /monitored_planning_scene
-      Planning Request:
-        Planning Group: both_arms
-        Colliding Link Color: 255; 0; 0
-        Goal State Alpha: 1
-        Goal State Color: 250; 128; 0
-        Interactive Marker Size: 0.15
-        Query Goal State: true
-        Query Start State: false
-        Show Workspace: false
-        Start State Alpha: 1
-        Start State Color: 0; 255; 0
-      Planned Path:
-        Trajectory Topic: /display_planned_path
-        Loop Animation: false
-        Show Robot Collision: false
-        Show Robot Visual: true
-        Show Trail: false
-        State Display Time: 0.05 s
-        Interrupt Display: false
-      Scene Geometry:
-        Scene Alpha: 0.9
-        Show Scene Geometry: true
-        Voxel Rendering: Occupied Voxels
-      Scene Robot:
-        Attached Body Color: 150; 50; 150
-        Robot Alpha: 0.5
-        Show Robot Collision: false
-        Show Robot Visual: true
+  - Class: rviz_default_plugins/Grid
+    Name: Grid
+    Enabled: true
+    Cell Size: 1
+    Plane Cell Count: 10
+    Color: 160; 160; 164
+  - Class: rviz_default_plugins/TF
+    Name: TF
+    Enabled: false
+    Marker Scale: 0.3
+    Show Arrows: false
+    Show Axes: true
+    Show Names: true
+  - Class: moveit_rviz_plugin/MotionPlanning
+    Name: MotionPlanning
+    Enabled: true
+    Move Group Namespace: ''
+    Robot Description: robot_description
+    Planning Scene Topic: /monitored_planning_scene
+    Planning Request:
+      Planning Group: both_arms
+      Colliding Link Color: 255; 0; 0
+      Goal State Alpha: 1
+      Goal State Color: 250; 128; 0
+      Interactive Marker Size: 0.15
+      Query Goal State: true
+      Query Start State: false
+      Show Workspace: false
+      Start State Alpha: 1
+      Start State Color: 0; 255; 0
+    Planned Path:
+      Trajectory Topic: /display_planned_path
+      Loop Animation: false
+      Show Robot Collision: false
+      Show Robot Visual: true
+      Show Trail: false
+      State Display Time: 0.05 s
+      Interrupt Display: false
+    Scene Geometry:
+      Scene Alpha: 0.9
+      Show Scene Geometry: true
+      Voxel Rendering: Occupied Voxels
+    Scene Robot:
+      Attached Body Color: 150; 50; 150
+      Robot Alpha: 0.5
+      Show Robot Collision: false
+      Show Robot Visual: true
+  - Class: rviz_default_plugins/MarkerArray
+    Enabled: true
+    Name: Object poses
+    Namespaces: {}
+    Topic:
+      Depth: 1
+      Durability Policy: Transient Local
+      History Policy: Keep Last
+      Reliability Policy: Reliable
+      Value: /object_markers
+    Value: true
   Global Options:
     Background Color: 48; 48; 48
     Fixed Frame: pelvis
     Frame Rate: 30
   Tools:
-    - Class: rviz_default_plugins/Interact
-    - Class: rviz_default_plugins/MoveCamera
-    - Class: rviz_default_plugins/FocusCamera
-    - Class: rviz_default_plugins/Measure
+  - Class: rviz_default_plugins/Interact
+  - Class: rviz_default_plugins/MoveCamera
+  - Class: rviz_default_plugins/FocusCamera
+  - Class: rviz_default_plugins/Measure
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
@@ -98,9 +99,5 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  # Not a plugin, which is why it cannot appear under Panels: the MotionPlanning display
-  # constructs this pane itself and registers it through addPane(), naming it after the
-  # display. So the key has to track the display's Name above, and the pane only exists while
-  # that display does. Every upstream config does it this way (turtlebot3, tiago).
   MotionPlanning - Trajectory Slider:
     collapsed: false

--- a/workspace/src/g1_navigation/README.md
+++ b/workspace/src/g1_navigation/README.md
@@ -222,3 +222,15 @@ ctest --test-dir build/g1_navigation -R '^test_navigate_to_pose$'
 ```
 
 There is deliberately no retry wrapper, because a retry would hide the rate.
+
+### AMCL motion model
+
+`OmniMotionModel`, not differential. The robot strafes: `g1_base_approach` commands lateral
+velocity to line up on an object, and the gait adds uncommanded lateral motion on top. A
+differential model factors every odometry delta into rotate/translate/rotate and cannot express
+sideways motion at all, so it enters the filter as rotation that never happened. Left wrong, a
+mission ended with `map -> odom` at 177 deg of yaw error.
+
+The alphas are nav2's defaults. Values an order of magnitude tighter were correct only against
+exact simulator odometry; `fast_lio` drifts, and a filter told to trust it that far lurches
+instead of correcting.

--- a/workspace/src/g1_navigation/config/g1_navigation.rviz
+++ b/workspace/src/g1_navigation/config/g1_navigation.rviz
@@ -1,325 +1,266 @@
-# RViz for the navigation track: Nav2 displays plus the sensor group, both toggleable.
-#   ros2 launch g1_bringup bringup.launch.py nav:=true mode:=localization rviz:=true
-#
-# Fixed frame is map, so in mapping mode nothing renders until slam_toolbox has published
-# map -> odom. That is a second or two after launch, not a fault.
-#
-# The sensor group here must stay byte-identical to g1_bringup/config/g1_sensors.rviz's,
-# apart from the group's own Enabled flag. test_rviz_configs enforces that -- the two live
-# in different packages and neither package's own tests can see the pair.
-#
-# This file lives in g1_navigation, not g1_bringup, because "Amcl Particle Swarm" is a
-# nav2_rviz_plugins class. Shipping it from g1_bringup would give the bring-up package a
-# Nav2 dependency, which is the one thing M6's layering decision forbids.
 Panels:
-  - Class: rviz_common/Displays
-    Name: Displays
-    Property Tree Widget:
-      Expanded:
-        - /Nav21
-        - /Nav21/Map1
-        - /Nav21/Scan1
-      Splitter Ratio: 0.5
-    Tree Height: 700
-  - Class: rviz_common/Views
-    Name: Views
+- Class: rviz_common/Displays
+  Name: Displays
+  Property Tree Widget:
+    Expanded:
+    - /Nav21
+    - /Nav21/Map1
+    - /Nav21/Scan1
+    Splitter Ratio: 0.5
+  Tree Height: 700
+- Class: rviz_common/Views
+  Name: Views
 Visualization Manager:
-  Class: ""
+  Class: ''
   Name: root
   Displays:
-    # Always relevant, in either mode, so outside both groups.
-    - Class: rviz_default_plugins/Grid
-      Name: Grid
+  - Class: rviz_default_plugins/Grid
+    Name: Grid
+    Enabled: true
+    Cell Size: 1
+    Plane Cell Count: 20
+    Color: 160; 160; 164
+    Alpha: 0.3
+    Reference Frame: <Fixed Frame>
+  - Class: rviz_default_plugins/RobotModel
+    Name: Robot
+    Enabled: true
+    Description Topic:
+      Value: /robot_description
+      Depth: 1
+      Durability Policy: Transient Local
+      Reliability Policy: Reliable
+    Alpha: 0.8
+  - Class: rviz_default_plugins/TF
+    Name: TF
+    Enabled: true
+    Show Names: true
+    Show Axes: true
+    Show Arrows: false
+    Marker Scale: 0.4
+  - Class: rviz_default_plugins/Odometry
+    Name: Odometry
+    Enabled: false
+    Topic:
+      Value: /g1_odometry_publisher/odom
+      Depth: 100
+      Durability Policy: Volatile
+      Reliability Policy: Reliable
+    Keep: 100
+    Position Tolerance: 0.2
+    Angle Tolerance: 0.2
+    Shape:
+      Alpha: 0.6
+      Color: 0; 170; 255
+      Shaft Length: 0.3
+      Shaft Radius: 0.03
+      Head Length: 0.1
+      Head Radius: 0.06
+  - Class: rviz_common/Group
+    Name: Nav2
+    Enabled: true
+    Displays:
+    - Class: rviz_default_plugins/Map
+      Name: Map
       Enabled: true
-      Cell Size: 1
-      Plane Cell Count: 20
-      Color: 160; 160; 164
-      Alpha: 0.3
-      Reference Frame: <Fixed Frame>
-
-    # Renders because g1_description installs the meshes from unitree_mujoco's vendored set
-    # and the URDF names them package://. Before that it drew nothing and emitted ~174
-    # "Could not resolve host: meshes" lines a session.
-    #
-    # Needs pelvis -> torso_link, which motion_service_sim supplies from /lowstate;
-    # joint_state_broadcaster only covers the arms.
-    - Class: rviz_default_plugins/RobotModel
-      Name: Robot
-      Enabled: true
-      Description Topic:
-        Value: /robot_description
+      Topic:
+        Value: /map
         Depth: 1
         Durability Policy: Transient Local
         Reliability Policy: Reliable
-      Alpha: 0.8
-
-    # base_footprint and pelvis are the two worth watching: the first should stay flat on the
-    # floor, the second carries the gait's tilt.
-    - Class: rviz_default_plugins/TF
-      Name: TF
+      Alpha: 0.7
+      Color Scheme: map
+      Draw Behind: true
+    - Class: rviz_default_plugins/LaserScan
+      Name: Scan
       Enabled: true
-      Show Names: true
-      Show Axes: true
-      Show Arrows: false
-      Marker Scale: 0.4
-
-    - Class: rviz_default_plugins/Odometry
-      Name: Odometry
-      Enabled: false
       Topic:
-        Value: /g1_odometry_publisher/odom
-        Depth: 100
+        Value: /scan
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Size (m): 0.04
+      Style: Points
+      Color: 255; 85; 0
+      Color Transformer: FlatColor
+    - Class: nav2_rviz_plugins/ParticleCloud
+      Name: Amcl Particle Swarm
+      Enabled: true
+      Topic:
+        Value: /particle_cloud
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Shape: Arrow (Flat)
+    - Class: rviz_default_plugins/Path
+      Name: Global plan
+      Enabled: true
+      Topic:
+        Value: /plan
+        Depth: 1
         Durability Policy: Volatile
         Reliability Policy: Reliable
-      Keep: 100
-      Position Tolerance: 0.2
-      Angle Tolerance: 0.2
-      Shape:
-        Alpha: 0.6
-        Color: 0; 170; 255
-        Shaft Length: 0.3
-        Shaft Radius: 0.03
-        Head Length: 0.1
-        Head Radius: 0.06
-
-    - Class: rviz_common/Group
-      Name: Nav2
+      Color: 0; 200; 120
+      Line Style: Lines
+    - Class: rviz_default_plugins/Path
+      Name: Local plan
       Enabled: true
-      Displays:
-        - Class: rviz_default_plugins/Map
-          Name: Map
-          Enabled: true
-          Topic:
-            Value: /map
-            Depth: 1
-            Durability Policy: Transient Local
-            Reliability Policy: Reliable
-          Alpha: 0.7
-          Color Scheme: map
-          Draw Behind: true
-
-        # What slam_toolbox and AMCL actually consume. If this looks right and the map does
-        # not, the problem is the matcher or the pose, not the flatten.
-        - Class: rviz_default_plugins/LaserScan
-          Name: Scan
-          Enabled: true
-          Topic:
-            Value: /scan
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Size (m): 0.04
-          Style: Points
-          Color: 255; 85; 0
-          Color Transformer: FlatColor
-
-        # AMCL's hypothesis spread. localization.yaml runs 500-2000 particles, so a swarm
-        # that has not collapsed after a few metres of driving means the scan match is not
-        # constraining the pose.
-        - Class: nav2_rviz_plugins/ParticleCloud
-          Name: Amcl Particle Swarm
-          Enabled: true
-          Topic:
-            Value: /particle_cloud
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Shape: Arrow (Flat)
-
-        # What the planner produced, and what the controller is actually following. If the
-        # robot is stationary with a plan on screen, the gap is the gait's dead zone, not the
-        # planner.
-        - Class: rviz_default_plugins/Path
-          Name: Global plan
-          Enabled: true
-          Topic:
-            Value: /plan
-            Depth: 1
-            Durability Policy: Volatile
-            Reliability Policy: Reliable
-          Color: 0; 200; 120
-          Line Style: Lines
-
-        - Class: rviz_default_plugins/Path
-          Name: Local plan
-          Enabled: true
-          Topic:
-            Value: /local_plan
-            Depth: 1
-            Durability Policy: Volatile
-            Reliability Policy: Reliable
-          Color: 255; 200; 0
-          Line Style: Lines
-
-        # Costmaps, not the raw map. The local one is where the 0.08 m floor cut and the
-        # 0.45 m footprint show up; if the whole floor is lethal, that cut is wrong.
-        - Class: rviz_default_plugins/Map
-          Name: Global costmap
-          Enabled: false
-          Topic:
-            Value: /global_costmap/costmap
-            Depth: 1
-            Durability Policy: Transient Local
-            Reliability Policy: Reliable
-          Alpha: 0.5
-          Color Scheme: costmap
-
-        - Class: rviz_default_plugins/Map
-          Name: Local costmap
-          Enabled: true
-          Topic:
-            Value: /local_costmap/costmap
-            Depth: 1
-            Durability Policy: Transient Local
-            Reliability Policy: Reliable
-          Alpha: 0.6
-          Color Scheme: costmap
-
-        # The voxel layer's marked cells, which is the only view that shows the z band the
-        # 40-voxel column actually covers. Local only: the global costmap runs obstacle_layer,
-        # not voxel_layer, so /global_costmap/voxel_marked_cloud is never published.
-        - Class: rviz_default_plugins/PointCloud2
-          Name: Local voxel grid
-          Enabled: false
-          Topic:
-            Value: /local_costmap/voxel_marked_cloud
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Reliable
-          Style: Boxes
-          Size (m): 0.05
-          Alpha: 1
-          Color: 125; 125; 125
-          Color Transformer: FlatColor
-          Decay Time: 0
-          Position Transformer: XYZ
-          Use Fixed Frame: true
-
-        # The ramp appears here as an obstacle. That is correct for this gait, and looks like
-        # a bug if you do not know it: slope_ramp's surface sits above the costmap's floor cut.
-        - Class: rviz_default_plugins/Polygon
-          Name: Footprint
-          Enabled: true
-          Topic:
-            Value: /local_costmap/published_footprint
-            Depth: 1
-            Durability Policy: Volatile
-            Reliability Policy: Reliable
-          Color: 0; 170; 255
-
-        - Class: rviz_default_plugins/Polygon
-          Name: Global footprint
-          Enabled: false
-          Topic:
-            Value: /global_costmap/published_footprint
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Reliable
-          Color: 25; 255; 0
-
-    # BEGIN SENSOR GROUP -- kept identical to g1_bringup/config/g1_sensors.rviz
-    - Class: rviz_common/Group
-      Name: Sensors
+      Topic:
+        Value: /local_plan
+        Depth: 1
+        Durability Policy: Volatile
+        Reliability Policy: Reliable
+      Color: 255; 200; 0
+      Line Style: Lines
+    - Class: rviz_default_plugins/Map
+      Name: Global costmap
       Enabled: false
-      Displays:
-        # Sampled inside unitree_mujoco, published by g1_sensor_relay. Best-effort to match
-        # the publisher: a Reliable subscriber here shows nothing at all.
-        - Class: rviz_default_plugins/PointCloud2
-          Name: LiDAR
-          Enabled: true
-          Topic:
-            Value: /livox/lidar
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Style: Points
-          Size (Pixels): 2
-          Alpha: 1
-          Decay Time: 0
-          Position Transformer: XYZ
-          Color Transformer: AxisColor
-          Axis: Z
-          Autocompute Intensity Bounds: true
-          Invert Rainbow: false
-
-        # Depth as a 3D cloud, projected through camera_info. This is the camera's own view
-        # of the world, so it should overlap the LiDAR returns where the two see the same
-        # surfaces; if it floats away from them, the mount or the depth scale is wrong.
-        - Class: rviz_default_plugins/DepthCloud
-          Name: Depth cloud
-          Enabled: true
-          Topic Filter: false
-          Depth Map Topic: /camera/aligned_depth_to_color/image_raw
-          Depth Map Transport Hint: raw
-          Color Transport Hint: raw
-          Queue Size: 5
-          Style: Points
-          Size (Pixels): 3
-          Alpha: 1
-          Decay Time: 0
-          Color Image Topic: /camera/color/image_raw
-          Color Transformer: RGB8
-          Occlusion Compensation:
-            Occlusion Time-Out: 30
-            Enabled: false
-
-        # The same data as a 2D panel, which is the quickest way to see that the camera is
-        # pointed where you think and is not returning a blank frame.
-        - Class: rviz_default_plugins/Image
-          Name: Depth image
-          Enabled: true
-          Topic:
-            Value: /camera/aligned_depth_to_color/image_raw
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Max Value: 4
-          Min Value: 0.5
-          Median window: 5
-          Normalize Range: false
-
-        # Colour from the same render as the depth above, so the two line up pixel for pixel.
-        - Class: rviz_default_plugins/Image
-          Name: Colour image
-          Enabled: true
-          Topic:
-            Value: /camera/color/image_raw
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Normalize Range: true
-
-        # Where the simulator says the sensor is. Diagnostic: it is the ground truth the
-        # cloud was swept from, so it should sit exactly on the robot's Mid360.
-        - Class: rviz_default_plugins/Pose
-          Name: Sensor pose
-          Enabled: false
-          Topic:
-            Value: /g1_sensor_relay/sensor_pose
-            Depth: 5
-            Durability Policy: Volatile
-            Reliability Policy: Best Effort
-          Shape: Axes
-          Axes Length: 0.3
-          Axes Radius: 0.02
-    # END SENSOR GROUP
-
+      Topic:
+        Value: /global_costmap/costmap
+        Depth: 1
+        Durability Policy: Transient Local
+        Reliability Policy: Reliable
+      Alpha: 0.5
+      Color Scheme: costmap
+    - Class: rviz_default_plugins/Map
+      Name: Local costmap
+      Enabled: true
+      Topic:
+        Value: /local_costmap/costmap
+        Depth: 1
+        Durability Policy: Transient Local
+        Reliability Policy: Reliable
+      Alpha: 0.6
+      Color Scheme: costmap
+    - Class: rviz_default_plugins/PointCloud2
+      Name: Local voxel grid
+      Enabled: false
+      Topic:
+        Value: /local_costmap/voxel_marked_cloud
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Reliable
+      Style: Boxes
+      Size (m): 0.05
+      Alpha: 1
+      Color: 125; 125; 125
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Position Transformer: XYZ
+      Use Fixed Frame: true
+    - Class: rviz_default_plugins/Polygon
+      Name: Footprint
+      Enabled: true
+      Topic:
+        Value: /local_costmap/published_footprint
+        Depth: 1
+        Durability Policy: Volatile
+        Reliability Policy: Reliable
+      Color: 0; 170; 255
+    - Class: rviz_default_plugins/Polygon
+      Name: Global footprint
+      Enabled: false
+      Topic:
+        Value: /global_costmap/published_footprint
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Reliable
+      Color: 25; 255; 0
+  - Class: rviz_common/Group
+    Name: Sensors
+    Enabled: false
+    Displays:
+    - Class: rviz_default_plugins/PointCloud2
+      Name: LiDAR
+      Enabled: true
+      Topic:
+        Value: /livox/lidar
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Style: Points
+      Size (Pixels): 2
+      Alpha: 1
+      Decay Time: 0
+      Position Transformer: XYZ
+      Color Transformer: AxisColor
+      Axis: Z
+      Autocompute Intensity Bounds: true
+      Invert Rainbow: false
+    - Class: rviz_default_plugins/DepthCloud
+      Name: Depth cloud
+      Enabled: true
+      Topic Filter: false
+      Depth Map Topic: /camera/aligned_depth_to_color/image_raw
+      Depth Map Transport Hint: raw
+      Color Transport Hint: raw
+      Queue Size: 5
+      Style: Points
+      Size (Pixels): 3
+      Alpha: 1
+      Decay Time: 0
+      Color Image Topic: /camera/color/image_raw
+      Color Transformer: RGB8
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Enabled: false
+    - Class: rviz_default_plugins/Image
+      Name: Depth image
+      Enabled: true
+      Topic:
+        Value: /camera/aligned_depth_to_color/image_raw
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Max Value: 4
+      Min Value: 0.5
+      Median window: 5
+      Normalize Range: false
+    - Class: rviz_default_plugins/Image
+      Name: Colour image
+      Enabled: true
+      Topic:
+        Value: /camera/color/image_raw
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Normalize Range: true
+    - Class: rviz_default_plugins/Pose
+      Name: Sensor pose
+      Enabled: false
+      Topic:
+        Value: /g1_sensor_relay/sensor_pose
+        Depth: 5
+        Durability Policy: Volatile
+        Reliability Policy: Best Effort
+      Shape: Axes
+      Axes Length: 0.3
+      Axes Radius: 0.02
+  - Class: rviz_default_plugins/MarkerArray
+    Enabled: true
+    Name: Object poses
+    Namespaces: {}
+    Topic:
+      Depth: 1
+      Durability Policy: Transient Local
+      History Policy: Keep Last
+      Reliability Policy: Reliable
+      Value: /object_markers
+    Value: true
   Global Options:
     Background Color: 48; 48; 48
     Fixed Frame: map
     Frame Rate: 30
   Tools:
-    - Class: rviz_default_plugins/MoveCamera
-    - Class: rviz_default_plugins/FocusCamera
-    - Class: rviz_default_plugins/Measure
-    - Class: rviz_default_plugins/SetGoal
-      Topic:
-        Value: /goal_pose
-    # AMCL takes an initial pose here when the shipped one is wrong -- e.g. after driving the
-    # robot somewhere before starting localization.
-    - Class: rviz_default_plugins/SetInitialPose
-      Topic:
-        Value: /initialpose
+  - Class: rviz_default_plugins/MoveCamera
+  - Class: rviz_default_plugins/FocusCamera
+  - Class: rviz_default_plugins/Measure
+  - Class: rviz_default_plugins/SetGoal
+    Topic:
+      Value: /goal_pose
+  - Class: rviz_default_plugins/SetInitialPose
+    Topic:
+      Value: /initialpose
   Value: true
   Views:
     Current:

--- a/workspace/src/g1_navigation/config/localization.yaml
+++ b/workspace/src/g1_navigation/config/localization.yaml
@@ -4,11 +4,14 @@
 # map. That mode loads a serialized pose graph, and for this map that is 33 MB against 130 KB
 # for the occupancy grid -- see maps/README.md.
 #
-# The honest caveat, repeated here because the numbers below look more meaningful than they
-# are: AMCL's motion model is parameterised on odometry noise, and this track's odometry is
-# exact MuJoCo ground truth. The model is degenerate, map -> odom converges to identity
-# immediately, and none of the alpha values can be tuned to anything that transfers to
-# hardware. This exercises the real pipeline; it does not validate localization.
+# Which odometry source is running changes what these values mean. Under
+# `odometry:=sportmodestate` the input is exact MuJoCo state, map -> odom converges to identity
+# and the noise model is degenerate. Under `odometry:=fast_lio` -- what the robot runs -- it
+# drifts, and every value below is load-bearing. Tuned for the latter, because a filter that
+# only works against ground truth is not localization.
+#
+# Every parameter nav2_amcl accepts is listed, defaults included, so changing one is an edit
+# rather than a search. `ros2 param dump /amcl` against a running node regenerates the list.
 map_server:
   ros__parameters:
     use_sim_time: false
@@ -21,29 +24,30 @@ amcl:
 
     global_frame_id: "map"
     odom_frame_id: "odom"
+    map_topic: "map"
+    # Default. True would ignore map updates after the first, which matters only if something
+    # republishes the map mid-run; nothing here does.
+    first_map_only: false
     # Gravity-aligned and on the ground. Nav2's default of base_footprint happens to be right
     # here, but only because g1_state_estimation publishes one -- the URDF root is pelvis.
     base_frame_id: "base_footprint"
     scan_topic: /scan
 
-    # The robot cannot strafe on command, so this is the closest of the shipped models. It is
-    # a poor description of a gait that produces 0.3 m/s of uncommanded lateral motion, which
-    # is another reason not to read anything into the alphas.
-    robot_model_type: "nav2_amcl::DifferentialMotionModel"
-    # Deliberately an order of magnitude below the usual 0.2. Those values describe wheel slip
-    # on a real differential base; this track's odometry is MuJoCo ground truth, so 0.2 injects
-    # error that is not there. The particle cloud spread on every motion update and the scan
-    # match then pulled it back, which is what produced visible map to odom steps: measured at
-    # 11 corrections in 200 s, up to 10.4 cm and 2.08 deg, against a source that is exact by
-    # construction.
-    #
-    # SIM-ONLY tuning. On hardware, where odometry really does drift, these are far too tight
-    # and the filter would fail to track.
-    alpha1: 0.02
-    alpha2: 0.02
-    alpha3: 0.02
-    alpha4: 0.02
-    alpha5: 0.02
+    # The robot does strafe: g1_base_approach commands lateral velocity to line up on an
+    # object, and the gait adds 0.22-0.30 m/s of uncommanded lateral motion on top. A
+    # differential model cannot express that at all -- it factors every delta into
+    # rotate/translate/rotate, so sideways motion enters the filter as a rotation that never
+    # happened. Measured cost of getting this wrong: a mission that ended with map -> odom at
+    # 177 deg of yaw error, the particle cloud having flipped end for end.
+    robot_model_type: "nav2_amcl::OmniMotionModel"
+    # Nav2's defaults. The 0.02 they replace said "the odometry is exact", which was true only
+    # of the sportmodestate track's MuJoCo ground truth. fast_lio drifts, so a filter told to
+    # trust it that far cannot correct in time and lurches instead.
+    alpha1: 0.2
+    alpha2: 0.2
+    alpha3: 0.2
+    alpha4: 0.2
+    alpha5: 0.2
 
     # Matches the scan's own limits, so AMCL weighs exactly the beams that exist.
     laser_max_range: 25.0
@@ -60,10 +64,8 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
 
-    # Tightened alongside the alphas above. The original reasoning was that a smaller threshold
-    # resamples on noise, but with the alphas cut there is far less injected noise to resample
-    # on, and batching the correction until the robot had moved 0.25 m is what made it land as
-    # one visible step. A 56 s gap between corrections was measured at the old values.
+    # Nav2's defaults. Correcting this often matters more now that the odometry drifts: at
+    # 0.25 m the correction batched up and landed as one visible step.
     update_min_d: 0.10
     update_min_a: 0.10
 
@@ -88,6 +90,9 @@ amcl:
     # so the initial pose is known rather than guessed. Without this AMCL waits for a manual
     # 2D Pose Estimate in RViz, which a launch test cannot give it.
     set_initial_pose: true
+    # Default. True re-seeds the filter from initial_pose on every activation, which would
+    # discard a good estimate every time the lifecycle cycles.
+    always_reset_initial_pose: false
     initial_pose:
       x: 0.0
       y: 0.0

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -7,6 +7,9 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
 find_package(livox_ros_driver2 REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 # Framing and validation, free of ROS and sockets so the wire format tests without a
 # simulator or a running graph.
@@ -19,7 +22,8 @@ target_compile_features(frame_reader PUBLIC cxx_std_20)
 
 add_executable(g1_sensor_relay src/g1_sensor_relay_node.cpp)
 target_link_libraries(g1_sensor_relay PUBLIC frame_reader)
-ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs geometry_msgs vision_msgs)
+ament_target_dependencies(g1_sensor_relay PUBLIC rclcpp sensor_msgs geometry_msgs vision_msgs
+  tf2 tf2_geometry_msgs tf2_ros)
 
 # The conversion itself, split out so it tests without a graph.
 add_library(livox_custom_msg src/livox_custom_msg.cpp)

--- a/workspace/src/g1_sensor_relay/README.md
+++ b/workspace/src/g1_sensor_relay/README.md
@@ -126,3 +126,14 @@ of `sensor_frame.h`. `test_livox_custom_msg` covers the conversion against FAST-
 discard gates (`line`, the tag bits, `offset_time`) and the miss handling. Neither needs a
 simulator. `g1_bringup`'s `test_lidar_geometry` asserts the
 published cloud measures the room it is in.
+
+### Object poses are reported as the camera would see them
+
+`~/object_poses` carries objects in `camera_color_optical_frame`, not in the simulator's world
+frame. The simulator knows world poses; a detector knows what is in front of its lens, and
+everything downstream is built for the latter. The conversion happens here so it stays inside
+the sim-only boundary and `g1_object_pose_source` runs the same code on the robot.
+
+The camera's world pose comes from the LiDAR sweep's own ground-truth pose composed with the
+rigid LiDAR-to-camera transform, so it is one sweep stale. That is a few centimetres at walking
+pace, and a truer model of a real detector than an exact answer would be.

--- a/workspace/src/g1_sensor_relay/package.xml
+++ b/workspace/src/g1_sensor_relay/package.xml
@@ -19,6 +19,9 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>livox_ros_driver2</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstring>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -24,6 +25,9 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <string>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <utility>
 #include <vector>
 #include <vision_msgs/msg/detection3_d_array.hpp>
@@ -279,14 +283,26 @@ private:
         imu_pub_->publish(std::move(imu));
     }
 
-    /// Ground truth, republished verbatim in the simulator's world frame. This node does no
-    /// interpreting: g1_object_pose_source is the boundary that decides whether a consumer is
-    /// allowed to believe any of it, and on hardware that node refuses to run at all.
+    /// Ground truth, re-expressed as the camera would have measured it. The simulator reports
+    /// world poses; a detector reports what it sees from its own lens, and everything
+    /// downstream is built for the latter. Doing the conversion here keeps the difference
+    /// inside the sim-only boundary, so g1_object_pose_source and the skills below it run the
+    /// same code on the robot.
+    ///
+    /// Publishing world coordinates under a fixed-frame label instead is what this replaced,
+    /// and it is exact only while that frame IS the world. It stopped being true the moment
+    /// odom became an estimate, and the base approach then drove at a point 2 m from the cube.
     void publishObjects(const CloudFrame& frame)
     {
+        geometry_msgs::msg::TransformStamped world_to_camera;
+        if (!worldToCamera(world_to_camera))
+        {
+            return;
+        }
+
         vision_msgs::msg::Detection3DArray msg;
         msg.header.stamp    = now();
-        msg.header.frame_id = world_frame_id_;
+        msg.header.frame_id = color_frame_id_;
         msg.detections.reserve(frame.objects.size());
 
         for (const grove_g1::ObjectPoseRecord& record : frame.objects)
@@ -300,13 +316,15 @@ private:
             // Ground truth: there is nothing to be uncertain about. A real detector fills
             // this with its own confidence and the consumer can threshold on it.
             hypothesis.hypothesis.score        = 1.0;
-            hypothesis.pose.pose.position.x    = record.pos[0];
-            hypothesis.pose.pose.position.y    = record.pos[1];
-            hypothesis.pose.pose.position.z    = record.pos[2];
-            hypothesis.pose.pose.orientation.w = record.quat[0];
-            hypothesis.pose.pose.orientation.x = record.quat[1];
-            hypothesis.pose.pose.orientation.y = record.quat[2];
-            hypothesis.pose.pose.orientation.z = record.quat[3];
+            geometry_msgs::msg::Pose in_world;
+            in_world.position.x    = record.pos[0];
+            in_world.position.y    = record.pos[1];
+            in_world.position.z    = record.pos[2];
+            in_world.orientation.w = record.quat[0];
+            in_world.orientation.x = record.quat[1];
+            in_world.orientation.y = record.quat[2];
+            in_world.orientation.z = record.quat[3];
+            tf2::doTransform(in_world, hypothesis.pose.pose, world_to_camera);
 
             detection.bbox.center = hypothesis.pose.pose;
             // Full widths, which is what BoundingBox3D means by size. A consumer builds its
@@ -320,6 +338,42 @@ private:
             msg.detections.push_back(std::move(detection));
         }
         objects_pub_->publish(std::move(msg));
+    }
+
+    /// Inverse of the camera's world pose, built from the LiDAR's ground-truth world pose and
+    /// the rigid LiDAR-to-camera transform out of the URDF. False until the first sweep, and
+    /// while TF has not yet published the robot's own links.
+    ///
+    /// One sweep stale: the simulator sends the object frame just before the sweep it shares a
+    /// cycle with, so this is the previous cycle's pose. That is a few centimetres at walking
+    /// pace, and it is a truer model of a real detector than an exact answer would be -- a
+    /// camera's measurement is always slightly behind the world too.
+    bool worldToCamera(geometry_msgs::msg::TransformStamped& out)
+    {
+        if (!sensor_in_world_valid_)
+        {
+            return false;
+        }
+        geometry_msgs::msg::TransformStamped sensor_to_camera;
+        try
+        {
+            sensor_to_camera =
+                tf_buffer_.lookupTransform(color_frame_id_, frame_id_, tf2::TimePointZero);
+        }
+        catch (const tf2::TransformException& ex)
+        {
+            RCLCPP_WARN_THROTTLE(
+                get_logger(), *get_clock(), 5000, "No %s -> %s yet: %s",
+                frame_id_.c_str(), color_frame_id_.c_str(), ex.what());
+            return false;
+        }
+
+        tf2::Transform world_to_sensor;
+        tf2::fromMsg(sensor_in_world_, world_to_sensor);
+        tf2::Transform to_camera;
+        tf2::fromMsg(sensor_to_camera.transform, to_camera);
+        out.transform = tf2::toMsg(to_camera * world_to_sensor.inverse());
+        return true;
     }
 
     void publishDepth(const CloudFrame& frame)
@@ -468,8 +522,19 @@ private:
         pose.pose.orientation.z = frame.sensor_quat[3];
         pose_pub_->publish(pose);
 
+        // The only ground-truth world pose of anything on the robot that reaches this node.
+        // publishObjects needs it to work out what the camera would have seen, and the object
+        // frame arrives with no sensor pose of its own (sensor_publisher.cc says so).
+        sensor_in_world_       = pose.pose;
+        sensor_in_world_valid_ = true;
+
         cloud_pub_->publish(std::move(msg));
     }
+
+    geometry_msgs::msg::Pose sensor_in_world_;
+    bool                     sensor_in_world_valid_ = false;
+    tf2_ros::Buffer          tf_buffer_{ get_clock() };
+    tf2_ros::TransformListener tf_listener_{ tf_buffer_ };
 
     std::string socket_path_;
     std::string frame_id_;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -11,6 +11,8 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <unistd.h>
 
 #include <cerrno>
@@ -26,8 +28,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <string>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 #include <utility>
 #include <vector>
 #include <vision_msgs/msg/detection3_d_array.hpp>
@@ -315,7 +315,7 @@ private:
             hypothesis.hypothesis.class_id = record.name;
             // Ground truth: there is nothing to be uncertain about. A real detector fills
             // this with its own confidence and the consumer can threshold on it.
-            hypothesis.hypothesis.score        = 1.0;
+            hypothesis.hypothesis.score = 1.0;
             geometry_msgs::msg::Pose in_world;
             in_world.position.x    = record.pos[0];
             in_world.position.y    = record.pos[1];
@@ -363,8 +363,13 @@ private:
         catch (const tf2::TransformException& ex)
         {
             RCLCPP_WARN_THROTTLE(
-                get_logger(), *get_clock(), 5000, "No %s -> %s yet: %s",
-                frame_id_.c_str(), color_frame_id_.c_str(), ex.what());
+                get_logger(),
+                *get_clock(),
+                5000,
+                "No %s -> %s yet: %s",
+                frame_id_.c_str(),
+                color_frame_id_.c_str(),
+                ex.what());
             return false;
         }
 
@@ -531,9 +536,9 @@ private:
         cloud_pub_->publish(std::move(msg));
     }
 
-    geometry_msgs::msg::Pose sensor_in_world_;
-    bool                     sensor_in_world_valid_ = false;
-    tf2_ros::Buffer          tf_buffer_{ get_clock() };
+    geometry_msgs::msg::Pose   sensor_in_world_;
+    bool                       sensor_in_world_valid_ = false;
+    tf2_ros::Buffer            tf_buffer_{ get_clock() };
     tf2_ros::TransformListener tf_listener_{ tf_buffer_ };
 
     std::string socket_path_;

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -21,6 +21,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <memory>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -350,7 +351,7 @@ private:
     /// camera's measurement is always slightly behind the world too.
     bool worldToCamera(geometry_msgs::msg::TransformStamped& out)
     {
-        if (!sensor_in_world_valid_)
+        if (!sensor_in_world_)
         {
             return false;
         }
@@ -373,11 +374,14 @@ private:
             return false;
         }
 
-        tf2::Transform world_to_sensor;
-        tf2::fromMsg(sensor_in_world_, world_to_sensor);
+        // sensor_to_world, not the reverse: sensor_in_world_ is the sensor's pose expressed in
+        // world, which maps sensor points into world. Inverting it is what makes the product
+        // camera_T_world, so the inverse is load-bearing rather than redundant.
+        tf2::Transform sensor_to_world;
+        tf2::fromMsg(*sensor_in_world_, sensor_to_world);
         tf2::Transform to_camera;
         tf2::fromMsg(sensor_to_camera.transform, to_camera);
-        out.transform = tf2::toMsg(to_camera * world_to_sensor.inverse());
+        out.transform = tf2::toMsg(to_camera * sensor_to_world.inverse());
         return true;
     }
 
@@ -530,16 +534,14 @@ private:
         // The only ground-truth world pose of anything on the robot that reaches this node.
         // publishObjects needs it to work out what the camera would have seen, and the object
         // frame arrives with no sensor pose of its own (sensor_publisher.cc says so).
-        sensor_in_world_       = pose.pose;
-        sensor_in_world_valid_ = true;
+        sensor_in_world_ = pose.pose;
 
         cloud_pub_->publish(std::move(msg));
     }
 
-    geometry_msgs::msg::Pose   sensor_in_world_;
-    bool                       sensor_in_world_valid_ = false;
-    tf2_ros::Buffer            tf_buffer_{ get_clock() };
-    tf2_ros::TransformListener tf_listener_{ tf_buffer_ };
+    std::optional<geometry_msgs::msg::Pose> sensor_in_world_;
+    tf2_ros::Buffer                         tf_buffer_{ get_clock() };
+    tf2_ros::TransformListener              tf_listener_{ tf_buffer_ };
 
     std::string socket_path_;
     std::string frame_id_;


### PR DESCRIPTION
Running the pick-and-place mission on `odometry:=fast_lio` -- the LiDAR-inertial source the real
robot uses -- hung forever in the base approach. Two separate faults, both invisible on the
simulator's ground-truth odometry.

## Object poses were announced in the wrong frame

`g1_sensor_relay` published objects at their simulator world coordinates while stamping them
`odom`, and `g1_object_pose_source` relabelled the frame rather than transforming it. That is
exact only while `odom` IS the world, which stops being true the moment odometry is an estimate.
With fast_lio drifted 18 deg, the approach chased a point it believed was 2.6 m away that was
really 0.55 m away, and could never converge.

The relay now reports in `camera_color_optical_frame`, which is what a 6D-pose detector on the
D435 produces, and the pose source does a real TF lookup at the message stamp. `g1_base_approach`
needed no change -- it already transformed into `base_footprint`, and that hop runs through rigid
robot links only, so odometry drift cancels instead of accumulating.

Measured with fast_lio's yaw 4.85 deg off ground truth: range correct to 0.16 mm, bearing to
0.027 deg.

## AMCL was running a differential motion model on a robot that strafes

`g1_base_approach` commands lateral velocity to line up on an object, and the gait adds more on
top. A differential model cannot express sideways motion -- it factors every delta into
rotate/translate/rotate, so each lateral pulse enters the filter as a rotation that never
happened. One mission ended with `map -> odom` at 177 deg of yaw error, the particle cloud
flipped end for end.

`OmniMotionModel`, and the alphas move to nav2's defaults: an order of magnitude tighter was
correct only against exact odometry. `map -> odom` now stays bounded at ~5 deg.

    map -> odom      translation        yaw      mission
    differential     (8.130, -9.733)    176.7    FAILURE
    omni             (0.308, -0.270)      5.6    SUCCESS

Every `nav2_amcl` parameter is now listed in `localization.yaml` at its default, so changing one
is an edit rather than a search.

## Also

- `~/object_markers` (on by default) draws each object for rviz, built from the same message
  `/objects` carries. Both shipped rviz configs display it.
- `TransformsThePoseRatherThanRelabellingTheFrame` is the regression that was missing. It fails
  against the old code; the previous suite passed either way, because both frame parameters were
  `odom` and the transform was an identity.

## Known, not introduced here

The mission passes roughly one run in three on fast_lio. Two pre-existing faults, both on that
path only, both now diagnosed:

- `pick_the_cube` -- the approach's `forward_tolerance_m` of +/-0.110 is wider than the arm's
  usable window, so it can stop somewhere the pregrasp is unreachable.
- `put_it_on_the_pad` -- the retreat is planned before collision checking against the touched
  objects is restored, so the arm may lift straight through the cube and nudge it. The check that
  reports this runs after the retreat while being labelled `release`, which misattributes it.

Neither is caused by this branch, and neither is fixed here.