### PR TITLE
Stop the arm hitting the bench, and give the postures room

### DIFF
--- a/workspace/src/g1_locomotion/README.md
+++ b/workspace/src/g1_locomotion/README.md
@@ -181,6 +181,11 @@ sits relative to the robot is the whole of reachability; which way the room face
 An earlier version judged it in the working-heading frame and spent most of its pulse budget chasing
 alignment that cost nothing.
 
+`standoff_object_ids` / `standoff_target_x_m` name objects that need a different `target_x_m` from
+the default. Reaching over a surface to set something down sweeps the palm and wrist across its
+face, which reaching onto one for an object does not: `drop_pad` is approached to 0.350 where the
+cube uses 0.270.
+
 `target_x_m` / `target_y_m` and their tolerances are the arm's reachable band, MEASURED with
 `/compute_ik` plus `/check_state_validity` at the workbench, not guessed. Being stricter than the arm is not free: a run that finished a good approach 13 mm
 outside a too-tight forward tolerance then creeped for forty pulses.

--- a/workspace/src/g1_locomotion/config/g1_base_approach.yaml
+++ b/workspace/src/g1_locomotion/config/g1_base_approach.yaml
@@ -111,6 +111,12 @@ g1_base_approach:
     target_x_m: 0.270
     target_y_m: -0.220
 
+    # Objects the robot must stand FURTHER BACK from than target_x_m. Reaching over a surface to
+    # set something down sweeps the palm and wrist across its face; reaching onto one for a cube
+    # does not. From the cube's 0.270 the drop pad's preplace has no collision-free path at all.
+    standoff_object_ids: ["drop_pad"]
+    standoff_target_x_m: [0.350]
+
     # From a 2D grid run at the workbench with the arms tucked, at the PREGRASP height, checking
     # each IK solution against /check_state_validity (m9-checks/reach_grid.py). Only the pregrasp
     # has to be collision-free: the grasp pose sits on the table and is inside its octomap by

--- a/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
@@ -120,6 +120,15 @@ public:
         limits_.lateral_tolerance_m =
             declare_parameter<double>("lateral_tolerance_m", d.lateral_tolerance_m);
         limits_.min_forward_m = declare_parameter<double>("min_forward_m", d.min_forward_m);
+        // Two parallel lists rather than a map, which ROS 2 parameters cannot express.
+        standoff_ids_      = declare_parameter<std::vector<std::string>>("standoff_object_ids", {});
+        standoff_target_x_ = declare_parameter<std::vector<double>>("standoff_target_x_m", {});
+        if (standoff_ids_.size() != standoff_target_x_.size())
+        {
+            throw std::runtime_error(
+                "g1_base_approach: standoff_object_ids and standoff_target_x_m must be the same "
+                "length");
+        }
         limits_.step_threshold_m =
             declare_parameter<double>("step_threshold_m", d.step_threshold_m);
 
@@ -385,6 +394,21 @@ private:
         if (goal->arm == ApproachObject::Goal::ARM_LEFT)
         {
             limits.target_y_m = -limits.target_y_m;
+        }
+        // Reaching over a surface needs more room than reaching onto one; see the config.
+        for (std::size_t i = 0; i < standoff_ids_.size(); ++i)
+        {
+            if (standoff_ids_[i] == goal->object_id)
+            {
+                limits.target_x_m = standoff_target_x_[i];
+                RCLCPP_INFO(
+                    get_logger(),
+                    "'%s' is approached to %.3f rather than the default %.3f",
+                    goal->object_id.c_str(),
+                    limits.target_x_m,
+                    limits_.target_x_m);
+                break;
+            }
         }
 
         const double timeout_s = goal->timeout_s > 0.0 ? goal->timeout_s : default_timeout_s_;
@@ -808,7 +832,9 @@ private:
     int         max_pulses_            = 90;
     double      default_timeout_s_     = 420.0;
 
-    ApproachLimits limits_;
+    ApproachLimits           limits_;
+    std::vector<std::string> standoff_ids_;
+    std::vector<double>      standoff_target_x_;
 
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr             cmd_pub_;
     rclcpp::Subscription<vision_msgs::msg::Detection3DArray>::SharedPtr objects_sub_;

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
@@ -133,8 +133,11 @@ private:
      * arm, one skill -- and always restored, including on every failure path, so the arm is
      * never left planning against a permanently blinded scene.
      */
+    /// @param include_links  false exempts the touchables from each other only, leaving the hand
+    ///        and wrist collision-checked -- what carrying an object over a surface wants.
     bool allowHandContact(
-        const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed);
+        const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed,
+        bool include_links = true);
 
     MoveGroup* groupFor(const std::string& name);
 

--- a/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
@@ -87,7 +87,8 @@ G1ManipulationServer::G1ManipulationServer(const rclcpp::NodeOptions& options)
 }
 
 bool G1ManipulationServer::allowHandContact(
-    const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed)
+    const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed,
+    bool include_links)
 {
     // The links that unavoidably enter occupied space during a grasp: the hand itself, and
     // the wrist that carries it. Taken from the robot model rather than listed, so a renamed
@@ -167,7 +168,7 @@ bool G1ManipulationServer::allowHandContact(
             acm.entry_values[b].enabled[a] = allowed;
         }
     }
-    for (const std::string& touchable : touchables)
+    for (const std::string& touchable : include_links ? touchables : std::vector<std::string>{})
     {
         const std::size_t other = index_of(touchable);
         for (const std::string& link : links)
@@ -691,8 +692,11 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
         goal_handle->abort(result);
     };
 
-    // Lowering onto a surface enters occupied space just as reaching into one does.
-    allowHandContact(arm, touchables, true);
+    // The carried object may pass through the surface's voxels on the way in; the ARM may not.
+    // Exempting the hand this early let plans route the arm into the bench, and the strike shoved
+    // the base 0.12 to 0.17 m, which then put the re-aimed descent out of reach. Same hazard the
+    // pick defers its exemption for; the descent below gets the full one.
+    allowHandContact(arm, touchables, true, /*include_links=*/false);
 
     // Prefer a surface read from /objects over the caller's coordinate.
     //
@@ -752,21 +756,22 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
         return;
     }
 
-    // Re-resolve the target before descending. Everything above was computed in the pelvis
-    // frame BEFORE the arm reached out, and reaching out moves the base: the robot is
-    // balancing, so extending a loaded arm forward shifts the COM and the gait steps to keep
-    // up. Measured, one place: the cube was released 0.155 m short of the pad and fell to the
-    // floor, while every leaf in the mission reported success.
+    // Re-resolve before descending. Everything above was computed in the pelvis frame before the
+    // arm reached out, and the reach moves the base: extending a loaded arm shifts the COM and
+    // the balancing gait steps to keep up, measured at 0.165 m.
     //
-    // The arm holds a joint trajectory, so a base that drifts back carries the held object back
-    // with it. Recomputing here prices in whatever moved during the preplace, and the descent
-    // is short enough that little more accumulates.
+    // `expected` is the same target in the /objects frame, for the accuracy check at the end.
+    // That check runs after a reach, a release and a retreat, so in the pelvis frame the base's
+    // own travel reads as placement error.
+    std::optional<geometry_msgs::msg::Point> expected;
     if (surface)
     {
         if (const auto fresh = lookUpObject(goal->surface_object_id))
         {
             const std::string frame =
                 fresh->header.frame_id.empty() ? objects_.header.frame_id : fresh->header.frame_id;
+            expected = fresh->results.front().pose.pose.position;
+            expected->z += 0.5 * (fresh->bbox.size.z + held_height);
             if (auto moved = toPlanningFrame(fresh->results.front().pose.pose, frame))
             {
                 moved->position.z += 0.5 * (fresh->bbox.size.z + held_height);
@@ -783,12 +788,18 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
                         shift);
                 }
                 place_goal = regrasp;
+                // The retreat returns here, so it moves with the re-aim. Left stale, the lift is
+                // diagonal by however far the base walked.
+                preplace = place_goal;
+                preplace.position.z += approach_height_m_;
             }
         }
     }
 
     feedback->phase = Place::Feedback::PHASE_LOWER;
     goal_handle->publish_feedback(feedback);
+    // Now the hand may touch the surface: the descent ends in contact by definition.
+    allowHandContact(arm, touchables, true);
     if (!moveTo(*arm_group, place_goal, arm.grasp_frame, "lower"))
     {
         fail(Place::Feedback::PHASE_LOWER, "could not lower onto the target");
@@ -817,6 +828,13 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
 
     feedback->phase = Place::Feedback::PHASE_RETREAT;
     goal_handle->publish_feedback(feedback);
+    // Restored BEFORE the retreat is planned, or the lift may route the open hand through what
+    // was just set down. The object only: the hand is inside the surface's voxels at this height
+    // by construction, so restoring `<octomap>` here would put the start state in collision.
+    if (!held_id.empty())
+    {
+        allowHandContact(arm, { held_id }, false);
+    }
     if (!moveTo(*arm_group, preplace, arm.grasp_frame, "retreat"))
     {
         fail(Place::Feedback::PHASE_RETREAT, "could not retreat clear of the object");
@@ -825,30 +843,35 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
 
     allowHandContact(arm, touchables, false);
 
-    // Did it actually land there? Detaching the object and retreating the arm proves only that
-    // the planner is happy; it says nothing about where the thing ended up. A place that
-    // released short dropped the cube on the floor 0.155 m away and every leaf in the mission
-    // still reported success, which is the worst outcome available -- a failure that announces
-    // itself is fixable, one that does not is not.
+    // Did it actually land there? A successful plan says nothing about where the object ended
+    // up: one release short dropped the cube on the floor with every leaf reporting success.
     //
-    // Compared against the pose the object was aimed at, in the planning frame, which is where
-    // `target` already is.
+    // Against `expected` when a surface gave one, so both sides come from /objects and the
+    // walking base cancels. A caller-supplied pose falls back to the planning frame.
     if (!held_id.empty())
     {
         if (const auto landed = lookUpObject(held_id))
         {
-            const std::string frame = landed->header.frame_id.empty() ? objects_.header.frame_id :
-                                                                        landed->header.frame_id;
-            if (const auto where = toPlanningFrame(landed->results.front().pose.pose, frame))
+            const geometry_msgs::msg::Pose& pose = landed->results.front().pose.pose;
+            // Binds without a temporary; `target` is checked engaged above.
+            const geometry_msgs::msg::Point& aim = expected ? *expected : target->position;
+
+            std::optional<geometry_msgs::msg::Point> where = pose.position;
+            if (!expected)
             {
-                const double off = std::hypot(
-                    where->position.x - target->position.x,
-                    where->position.y - target->position.y,
-                    where->position.z - target->position.z);
+                const std::string frame       = landed->header.frame_id.empty() ?
+                                                    objects_.header.frame_id :
+                                                    landed->header.frame_id;
+                const auto        in_planning = toPlanningFrame(pose, frame);
+                where = in_planning ? std::optional(in_planning->position) : std::nullopt;
+            }
+            if (where)
+            {
+                const double off = std::hypot(where->x - aim.x, where->y - aim.y, where->z - aim.z);
                 if (off > place_tolerance_m_)
                 {
                     result->success = false;
-                    result->message = std::string(Place::Feedback::PHASE_RELEASE) + ": " + held_id +
+                    result->message = std::string(Place::Feedback::PHASE_RETREAT) + ": " + held_id +
                                       " ended up " + std::to_string(off) +
                                       " m from where it was placed";
                     RCLCPP_ERROR(get_logger(), "%s", result->message.c_str());

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -184,9 +184,11 @@
     <joint name="right_wrist_yaw_joint" value="0.00"/>
   </group_state>
 
+  <!-- Shoulder roll is 0.55 for the same reason carry's is 0.60: at 0.40 the thumb sits 0.10 rad
+       from the hip. Nothing walks narrower for it, since the carry leg is already at 0.60. -->
   <group_state name="tucked" group="left_arm">
     <joint name="left_shoulder_pitch_joint" value="0.25"/>
-    <joint name="left_shoulder_roll_joint" value="0.40"/>
+    <joint name="left_shoulder_roll_joint" value="0.55"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.30"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
@@ -195,7 +197,7 @@
   </group_state>
   <group_state name="tucked" group="right_arm">
     <joint name="right_shoulder_pitch_joint" value="0.25"/>
-    <joint name="right_shoulder_roll_joint" value="-0.40"/>
+    <joint name="right_shoulder_roll_joint" value="-0.55"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.30"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>
@@ -204,14 +206,14 @@
   </group_state>
   <group_state name="tucked" group="both_arms">
     <joint name="left_shoulder_pitch_joint" value="0.25"/>
-    <joint name="left_shoulder_roll_joint" value="0.40"/>
+    <joint name="left_shoulder_roll_joint" value="0.55"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.30"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
     <joint name="left_wrist_pitch_joint" value="0.00"/>
     <joint name="left_wrist_yaw_joint" value="0.00"/>
     <joint name="right_shoulder_pitch_joint" value="0.25"/>
-    <joint name="right_shoulder_roll_joint" value="-0.40"/>
+    <joint name="right_shoulder_roll_joint" value="-0.55"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.30"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>
@@ -293,15 +295,21 @@
        upright and close to the chest while the robot walks. tucked itself is the smallest
        swept volume, but its wrist pitch would tip whatever the hand is holding.
 
-       The shoulder roll is 0.40 rather than the 0.25 this pose first shipped with, and that
-       is measured, not taste: at 0.25 /check_state_validity reports
-       right_hand_thumb_2_link <-> right_hip_roll_link and the pose is simply unreachable, with
-       or without an object held. It is the same hand-versus-hip clearance M8 ran into from the
-       other side; rolling the shoulder further from the
-       body is what buys the thumb room. Valid at 0.40 for both hands. -->
+       The shoulder roll is 0.60, and it is the one value in this pose with a measurement behind
+       it. Rolling the shoulder away from the body is what buys the thumb room off the hip: at
+       0.25 the pose is invalid outright (right_hand_thumb_2_link <-> right_hip_roll_link), the
+       same hand-versus-hip clearance M8 met from the other side.
+
+       0.40 fixed that and was left there, valid but with 4.6 DEGREES OF MARGIN. The arm droops
+       more than that carrying the cube through a walk, and a start state in collision cannot be
+       planned out of: fix_start_state_collision jitters the start, plans from the jitter, and
+       the path check rejects the result against the original.
+
+       Margin against roll, others held: 0.40 -> 4.6 deg, 0.50 -> 10.3, 0.55 -> 12.6,
+       0.60 -> 16.0, 0.65 -> 18.3. test_robot_model holds the line at 0.20 rad. -->
   <group_state name="carry" group="left_arm">
     <joint name="left_shoulder_pitch_joint" value="-0.20"/>
-    <joint name="left_shoulder_roll_joint" value="0.40"/>
+    <joint name="left_shoulder_roll_joint" value="0.60"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.40"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
@@ -310,7 +318,7 @@
   </group_state>
   <group_state name="carry" group="right_arm">
     <joint name="right_shoulder_pitch_joint" value="-0.20"/>
-    <joint name="right_shoulder_roll_joint" value="-0.40"/>
+    <joint name="right_shoulder_roll_joint" value="-0.60"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.40"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>
@@ -319,14 +327,14 @@
   </group_state>
   <group_state name="carry" group="both_arms">
     <joint name="left_shoulder_pitch_joint" value="-0.20"/>
-    <joint name="left_shoulder_roll_joint" value="0.40"/>
+    <joint name="left_shoulder_roll_joint" value="0.60"/>
     <joint name="left_shoulder_yaw_joint" value="0.00"/>
     <joint name="left_elbow_joint" value="1.40"/>
     <joint name="left_wrist_roll_joint" value="0.00"/>
     <joint name="left_wrist_pitch_joint" value="0.00"/>
     <joint name="left_wrist_yaw_joint" value="0.00"/>
     <joint name="right_shoulder_pitch_joint" value="-0.20"/>
-    <joint name="right_shoulder_roll_joint" value="-0.40"/>
+    <joint name="right_shoulder_roll_joint" value="-0.60"/>
     <joint name="right_shoulder_yaw_joint" value="0.00"/>
     <joint name="right_elbow_joint" value="1.40"/>
     <joint name="right_wrist_roll_joint" value="0.00"/>

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -7,12 +7,14 @@
  */
 
 #include <gmock/gmock.h>
+#include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <srdfdom/model.h>
 #include <urdf_parser/urdf_parser.h>
 
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <set>
@@ -44,6 +46,15 @@ const std::vector<std::string> kReachingLinks = {
     "elbow_link", "wrist_roll_link", "wrist_pitch_link", "wrist_yaw_link", "hand_palm_link",
 };
 
+/// How far every joint of a named posture must move before the robot self-collides.
+///
+/// Merely valid is not usable. `carry` shipped valid with 4.6 degrees of room on
+/// right_shoulder_roll, and an arm carrying the cube through a walk droops more than that --
+/// 0.071 and 0.155 rad on two missions that then deadlocked, since MoveIt cannot plan out of a
+/// start state in collision. 0.20 clears the worst droop seen with room over.
+constexpr double kPostureMarginRad = 0.20;
+constexpr double kMarginStepRad    = 0.02;
+
 class RobotModelTest : public ::testing::Test
 {
 protected:
@@ -59,9 +70,77 @@ protected:
         ASSERT_TRUE(model_);
     }
 
+    /// Smallest distance any single joint of `group` can move out of `posture` before the state
+    /// self-collides, capped at `cap` so an unbounded axis does not sweep the whole range.
+    double postureMargin(
+        const std::string& group, const std::string& posture, std::string& tightest,
+        double cap = 0.30) const
+    {
+        planning_scene::PlanningScene scene(model_);
+        const auto*                   jmg = model_->getJointModelGroup(group);
+        moveit::core::RobotState      state(model_);
+        state.setToDefaultValues();
+        EXPECT_TRUE(state.setToDefaultValues(jmg, posture))
+            << group << " has no named posture '" << posture << "'";
+        state.update();
+
+        std::vector<double> base;
+        state.copyJointGroupPositions(jmg, base);
+        double worst = cap;
+        for (std::size_t i = 0; i < base.size(); ++i)
+        {
+            for (const double direction : { -1.0, 1.0 })
+            {
+                for (double delta = kMarginStepRad; delta <= cap + 1e-9; delta += kMarginStepRad)
+                {
+                    std::vector<double> probe = base;
+                    probe[i] += direction * delta;
+                    moveit::core::RobotState moved(state);
+                    moved.setJointGroupPositions(jmg, probe);
+                    moved.update();
+                    // Joint limits are the model's business, not this test's: a posture backed
+                    // against a limit is reported by satisfiesBounds, not by a collision.
+                    if (!moved.satisfiesBounds(jmg))
+                    {
+                        break;
+                    }
+                    if (scene.isStateColliding(moved, group))
+                    {
+                        if (delta < worst)
+                        {
+                            worst    = delta;
+                            tightest = jmg->getActiveJointModelNames()[i];
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return worst;
+    }
+
     std::shared_ptr<srdf::Model>              srdf_;
     std::shared_ptr<moveit::core::RobotModel> model_;
 };
+
+TEST_F(RobotModelTest, NamedPosturesKeepRoomBeforeSelfCollision)
+{
+    for (const std::string& group : { "left_arm", "right_arm" })
+    {
+        for (const std::string& posture : { "tucked", "carry" })
+        {
+            std::string  tightest = "(none)";
+            const double margin   = postureMargin(group, posture, tightest);
+            std::cout << "  " << group << "/" << posture << ": " << margin << " rad on " << tightest
+                      << "\n";
+            EXPECT_GE(margin, kPostureMarginRad)
+                << group << "/" << posture << " has only " << margin << " rad of room on "
+                << tightest
+                << ". A posture this close to a self-collision deadlocks every later plan when "
+                   "the arm droops into it.";
+        }
+    }
+}
 
 TEST_F(RobotModelTest, PlansInThePelvisFrame)
 {

--- a/workspace/src/g1_orchestration/CMakeLists.txt
+++ b/workspace/src/g1_orchestration/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(nav2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(controller_manager_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
@@ -25,6 +26,7 @@ add_library(g1_bt_nodes
   src/skills/approach_object.cpp
   src/skills/arm_authority_leaves.cpp
   src/skills/clear_costmaps.cpp
+  src/skills/clear_octomap.cpp
   src/skills/navigate_to_pose.cpp
   src/skills/pick.cpp
   src/skills/place.cpp
@@ -38,7 +40,7 @@ target_include_directories(g1_bt_nodes PUBLIC
 target_compile_features(g1_bt_nodes PUBLIC cxx_std_20)
 ament_target_dependencies(g1_bt_nodes PUBLIC
   rclcpp rclcpp_action behaviortree_cpp g1_msgs nav2_msgs geometry_msgs
-  controller_manager_msgs lifecycle_msgs tf2 tf2_geometry_msgs)
+  controller_manager_msgs lifecycle_msgs std_srvs tf2 tf2_geometry_msgs)
 
 add_executable(g1_bt_executor src/g1_bt_executor_main.cpp)
 target_link_libraries(g1_bt_executor PUBLIC g1_bt_nodes)

--- a/workspace/src/g1_orchestration/README.md
+++ b/workspace/src/g1_orchestration/README.md
@@ -7,6 +7,7 @@ BehaviorTree.CPP **v4**. `ament_cmake`, C++20.
 flowchart LR
     EXE["g1_bt_executor<br/>ticks the tree at 10 Hz"]
     EXE -- "NavigateToPose, ClearCostmaps" --> NAV["Nav2"]
+    EXE -- "ClearOctomap" --> MG["move_group"]
     EXE -- "ApproachObject, Retreat" --> BA["g1_locomotion"]
     EXE -- "Pick, Place,<br/>SetArmPosture" --> MAN["g1_manipulation"]
     EXE -- "acquire / release" --> CM["controller_manager"]
@@ -44,6 +45,7 @@ One file per leaf, the layout `nav2_behavior_tree` uses.
 | `Place` | `/g1_manipulation_server/place` | `surface` (preferred), or `target` as `"x;y;z"` with `frame_id`; `arm` |
 | `SetArmPosture` | `/g1_manipulation_server/set_arm_posture` | `group`, `named_target` |
 | `ClearCostmaps` | Nav2 costmap clear services | `timeout_s`, `global_service`, `local_service` |
+| `ClearOctomap` | MoveIt `/clear_octomap` | `timeout_s`, `service` |
 | `AcquireArm` / `ReleaseArm` | `controller_manager` services | `timeout_s` |
 
 Every action leaf also takes `server_timeout_s` (default 10.0), how long to wait for the server to

--- a/workspace/src/g1_orchestration/include/g1_orchestration/skill_nodes.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/skill_nodes.hpp
@@ -17,6 +17,7 @@
 #include "g1_orchestration/skills/approach_object.hpp"
 #include "g1_orchestration/skills/arm_authority_leaves.hpp"
 #include "g1_orchestration/skills/clear_costmaps.hpp"
+#include "g1_orchestration/skills/clear_octomap.hpp"
 #include "g1_orchestration/skills/navigate_to_pose.hpp"
 #include "g1_orchestration/skills/pick.hpp"
 #include "g1_orchestration/skills/place.hpp"

--- a/workspace/src/g1_orchestration/include/g1_orchestration/skills/clear_octomap.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/skills/clear_octomap.hpp
@@ -1,0 +1,31 @@
+#ifndef G1_ORCHESTRATION__SKILLS__CLEAR_OCTOMAP_HPP_
+#define G1_ORCHESTRATION__SKILLS__CLEAR_OCTOMAP_HPP_
+
+#include <string>
+
+#include "g1_orchestration/service_leaf.hpp"
+
+namespace g1_orchestration
+{
+
+/// Wipes MoveIt's octomap. The 3D counterpart to ClearCostmaps, and a different subsystem: that
+/// one clears Nav2's 2D grids, which the base plans over, and never touches the planning scene
+/// the arm plans against.
+///
+/// Manipulating beside a surface leaves the octomap holding the arm and whatever it picked up,
+/// where they used to be. Those voxels do not decay, so later plans route around a ghost: one
+/// mission died at `carry` on <octomap> against the carried cube, a metre clear of the bench.
+///
+/// Succeeds even when the clear fails, for ClearCostmaps' reason: housekeeping, not a
+/// precondition.
+class ClearOctomap : public ServiceLeaf
+{
+public:
+    ClearOctomap(const std::string& name, const BT::NodeConfig& config, RosContext context);
+    static BT::PortsList providedPorts();
+    BT::NodeStatus       tick() override;
+};
+
+}  // namespace g1_orchestration
+
+#endif  // G1_ORCHESTRATION__SKILLS__CLEAR_OCTOMAP_HPP_

--- a/workspace/src/g1_orchestration/package.xml
+++ b/workspace/src/g1_orchestration/package.xml
@@ -22,6 +22,7 @@
   <depend>geometry_msgs</depend>
   <depend>controller_manager_msgs</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
 

--- a/workspace/src/g1_orchestration/src/registration.cpp
+++ b/workspace/src/g1_orchestration/src/registration.cpp
@@ -7,6 +7,7 @@
 #include "g1_orchestration/skills/approach_object.hpp"
 #include "g1_orchestration/skills/arm_authority_leaves.hpp"
 #include "g1_orchestration/skills/clear_costmaps.hpp"
+#include "g1_orchestration/skills/clear_octomap.hpp"
 #include "g1_orchestration/skills/navigate_to_pose.hpp"
 #include "g1_orchestration/skills/pick.hpp"
 #include "g1_orchestration/skills/place.hpp"
@@ -25,6 +26,7 @@ void registerSkillNodes(BT::BehaviorTreeFactory& factory, const RosContext& cont
     registerLeaf<Place>(factory, "Place", context);
     registerLeaf<SetArmPosture>(factory, "SetArmPosture", context);
     registerLeaf<ClearCostmaps>(factory, "ClearCostmaps", context);
+    registerLeaf<ClearOctomap>(factory, "ClearOctomap", context);
     registerLeaf<AcquireArm>(factory, "AcquireArm", context);
     registerLeaf<ReleaseArm>(factory, "ReleaseArm", context);
 }

--- a/workspace/src/g1_orchestration/src/skills/clear_octomap.cpp
+++ b/workspace/src/g1_orchestration/src/skills/clear_octomap.cpp
@@ -1,0 +1,52 @@
+#include "g1_orchestration/skills/clear_octomap.hpp"
+
+#include <memory>
+#include <std_srvs/srv/empty.hpp>
+#include <string>
+
+#include "g1_orchestration/ports.hpp"
+
+namespace g1_orchestration
+{
+
+ClearOctomap::ClearOctomap(const std::string& name, const BT::NodeConfig& config, RosContext context)
+  : ServiceLeaf(name, config, std::move(context))
+{}
+
+BT::PortsList ClearOctomap::providedPorts()
+{
+    return {
+        ports::serviceTimeout(5.0, "Service budget."),
+        BT::InputPort<std::string>(
+            "service",
+            "/clear_octomap",
+            "move_group's octomap clear service. Empty skips it."),
+    };
+}
+
+BT::NodeStatus ClearOctomap::tick()
+{
+    const double      timeout_s = getInput<double>("timeout_s").value_or(5.0);
+    const std::string service   = getInput<std::string>("service").value_or("");
+    if (service.empty())
+    {
+        return BT::NodeStatus::SUCCESS;
+    }
+
+    auto       client_node = makeClientNode("g1_clear_octomap_client");
+    const auto response    = callService<std_srvs::srv::Empty>(
+        client_node,
+        service,
+        std::make_shared<std_srvs::srv::Empty::Request>(),
+        timeout_s);
+    if (response == nullptr)
+    {
+        RCLCPP_WARN(
+            node_->get_logger(),
+            "[%s] continuing with the octomap uncleared",
+            name().c_str());
+    }
+    return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace g1_orchestration

--- a/workspace/src/g1_orchestration/trees/g1_orchestration_nodes.xml
+++ b/workspace/src/g1_orchestration/trees/g1_orchestration_nodes.xml
@@ -16,6 +16,10 @@
             <input_port name="global_service" type="std::string" default="/global_costmap/clear_entirely_global_costmap">Nav2 global costmap clear service. Empty skips it.</input_port>
             <input_port name="timeout_s" type="double" default="5.000000">Per-costmap service budget.</input_port>
         </Action>
+        <Action ID="ClearOctomap">
+            <input_port name="service" type="std::string" default="/clear_octomap">move_group's octomap clear service. Empty skips it.</input_port>
+            <input_port name="timeout_s" type="double" default="5.000000">Service budget.</input_port>
+        </Action>
         <Action ID="NavigateToPose">
             <output_port name="goal_yaw" type="double">The goal's heading, for an ApproachObject that has to hold it.</output_port>
             <input_port name="behavior_tree" type="std::string" default="">Nav2 tree to drive with. Empty uses its default.</input_port>

--- a/workspace/src/g1_orchestration/trees/pick_and_place.xml
+++ b/workspace/src/g1_orchestration/trees/pick_and_place.xml
@@ -101,6 +101,13 @@
            around the robot's own recent history. -->
       <ClearCostmaps name="forget_the_workbench"/>
 
+      <!-- The 3D counterpart, and a different subsystem: ClearCostmaps wipes Nav2's grids, which
+           the base plans over, and leaves the planning scene the ARM plans against untouched.
+           Reaching over the workbench leaves the octomap holding the arm and the cube where they
+           were, and those voxels do not decay: one mission died here with <octomap> against the
+           carried cube at the third waypoint of the carry, a metre clear of the bench. -->
+      <ClearOctomap name="forget_the_workbench_in_3d"/>
+
       <RetryUntilSuccessful name="carry_with_retries" num_attempts="3">
         <SetArmPosture name="hold_it_close" group="right_arm" named_target="carry"/>
       </RetryUntilSuccessful>


### PR DESCRIPTION
The place was driving the arm into the workbench. The strike shoved the robot 0.12 to 0.17 m
mid-reach, which then put the descent out of the arm's range, and the cube ended up off the pad.
Four fixes, all found by watching the simulator and confirmed against measurements.

## The place reached with the hand blind to the octomap

`executePlace` exempted the hand and wrist from the octomap from its first line, so the reach to
preplace was planned as though the bench were not there. The planner took the free path, and the
physical arm hit the surface.

The pick already had this bug and fixed it -- its comment spells out the hazard -- but the place
never inherited the fix. Now only the *carried object* may pass through the surface's voxels on
the way in; the arm is collision-checked, and the full exemption waits for the descent, where
contact is the point. `allowHandContact` grew an `include_links` flag to express that.

Measured, same geometry: contacts rejecting the reach went from 18 to 1, base travel during the
reach from 0.170 m to 0.031 m, and placement error from 0.065-0.145 m to 0.012-0.019 m against a
pad whose half-width is 0.080 m.

## Three more defects in the place's tail

- `preplace` was computed before the reach and never updated, while `place_goal` *is* re-aimed
  after it. The retreat returned to the stale one, so the lift was diagonal by however far the
  base had walked, at the height of the object just released.
- Collision checking against the placed object was restored *after* the retreat was planned,
  leaving the planner free to route the open hand through it.
- The accuracy check compared in the planning frame, which is the pelvis, across a reach, a
  release and a retreat. Base travel arrived as placement error. It now compares against the
  surface's own detection, so both sides come from `/objects` and the base cancels. The failure
  message was also labelled `release`; it is `retreat`.

## `carry` sat 4.6 degrees from a self-collision

Two missions died at `SetArmPosture(carry)` with the arm's start state in collision, three
attempts each inside a second: MoveIt cannot plan out of that, because `fix_start_state_collision`
jitters the start, plans from the jitter, then validates the path against the original.

Walking each joint out of the posture against `/check_state_validity`: every axis had 16-34
degrees of room except shoulder roll, which had 4.6 -- and the droop measured in the two failures
was 4.1 and 8.9. The contact is the thumb against the hip, real geometry rather than a modelling
artefact. The SRDF already recorded half the story: roll was moved from 0.25 to 0.40 in an earlier
session because 0.25 was invalid outright, and the note ends "Valid at 0.40". Nobody measured what
was left.

Margin against roll: 0.40 -> 4.6 deg, 0.50 -> 10.3, 0.55 -> 12.6, 0.60 -> 16.0, 0.65 -> 18.3.
`carry` moves to 0.60 and `tucked` to 0.55, with `NamedPosturesKeepRoomBeforeSelfCollision` in
`test_robot_model` to hold the line at 0.20 rad. It fails against the old numbers, needs no
simulator, and runs in CI.

## An object can name its own standoff

Reaching over a surface to set something down is not the same problem as reaching onto one to pick
something up. From the cube's 0.270 m standoff the drop pad's preplace has no collision-free path
at all. `standoff_object_ids` / `standoff_target_x_m` let one object ask for a different
`target_x_m`; `drop_pad` uses 0.350, everything else is unchanged.

## MoveIt's octomap is now cleared too

The mission cleared Nav2's costmaps in four places and never touched the planning scene the arm
plans against. Manipulating beside a surface leaves the octomap holding the arm and the cube where
they used to be, and those voxels do not decay: one mission died at `carry` on `<octomap>` against
the carried cube, a metre clear of the bench. `ClearOctomap` is the 3D counterpart to
`ClearCostmaps`, same base class, same succeed-anyway policy, placed after the reverse off the
desk so nothing is reaching during the window.

## Verification

Full non-simulator suite green across all 13 packages. Missions on `odometry:=fast_lio`, judged by
the cube's physical pose rather than the tree's return value:

    before   0 of 2   retreat invalid; lower goal invalid after 0.165 m of base drift
    after    4 of 5   the one failure was the octomap ghosts, addressed by the last commit

## Known, and deliberately not addressed here

The approach's forward window is +/-0.110 m, so it can report success at 0.254 m when aiming for
0.350 m, and the place then depends on OMPL sampling a path from a marginal pose. A narrower
symmetric window is not the answer -- 0.065 was tried and limit-cycles, since a forward step is
irreducible at about 0.29 m and cannot land inside a 0.13 m window. An asymmetric window, tight on
the near side where the bench is and loose on the far side, is the likely fix, but it is a change
to the planner and unproven, so it is left out.

An earlier attempt in this branch retuned the lateral drive/pulse handoff from 0.055 to 0.170. It
turned a two-move correction into a thirty-move crawl and was reverted wholesale; the approach's
control law is byte-identical to `main`.