### PR TITLE
Comment cleanup, C++ tightening, and a clang-tidy gate

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: '
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-function-cognitive-complexity,
+  -readability-named-parameter,
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
@@ -39,7 +40,9 @@ Checks: '
   -bugprone-easily-swappable-parameters,
   -bugprone-reserved-identifier,
   concurrency-*,
+  cert-err33-c,
   cppcoreguidelines-*,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-bounds-constant-array-index,
@@ -65,9 +68,32 @@ Checks: '
 # -bugprone-easily-swappable-parameters: assembleSimLowCmd() intentionally
 #   takes parallel gain/target groups; splitting them into structs would hurt
 #   the call site more than it helps.
+# -cppcoreguidelines-non-private-member-variables-in-classes: an ALIAS of the
+#   misc- check disabled above. clang-tidy does not propagate a disable across
+#   an alias pair, so both halves have to be named -- the same reason
+#   readability-magic-numbers and cppcoreguidelines-avoid-magic-numbers both
+#   appear here.
+# -readability-named-parameter: every hit is an unused rclcpp_lifecycle::State&,
+#   rclcpp::Time& or rclcpp::Duration& on a lifecycle / hardware-interface
+#   override, or the unused int on a POSIX signal handler. Naming them trades a
+#   warning for an unused-variable one and fights the override idiom.
+# cert-err33-c (cherry-picked, NOT cert-*): catches an unchecked std::signal(),
+#   which is how the authority-release handlers in g1_loco_authority_node and
+#   g1_bt_executor_main are installed -- a silent SIG_ERR there loses the
+#   Ctrl-C release the control-mode rules require. The rest of cert-* is
+#   aliases plus cert-dcl37-c/dcl51-cpp, which re-flag the ROS 2
+#   PACKAGE__FILE_HPP_ include guards that -bugprone-reserved-identifier above
+#   deliberately allows.
 
 # First-party headers only -- keeps vendored unitree_ros2 headers out.
 HeaderFilterRegex: '^.*/g1_[a-z_]+/(include|src)/.*$'
+
+# The workspace is clean under the checks above, so anything that fires is a regression rather
+# than a backlog item. This is what makes the per-package clang_tidy_check_* CTest targets a
+# gate: run-clang-tidy 14 has no --warnings-as-errors of its own and only propagates the exit
+# code. A finding that is genuinely correct-as-written gets a NOLINT naming the check and the
+# reason, not a relaxation here.
+WarningsAsErrors: '*'
 
 CheckOptions:
   - key:    readability-identifier-naming.NamespaceCase
@@ -136,3 +162,14 @@ CheckOptions:
     value:  lower_case
   - key:    readability-identifier-naming.ConstantMemberPrefix
     value:  ''
+  # A const member is still a member, so it keeps the trailing underscore its
+  # non-const siblings have. Without this it falls through to a rule that has
+  # no suffix expectation and every const member reads as misnamed.
+  - key:    readability-identifier-naming.ConstantMemberSuffix
+    value:  '_'
+  # Static data members (ClassMember) are their own category; unset, they land
+  # on the plain-variable rule instead of the member one.
+  - key:    readability-identifier-naming.ClassMemberCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ClassMemberSuffix
+    value:  '_'

--- a/.github/ci.Dockerfile
+++ b/.github/ci.Dockerfile
@@ -13,13 +13,16 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 # clang-format's output is not stable across major versions, so an unpinned one rejects
-# correctly formatted files. liburdfdom-tools is check_urdf, which g1_description's xacro test
-# shells out to.
+# correctly formatted files. The same pin covers clang-tidy, whose check set and fix-its also
+# move between releases -- and it has to match the dev container's 14, or the clang_tidy_check_*
+# tests disagree with what a developer reproduces locally. liburdfdom-tools is check_urdf, which
+# g1_description's xacro test shells out to.
 ARG LLVM_VERSION=14
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ccache \
         clang-format-${LLVM_VERSION} \
+        clang-tidy-${LLVM_VERSION} \
         cmake \
         curl \
         gcovr \
@@ -29,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-pip \
         python3-vcstool \
     && ln -sf /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format \
+    && ln -sf /usr/bin/clang-tidy-${LLVM_VERSION} /usr/bin/clang-tidy \
     && rm -rf /var/lib/apt/lists/*
 
 # Pinned: ruff's rule set changes between minor versions.

--- a/workspace/src/g1_bringup/config/sim_sensors.yaml
+++ b/workspace/src/g1_bringup/config/sim_sensors.yaml
@@ -44,7 +44,7 @@ object_bodies:
   - yellow_box
   # Not manipulable, and tracked anyway: g1_base_approach ranges to something on /objects to
   # decide where to stand, and the place leg needs a landmark on the drop-off bench the way the
-  # pick leg has the cube itself. Static, so its pose never changes -- which is the point.
+  # pick leg has the cube itself. Static, so its pose never changes.
   - drop_pad
 
 # SIMULATION ONLY, and a stand-in rather than a model of anything. The Dex3 fingers carry no
@@ -55,7 +55,7 @@ object_bodies:
 # NONE OF THESE THREE NUMBERS TRANSFER TO HARDWARE. There the mechanism is friction between
 # real finger pads and a real object; these describe the weld, not the Dex3's grip, and a grasp
 # that holds here says nothing about whether the real hand holds it. They sit on the hardware
-# re-validation list with the gait deadband and the hand-mass scaling, in the simulation setup notes.
+# re-validation list with the gait deadband and the hand-mass scaling.
 #
 # Which welds exist is declared in the scene, not here: g1_navigation_scene.xml's `grasp_*`
 # equality constraints are found by name.

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -330,8 +330,8 @@ def _rviz(navigating, want_nav, want_moveit):
 
     With MoveIt and Nav2 BOTH running this returns two windows: the MoveIt one for the arm and
     a second on g1_navigation.rviz for the map, costmaps and plan. A combined single-window view
-    is NOT available; three merged configs were built and every one segfaulted rviz2 on load
-    once the navigation stack was up.
+    is NOT available: merging the two configs segfaults rviz2 on load once the navigation stack
+    is up.
 
     The second window keys off nav, not mode: mode=localization without nav has a map but no
     planner, and MoveIt's view is the only one worth opening.

--- a/workspace/src/g1_bringup/mjcf/g1_lio_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_lio_scene.xml
@@ -1,26 +1,26 @@
 <mujoco model="g1_lio_scene">
   <!--
-    A room built to TEST LIDAR-INERTIAL ODOMETRY, not to look like a facility.
+    A room built to test lidar-inertial odometry, not to look like a facility.
 
     Everything here exists to make scan matching observable and the answer checkable:
 
       * 14 x 14 m, walls on all four sides. Walls are what constrain x, y and yaw; without a
         return at range in every direction the match is free to slide.
-      * Deliberately ASYMMETRIC feature furniture. A square empty room is degenerate: four
+      * Deliberately asymmetric feature furniture. A square empty room is degenerate: four
         identical walls give a scan matcher no way to tell one 90-degree rotation from
         another, and it will happily lock onto the wrong one. The pillars, alcove and steps
         below are placed so no two quadrants look alike from the middle.
       * Vertical structure at several heights (pillars, a low block, a tall post). A sweep
         that only ever sees flat wall has weak vertical constraint, which is exactly the
         z drift being chased.
-      * A 5 m square of floor markers at KNOWN coordinates, so a run can be scored against
+      * A 5 m square of floor markers at known coordinates, so a run can be scored against
         absolute truth rather than only against relative drift.
 
     The test path is the 5 m square (0,0) -> (5,0) -> (5,5) -> (0,5) -> (0,0). The robot
     spawns at the origin facing +x. Every marker centre below is on that path, and the
-    corners are (0,0), (5,0), (5,5), (0,5). Closing the loop is the point: a LIO estimate
-    that drifts shows up as a gap between start and finish that no amount of local
-    smoothness hides.
+    corners are (0,0), (5,0), (5,5), (0,5). The path closes the loop: a LIO estimate that
+    drifts shows up as a gap between start and finish that no amount of local smoothness
+    hides.
 
     Keep the path clear. The furniture is set back from it on purpose, because a collision
     invalidates the measurement, because the gait recovers by lurching and that is not the

--- a/workspace/src/g1_bringup/mjcf/g1_manipulation_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_manipulation_pinned_scene.xml
@@ -2,7 +2,7 @@
   <include file="g1_manipulation_scene.staged.xml"/>
 
   <equality>
-    <!-- pelvis, NOT torso_link, which is what g1_navigation_pinned_scene welds.
+    <!-- pelvis, not torso_link, which is what g1_navigation_pinned_scene welds.
          That scene wants the waist free so the torso pitches the way it does when walking,
          because its sensor mounts hang off the torso and the geometry checks measure them.
          This scene wants the opposite: a repeatable arm base.
@@ -10,10 +10,9 @@
          Welding the torso leaves the waist free, so the torso settles under gravity to a
          slightly different place every launch. Measured across three: the odom origin landed
          at pelvis x +0.039, +0.070 and +0.078. Five centimetres of that is the difference
-         between a grasp being inside the arm's reach and having no IK at all, which made
-         every placement measurement unrepeatable and sent the same test scene through three
-         wrong table heights. Welding the pelvis instead fixes the base the arm reaches from,
-         and the waist is then held by the walking policy's own stiff hold. -->
+         between a grasp being inside the arm's reach and having no IK at all. Welding the
+         pelvis instead fixes the base the arm reaches from, and the waist is then held by
+         the walking policy's own stiff hold. -->
     <weld name="pelvis_world_pin" body1="pelvis"/>
   </equality>
 </mujoco>

--- a/workspace/src/g1_bringup/mjcf/g1_manipulation_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_manipulation_scene.xml
@@ -8,8 +8,7 @@
 
        Deliberately measured against by nothing else. g1_perception_scene is what the LiDAR
        and octomap tests assert geometry from, and adding a pedestal to it would move numbers
-       those tests were written against, which is exactly how the +x wall assertion broke
-       once already.
+       those tests were written against.
 
        Every geom is group 2, for the reason g1_perception_scene explains: the sweep masks to
        that group, or every ray returns the robot's own shell.
@@ -40,22 +39,13 @@
     <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
     <geom name="floor" group="2" size="0 0 0.05" type="plane" material="groundplane"/>
 
-    <!-- THE NEAR EDGE MUST CLEAR THE SPAWNED ARM. That is the constraint that decides this
-         geometry, and getting it wrong is not subtle: an earlier version put the top at
-         x 0.14 to 0.46 and the robot spawned with its right forearm resting inside the
-         tabletop. It knocked the cube several centimetres on every launch, and it quietly
-         corrupted every collision-checked IK measurement taken in the scene, because the arm
-         was in contact with the table before anything had been asked of it.
-
-         The right palm hangs at about odom (0.18, -0.18, 0.74) at spawn: arms down, elbows
-         bent forward by the hold pose in motion_service_sim. So the top starts at x 0.26,
-         8 cm clear of it, and sits at 0.80, above where the palm hangs rather than around it.
+    <!-- The near edge must clear the spawned arm. The right palm hangs at about odom
+         (0.18, -0.18, 0.74) at spawn: arms down, elbows bent forward by the hold pose in
+         motion_service_sim. So the top starts at x 0.26, 8 cm clear of it, and sits at 0.80,
+         above where the palm hangs rather than around it.
 
          Height is chosen to match the facility workbench (0.75) as closely as the arm's reach
-         allows, so a grasp tuned here transfers. Two earlier attempts, both wrong and both
-         worth remembering: 0.97, measured against a grasp offset that had the hand's closing
-         axis wrong so the sweep meant nothing, and 0.485, which is below the arm's reach
-         entirely. -->
+         allows, so a grasp tuned here transfers. -->
     <geom name="table_top" group="2" type="box" size="0.16 0.14 0.015" pos="0.42 -0.20 0.785"
       material="pedestal_mat" contype="1" conaffinity="1"/>
     <geom name="table_leg_near" group="2" type="box" size="0.02 0.02 0.385"

--- a/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_navigation_scene.xml
@@ -95,13 +95,10 @@
     <!-- ZONE 1: Pick-and-Place Manipulation Testing Lab (East-South Room)   -->
     <!-- ==================================================================== -->
     <body name="manipulation_workbench" pos="4.5 -4.5 0">
-      <!-- Top at 0.80, matching g1_manipulation_scene's pedestal exactly rather than the 0.75
-           it used to be. Not cosmetic: the arm's reachable band at a useful forward reach
-           starts around pelvis z +0.03, which with the pelvis at 0.7925 puts the lowest
-           graspable object at about 0.82. At the old height the cube sat at 0.78, BELOW the
-           whole measured envelope, so the approach could have been perfect and the grasp would
-           still have had no IK. Matching the scene the pick is proven in means the demo depends
-           on a measured grasp instead of an assumed one. -->
+      <!-- Top at 0.80, matching g1_manipulation_scene's pedestal exactly, so the pick this demo
+           runs is the same pick already proven reachable there. The arm's useful forward-reach
+           band starts around pelvis z +0.03, and with the pelvis at 0.7925 that puts the lowest
+           graspable object at about 0.82: a measured constraint, not a cosmetic choice. -->
       <geom group="2" name="desk_top" type="box" size="0.9 0.55 0.03" pos="0 0 0.77" material="wood_desk" contype="1" conaffinity="1"/>
       <geom group="2" name="desk_leg_1" type="box" size="0.04 0.04 0.385" pos="0.8 0.45 0.385" material="metal_gray" contype="1" conaffinity="1"/>
       <geom group="2" name="desk_leg_2" type="box" size="0.04 0.04 0.385" pos="-0.8 0.45 0.385" material="metal_gray" contype="1" conaffinity="1"/>
@@ -188,10 +185,9 @@
          same reason: that is the height the grasp and the release are measured at, and a
          surface at any other height would need its own reachability answer.
 
-         The crate stacks are NOT usable for this. crate_stack_1's top sits at 1.10 m, above the
+         The crate stacks are not usable for this: crate_stack_1's top sits at 1.10 m, above the
          measured envelope, and its footprint is a metre across, so an approach that ranges to a
-         body origin would ask the robot to stand inside it. The mission tree used to name a
-         place target of 0.78 there, which is the SIDE of the upper crate. -->
+         body origin would ask the robot to stand inside it. -->
     <body name="storage_bench" pos="6.5 6.5 0">
       <geom group="2" name="bench_top" type="box" size="0.35 0.35 0.03" pos="0 0 0.77" material="wood_desk" contype="1" conaffinity="1"/>
       <geom group="2" name="bench_leg_1" type="box" size="0.04 0.04 0.385" pos="0.28 0.28 0.385" material="metal_gray" contype="1" conaffinity="1"/>

--- a/workspace/src/g1_bringup/mjcf/g1_pinned_scene.xml
+++ b/workspace/src/g1_bringup/mjcf/g1_pinned_scene.xml
@@ -1,8 +1,7 @@
 <mujoco model="g1_pinned_scene">
-  <!-- SIM-ONLY testing scaffolding for the arm-bridge milestone. Pins the pelvis
-       to the world purely so the arm bridge can be validated in isolation.
-       Staged into the vendored model directory at launch time so MuJoCo's
-       relative meshdir and include paths resolve correctly. -->
+  <!-- SIM-ONLY testing scaffolding: pins the pelvis to the world purely so the arm bridge
+       can be validated in isolation. Staged into the vendored model directory at launch
+       time so MuJoCo's relative meshdir and include paths resolve correctly. -->
   <include file="g1_29dof.xml"/>
 
   <statistic center="0 0 0.5" extent="2.0"/>
@@ -28,7 +27,7 @@
   </worldbody>
 
   <equality>
-    <!-- weld fixes position AND orientation. Scoped to the pelvis body only,
+    <!-- weld fixes position and orientation. Scoped to the pelvis body only,
          leaving all 14 arm joints and legs freely actuated via /lowcmd. -->
     <weld name="pelvis_world_pin" body1="pelvis"/>
   </equality>

--- a/workspace/src/g1_bringup/test/test_fastlio_odometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_fastlio_odometry.launch.py
@@ -14,8 +14,8 @@ when the extrinsic estimator was left on) with room for a bad gait.
 
 `odom` is latched wherever FAST-LIO first produced a pose and the robot does not settle on a
 repeatable heading, so the two frames are aligned by the headings measured at the first paired
-sample. NOT by a best fit over the path: that reads lower where the estimate is bad and it is
-easy to get the sign wrong, which is exactly what happened here and to lio_bench.
+sample, not by a best fit over the path: that reads lower where the estimate is bad and it is
+easy to get the sign wrong.
 """
 
 import math

--- a/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
@@ -5,9 +5,9 @@ also publishes the sensor's exact world pose, so the points can be put into worl
 coordinates and checked against facts of g1_perception_pinned_scene.xml: floor at z=0,
 inner wall faces at +/-4.0 m.
 
-Runs with the pelvis pinned. Not for convenience: a free-standing G1 drifts and its waist
-leans (the torso pitches tens of degrees), so the numbers would move under the test
-without anything being wrong.
+Runs with the pelvis pinned: a free-standing G1 drifts and its waist leans (the torso
+pitches tens of degrees), so the numbers would move under the test without anything
+being wrong.
 """
 
 import os
@@ -80,8 +80,8 @@ class LidarGeometryTest(unittest.TestCase):
     def setUpClass(cls):
         rclpy.init()
         cls.node = Node("test_lidar_geometry")
-        # Bounded: 11520-point clouds at 10 Hz over a long bring-up would otherwise be
-        # hundreds of megabytes, the resource-starvation shape that bit milestone 3.
+        # Bounded: 11520-point clouds at 10 Hz over a long bring-up would otherwise
+        # accumulate to hundreds of megabytes.
         cls.clouds = deque(maxlen=4)
         cls.poses = deque(maxlen=4)
         cls.stamps = deque(maxlen=512)
@@ -173,8 +173,8 @@ class LidarGeometryTest(unittest.TestCase):
     def test_04_the_sensor_is_where_the_mount_puts_it(self):
         """Height above the floor, from the vendored URDF mount on a pinned pelvis.
 
-        Not a round number by choice: it is the waist chain plus mid360_joint's own offset,
-        so a wrong mount or a wrong torso pose moves it.
+        The waist chain plus mid360_joint's own offset, so a wrong mount or a wrong torso
+        pose moves it.
         """
         _, origin = self.world_returns()
         self.assertAlmostEqual(
@@ -215,8 +215,8 @@ class LidarGeometryTest(unittest.TestCase):
 
         # Three walls, so a sweep that lost a sector fails rather than averaging out. The +x
         # wall is deliberately absent: reach_obstacle sits 0.18 m in front of the sensor at its
-        # own height and occludes that whole direction, which is exactly what makes
-        # g1_moveit_config's octomap test work. Measured, the cloud stops at x = 1.60.
+        # own height and occludes that whole direction, so it is the only obstacle
+        # g1_moveit_config's octomap test sees in +x. Measured, the cloud stops at x = 1.60.
         for axis, sign, name in ((0, -1, "-x"), (1, 1, "+y"), (1, -1, "-y")):
             on_wall = np.abs(world[:, axis] - sign * ROOM_HALF) < 0.05
             self.assertGreater(

--- a/workspace/src/g1_bringup/test/test_loco.launch.py
+++ b/workspace/src/g1_bringup/test/test_loco.launch.py
@@ -1,9 +1,9 @@
 """Headless sim integration test: the LocoClient loop end to end -- g1_locomotion's g1_loco_bridge
 talking real DDS to motion_service_sim's protocol-only /api/sport/* responder.
 
-sim.launch.py now brings up g1_loco_bridge itself (via loco.launch.py, lifecycle-configured and
-activated automatically), so this test only has to drive it: a manual SET_VELOCITY published
-directly (the bridge itself never sends one outside kHeld, so this is the only way to exercise the
+sim.launch.py brings up g1_loco_bridge itself (via loco.launch.py, lifecycle-configured and
+activated automatically), so this test drives it: a manual SET_VELOCITY published directly
+(the bridge itself never sends one outside kHeld, so this is the only way to exercise the
 responder's Start-only gate before any SetLocoMode goal has run -- see g1_bringup's README's FSM
 table), the STAND_UP -> START sequence the responder's legality table requires, the velocity
 re-issue loop's rate and fixed duration, the zero-Twist stop, and DAMP releasing authority. All in
@@ -33,7 +33,7 @@ from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReli
 from unitree_api.msg import Request, Response
 
 # See test_sim_bringup.launch.py's comment on this constant: kept below launch_testing's own
-# hardcoded 15 s process-startup deadline. sim.launch.py now also configures+activates
+# hardcoded 15 s process-startup deadline. sim.launch.py also configures+activates
 # g1_loco_bridge, a near-instant lifecycle handshake (no ramp) well inside this same window.
 SIM_SETTLE_S = 10.0
 

--- a/workspace/src/g1_bringup/test/test_walk_and_arm.launch.py
+++ b/workspace/src/g1_bringup/test/test_walk_and_arm.launch.py
@@ -1,8 +1,6 @@
-"""Milestone-3 acceptance test: legs walking and arms moving in the SAME session.
+"""Acceptance test: legs walking and arms moving in the same session.
 
-Neither half is new on its own -- Milestone 1 shipped the arm bridge and Milestone 3
-the walking policy -- but the point of the milestone is that they coexist. The two
-own disjoint motor ranges (policy 0-14, /arm_sdk 15-28) through a single /lowcmd
+The two own disjoint motor ranges (policy 0-14, /arm_sdk 15-28) through a single /lowcmd
 writer, and this is the test that says so end to end: drive the robot forward through
 the real LocoClient path while a FollowJointTrajectory goal runs on the arms.
 
@@ -192,9 +190,9 @@ class WalkAndArmTest(unittest.TestCase):
         self.assertTrue(self._set_mode(SetLocoMode.Goal.STAND_UP).success, "StandUp rejected")
         self.assertTrue(self._set_mode(SetLocoMode.Goal.START).success, "Start rejected")
 
-        # 4. Send the arm trajectory, then drive the legs WHILE it executes. The overlap is the
-        #    whole point -- run sequentially and the test would pass with the two paths still
-        #    fighting over /lowcmd.
+        # 4. Send the arm trajectory, then drive the legs while it executes: run the two
+        #    sequentially instead and the test would pass even with the two paths fighting
+        #    over /lowcmd.
         client = ActionClient(
             self.node, FollowJointTrajectory, "/arm_trajectory_controller/follow_joint_trajectory"
         )

--- a/workspace/src/g1_bringup/test/test_walk_stand.launch.py
+++ b/workspace/src/g1_bringup/test/test_walk_stand.launch.py
@@ -1,6 +1,6 @@
 """Headless sim integration test: the walking policy stands the robot up and holds it.
 
-Everything here requires the robot NOT to have moved, so it is deliberately
+Everything here requires the robot not to have moved, so it is deliberately
 separate from test_walk_teleop.launch.py (which drives it). Launches the default
 unwelded stack -- pin_pelvis defaults false, so nothing but the policy keeps the
 robot upright.
@@ -60,8 +60,8 @@ def generate_test_description():
         PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory("g1_bringup"), "launch", "sim.launch.py")
         )
-        # No launch_arguments: this suite exercises the DEFAULT stack, unwelded, with the
-        # walking policy holding the robot up. That default is the point of the test.
+        # No launch_arguments: this suite exercises the default stack, unwelded, with the
+        # walking policy holding the robot up.
     )
     return (
         LaunchDescription([sim_launch, TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()])]),

--- a/workspace/src/g1_bringup/test/test_walk_teleop.launch.py
+++ b/workspace/src/g1_bringup/test/test_walk_teleop.launch.py
@@ -149,7 +149,7 @@ class WalkTeleopTest(unittest.TestCase):
             self._spin(settle_s)
 
     def _set_mode(self, fsm_id, timeout_s=10.0):
-        """Drives the REAL SetLocoMode action -- the same path an operator or Nav2 would use."""
+        """Drives the real SetLocoMode action -- the same path an operator or Nav2 would use."""
         self.assertTrue(self.mode_client.wait_for_server(timeout_sec=timeout_s), "no action server")
         goal = SetLocoMode.Goal()
         goal.fsm_id = fsm_id
@@ -180,11 +180,11 @@ class WalkTeleopTest(unittest.TestCase):
     def test_01_velocity_before_start_is_rejected_and_moves_nothing(self):
         """SET_VELOCITY outside Start must return 7301 and not move the robot.
 
-        Published as a RAW request because the bridge's VelocityGate would never emit
+        Published as a raw request because the bridge's VelocityGate would never emit
         one outside kHeld. Publisher is created/destroyed inside this test to avoid
         tripping the single-writer guard for the rest of the session.
         """
-        # Settle first: the measurement below is about whether a REJECTED command moved the
+        # Settle first: the measurement below is about whether a rejected command moved the
         # robot, so the spawn transient must not be inside the window.
         self._await_standing(settle_s=4.0)
         before = list(self._position())
@@ -266,7 +266,7 @@ class WalkTeleopTest(unittest.TestCase):
         )
 
     def test_05_damp_releases_authority_and_robot_keeps_standing(self):
-        """Releasing locomotion authority stops motion but must NOT drop the robot.
+        """Releasing locomotion authority stops motion but must not drop the robot.
 
         The policy runs continuously regardless of FSM state -- leg authority is gated on policy
         freshness, not on the FSM -- so Damp ends walking without ending balance.
@@ -315,7 +315,7 @@ class WalkTeleopTest(unittest.TestCase):
         """Slam between above- and below-threshold commands.
 
         The policy has no hysteresis: dropping below threshold stops the gait outright. Doing that
-        at speed, repeatedly, is the transition Phase-1 characterisation never measured.
+        at speed, repeatedly, is the transition this test exists to cover.
         """
         worst_height = 10.0
         for _ in range(3):

--- a/workspace/src/g1_description/config/arm_sdk_params.yaml
+++ b/workspace/src/g1_description/config/arm_sdk_params.yaml
@@ -15,7 +15,7 @@ system:
   max_joint_velocity_rad_s: 1.0  # rad/s; slew clamp applied to every commanded joint
   lowstate_timeout_ms: 100       # ms; /lowstate age beyond this trips the emergency ramp-down
 
-  # The waist (motors 12-14) comes with the arms on /arm_sdk and is HELD, not planned: the
+  # The waist (motors 12-14) comes with the arms on /arm_sdk and is held, not planned: the
   # component latches its measured position when the blend engages and commands that. Unitree's
   # own arm_sdk example runs the waist at four times its arm gains (60/1.5 -> 240/6.0); ours are
   # 40/1 and 25/1, so these are 4x the shoulder pair. Stiff on purpose -- this is the joint

--- a/workspace/src/g1_description/config/dex3_params.yaml
+++ b/workspace/src/g1_description/config/dex3_params.yaml
@@ -29,7 +29,7 @@ system:
 # looks like a transposed digit); the URDF matches the published spec and is the conservative
 # pair, so it wins.
 #
-# Order is the Dex3 WIRE order and the component refuses to init if the xacro reorders it.
+# Order is the Dex3 wire order and the component refuses to init if the xacro reorders it.
 joints:
   left_hand_thumb_0_joint:   { min: -1.04719755, max:  1.04719755 }
   left_hand_thumb_1_joint:   { min: -0.61086523, max:  1.04719755 }

--- a/workspace/src/g1_description/test/test_motor_order.py
+++ b/workspace/src/g1_description/test/test_motor_order.py
@@ -6,7 +6,7 @@ publish the legs and waist to `/joint_states` on the robot, where no controller 
 two packages cannot share a header -- one is simulation only and the other is what ships -- so
 each carries its own table.
 
-Index into either table IS the LowState motor index. Permute one and a knee angle lands on a
+Index into either table is the LowState motor index. Permute one and a knee angle lands on a
 waist joint, which moves every sensor frame hanging off `torso_link` and reads downstream as an
 odometry or calibration fault rather than as what it is.
 """

--- a/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
+++ b/workspace/src/g1_description/urdf/g1_arm_sdk.urdf.xacro
@@ -27,7 +27,7 @@
     <origin xyz="0 0 0" rpy="-1.5707963267948966 0 -1.5707963267948966"/>
   </joint>
 
-  <!-- Sensor bodies. The vendored URDF leaves d435_link and mid360_link as EMPTY links, so both
+  <!-- Sensor bodies. The vendored URDF leaves d435_link and mid360_link as empty links, so both
        sensors are invisible in RViz and it is impossible to see where either is pointing.
        Attached as child links rather than by editing those links, for the same reason the
        optical frames above are: the vendored file stays byte-for-byte diffable against
@@ -179,7 +179,7 @@
 
   <!-- Where the hand actually closes, as a frame rather than a number in a config file.
 
-       The palm link's origin is NOT the point the fingers grip at, and the difference is large
+       The palm link's origin is not the point the fingers grip at, and the difference is large
        enough to matter: at the SRDF's `closed` posture the thumb tip lands at palm
        (-0.030, +0.020, +0.017) and the middle and index tips at (+0.050, +0.068, -/+0.029), so
        what the hand encloses sits well forward of the origin and mostly to one side of it.

--- a/workspace/src/g1_hand_interface/CMakeLists.txt
+++ b/workspace/src/g1_hand_interface/CMakeLists.txt
@@ -60,6 +60,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_hand_interface test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_hand_interface
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_hand_interface PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_hand_interface test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_hand_interface/CMakeLists.txt
+++ b/workspace/src/g1_hand_interface/CMakeLists.txt
@@ -66,8 +66,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_hand_interface
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -75,7 +75,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_hand_interface PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_hand_interface test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_hand_interface test")
   endif()
 endif()
 

--- a/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
+++ b/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
@@ -8,7 +8,7 @@
  * Real hardware code. It speaks Unitree's published Dex3 contract and carries to the robot
  * unchanged; the simulator is expected to answer the same topics.
  *
- * Deliberately NOT part of G1ArmSdkSystem. The hand is a separate device on separate topics
+ * Deliberately not part of G1ArmSdkSystem. The hand is a separate device on separate topics
  * with separate authority, and one component per hand keeps a hand
  * fault from taking the arms down with it.
  */

--- a/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
+++ b/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
@@ -82,8 +82,8 @@ G1Dex3System::on_init(const hardware_interface::HardwareInfo& info)
         // disagrees on thumb_1 (0.724 vs 0.611) and its right hand says 0.742, which looks
         // like a transposed digit. The conservative pair is the right one to trust.
         const auto& limits = info.joints[i].parameters;
-        lower_limit_[i]    = limits.count("min") ? std::stod(limits.at("min")) : -3.15;
-        upper_limit_[i]    = limits.count("max") ? std::stod(limits.at("max")) : 3.15;
+        lower_limit_[i]    = limits.contains("min") ? std::stod(limits.at("min")) : -3.15;
+        upper_limit_[i]    = limits.contains("max") ? std::stod(limits.at("max")) : 3.15;
     }
 
     kp_                   = paramOr(info, "kp", 1.5);

--- a/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
+++ b/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
@@ -119,7 +119,7 @@ hardware_interface::CallbackReturn G1Dex3System::on_configure(const rclcpp_lifec
     cmd_pub_ =
         std::make_shared<realtime_tools::RealtimePublisher<unitree_hg::msg::HandCmd>>(cmd_pub_raw_);
 
-    // motor_cmd is an UNBOUNDED SEQUENCE, not a fixed array. Publishing it unresized is
+    // motor_cmd is an unbounded sequence, not a fixed array. Publishing it unresized is
     // accepted by DDS and silently moves nothing, which is a miserable thing to debug.
     cmd_pub_->msg_.motor_cmd.resize(kNumHandJoints);
 

--- a/workspace/src/g1_hand_interface/test/test_wire_contract.cpp
+++ b/workspace/src/g1_hand_interface/test/test_wire_contract.cpp
@@ -40,8 +40,8 @@ TEST(Dex3WireContract, EveryMotorCarriesItsOwnIndex)
 TEST(Dex3WireContract, JointOrderIsThumbThenMiddleThenIndex)
 {
     // Unitree's own Dex3_1_Right_JointIndex enum lists index before middle, contradicting
-    // their documented order. It is inert in their code and a hand that closes the wrong
-    // fingers here, so it is pinned rather than trusted.
+    // their documented order. It is inert in their code, but transcribing it here would
+    // close the wrong fingers, so this order is pinned rather than trusted.
     EXPECT_THAT(
         kJointSuffixes,
         ::testing::ElementsAre(

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -114,6 +114,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_hardware_interface test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_hardware_interface
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_hardware_interface PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_hardware_interface test")
+  endif()
 endif()
 
 ament_export_include_directories(include)

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -120,8 +120,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_hardware_interface
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -129,7 +129,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_hardware_interface PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_hardware_interface test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_hardware_interface test")
   endif()
 endif()
 

--- a/workspace/src/g1_locomotion/CMakeLists.txt
+++ b/workspace/src/g1_locomotion/CMakeLists.txt
@@ -174,6 +174,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_locomotion test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_locomotion
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_locomotion PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_locomotion test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_locomotion/CMakeLists.txt
+++ b/workspace/src/g1_locomotion/CMakeLists.txt
@@ -180,8 +180,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_locomotion
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -189,7 +189,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_locomotion PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_locomotion test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_locomotion test")
   endif()
 endif()
 

--- a/workspace/src/g1_locomotion/config/g1_base_approach.yaml
+++ b/workspace/src/g1_locomotion/config/g1_base_approach.yaml
@@ -1,5 +1,5 @@
 # Walks the base into arm's reach of a measured object, and backs it out again.
-# See g1_locomotion/README.md and the local engineering notes.
+# See g1_locomotion/README.md.
 #
 # *** THESE ARE SIM BRING-UP VALUES, NOT HARDWARE-SAFE DEFAULTS. ***
 # The pulse velocities and durations encode the SIM WALKING POLICY's gait-initiation dead zone,
@@ -17,9 +17,9 @@ g1_base_approach:
 
     # Every one of these must clear g1_gait_shaper's engage thresholds (fwd 0.45, yaw 1.20,
     # lat 0.50) or the shaper zeroes them and this node walks nowhere while reporting that it is
-    # walking. pulse_vyaw was 1.30 originally, which clears the SHAPER and not the POLICY -- the
-    # policy measures "no motion at or below 0.60, steps from 1.50" -- so the first live approach
-    # spent its whole budget asking for a turn that never happened.
+    # walking. pulse_vyaw has to clear the POLICY's own threshold too, which is stricter than
+    # the shaper's: the policy measures "no motion at or below 0.60, steps from 1.50", so a
+    # value that only clears the shaper asks for a turn that never happens.
     pulse_vx: 0.45
     pulse_vyaw: 1.50
     pulse_vy: 0.50
@@ -53,9 +53,9 @@ g1_base_approach:
     turn_pulse_cw_s: 0.60
     strafe_pulse_s: 0.15
 
-    # Forward drives and big heading corrections are CONTINUOUS, closed on the measured error --
+    # Forward drives and big heading corrections are CONTINUOUS, closed on the measured error:
     # a train of pulses winds the walking policy down to nothing (8.3 deg on the first pulse,
-    # ~0.1 by the twentieth), which is why a pulse-growing scheme used to live here and is gone.
+    # ~0.1 by the twentieth).
     # The ceilings bound one drive if the loop's own feedback never ends it; the leads stop the
     # command short of the target because the gait coasts after it: ~17 deg after a turn, and
     # about step_lead_m of travel after a drive.
@@ -67,17 +67,15 @@ g1_base_approach:
     # Hold zero while the gait finishes the stride it is already in, THEN say nothing at all for
     # a moment.
     #
-    # The quiet gap is the more important of the two, and was missing for most of this skill's
-    # life. Every duration in this file was measured by a probe that stopped publishing between
-    # pulses; the loop published zeros continuously instead, and the same 0.60 s clockwise pulse
-    # that turns 4 to 6 degrees under the probe turned 0.5 degrees in the loop. Going quiet lets
-    # g1_loco_bridge's velocity gate fall idle rather than re-issue SetVelocity(0) at 5 Hz, so
-    # the next pulse starts from rest.
-    # Sized for a loop that fired dozens of short pulses. Forward, reverse, lateral and big
-    # heading corrections are continuous drives now, so a run takes a handful of moves rather
-    # than fifty and settle_s was trimmed. Not removed: the gait keeps stepping after the
-    # command stops, and measuring before it settles reports the command plus whatever of the
-    # stride was still in flight.
+    # The quiet gap is the more important of the two. Every duration in this file was measured
+    # by a probe that stopped publishing between pulses; commanding zero continuously instead of
+    # going quiet drops the same 0.60 s clockwise pulse from 4-6 degrees of turn to 0.5. Going
+    # quiet lets g1_loco_bridge's velocity gate fall idle rather than re-issue SetVelocity(0) at
+    # 5 Hz, so the next pulse starts from rest.
+    #
+    # settle_s is not zero: the gait keeps stepping for a moment after the command stops, and
+    # measuring before it settles reports the command plus whatever of the stride was still in
+    # flight.
     settle_s: 1.5
     quiet_after_s: 1.2
     cmd_rate_hz: 20.0
@@ -91,8 +89,7 @@ g1_base_approach:
     # MUST stay under forward_tolerance_m. A reverse that stops further out than the tolerance
     # leaves a dead band where the planner keeps asking for a reverse and the drive keeps
     # reporting itself already arrived: the same error logged every 2.7 s, forever, with the
-    # robot standing still. It was step_lead_m (0.22) against a tolerance of 0.110 and did
-    # exactly that. The node clamps it to half the tolerance regardless.
+    # robot standing still. The node clamps it to half the tolerance regardless.
     reverse_lead_m: 0.045
 
     # WHERE THE OBJECT HAS TO END UP, in the base frame, for the arm to reach it.
@@ -100,12 +97,6 @@ g1_base_approach:
     # MEASURED, by asking /compute_ik for the grasp frame at the workbench cube's own height
     # (pelvis z +0.0375) across a sweep of x, four attempts each: m9-checks/reach_sweep.py.
     # Everything from x 0.16 to 0.36 solves 4/4; 0.38 and beyond solve none.
-    #
-    # This replaced 0.28 with a tolerance of 0.045, which came from the one configuration the
-    # pick is proven at in the manipulation scene. That was one sample mistaken for a range, and
-    # it cost twice: it put the target 8 cm nearer than the arm needs, which drives the robot's
-    # hips into the table edge, and it made the window a third of its real width, so the approach
-    # was chasing precision the gait does not have.
     #
     # target_y_m mirrors for the left arm, exactly as the grasp offset does.
     target_x_m: 0.270
@@ -126,18 +117,8 @@ g1_base_approach:
     # and gets patchy above -0.17. So the lateral window is the tight one and the forward window
     # is not.
     #
-    # The old +/-0.07 lateral is what let the approach stop with the cube at y -0.114, well into
-    # the patchy region, and the pick then died on the pregrasp with GOAL_STATE_INVALID.
-    # Forward is the LOOSE axis and lateral is the tight one, which is the opposite of what the
-    # first single-line sweep suggested. 0.09 puts the forward window at x 0.19..0.37, all of it
-    # inside the solid band; a run that stopped at 0.066 of forward error and 0.022 of lateral
-    # was refused by a 0.060 forward tolerance it had no reason to be held to.
-    # 0.27 +/- 0.11 IS the measured band, x 0.16..0.38, rather than a cautious slice of it.
-    #
-    # Cutting it short is what caused the retries: a run stepped from 0.718 of forward error to
-    # 0.103 in one drive -- a good, finished approach -- and was then sent nudging for forty
-    # pulses because the tolerance was 0.090 and it was 13 mm outside. The arm could reach it the
-    # whole time. Being stricter than the arm buys nothing and costs minutes.
+    # 0.27 +/- 0.11 IS the measured band, x 0.16..0.38, rather than a cautious slice of it: being
+    # stricter than the arm actually needs buys nothing and costs minutes of retries.
     forward_tolerance_m: 0.110
     lateral_tolerance_m: 0.040
     # LOOSE on purpose, 20 degrees, and consumed ONLY by the aim before a forward drive. The
@@ -149,12 +130,11 @@ g1_base_approach:
     # Nearer than this and the object is genuinely under the robot, where no move helps and the
     # tree has to re-stage through Nav2. Everything above it is recovered by reversing.
     #
-    # It was 0.120, just under the arm band's near end, and that was too high to be a floor. The
-    # last few centimetres of forward error are closed by deliberately overshooting and reversing
-    # back, because forward is IRREDUCIBLE at about 0.29 m -- so a 0.123 m error steps to -0.161
-    # every time, by design. At 0.120 that landed 11 mm under the floor and aborted a healthy
-    # approach as unrecoverable, on the one move the design depends on. Reverse works: Retreat
-    # covers a metre with it.
+    # The last few centimetres of forward error are closed by deliberately overshooting and
+    # reversing back, because forward is IRREDUCIBLE at about 0.29 m -- so a 0.123 m error steps
+    # to -0.161 every time, by design. This floor has to stay under that, or the one move the
+    # design depends on gets treated as unrecoverable. Reverse works: Retreat covers a metre
+    # with it.
     min_forward_m: 0.050
 
     # More than this left and the forward drive may stop early and let the gait coast; less, and
@@ -162,10 +142,10 @@ g1_base_approach:
     # 0.293 m from a settled robot, 0.37 to 0.51 inside the approach loop where the gait is
     # already warm from the re-aim before it.
     #
-    # It is NOT an upper bound, and was, which broke the approach outright. At 0.60 the planner
-    # refused to step with 0.58 m of gap left -- on the grounds that a 0.60 step might overshoot
-    # -- and set about closing the whole 0.58 m two centimetres at a time. It never arrived.
-    # Overshooting is recoverable (the robot reverses), so caution here costs more than it saves.
+    # NOT an upper bound on how far the drive may step: treating it as one makes the planner
+    # refuse to close large gaps at all, inching in two centimetres at a time and never
+    # arriving. Overshooting is recoverable (the robot reverses), so caution here costs more
+    # than it saves.
     step_threshold_m: 0.32
 
     object_timeout_ms: 1500.0

--- a/workspace/src/g1_locomotion/config/g1_gait_shaper.yaml
+++ b/workspace/src/g1_locomotion/config/g1_gait_shaper.yaml
@@ -22,11 +22,11 @@ g1_gait_shaper:
     # Reverse gets its OWN threshold, higher than forward's, rather than being refused outright.
     #
     # Measured: -0.60 yields -0.247 m/s and -0.40 yields exactly 0.000, so reverse exists but only
-    # well past where a planner would ask for it. Nav2's backup speeds are 0.025 to 0.15 m/s and
-    # stay zeroed, which is the whole point of the old blanket refusal and is preserved here. What
-    # changed is that a caller who deliberately commands -0.60 -- g1_base_approach backing away
-    # from a workbench -- now gets it, because turning to walk away sweeps the arm across the
-    # table it just picked from.
+    # well past where a planner would ask for it. Nav2's backup speeds (0.025 to 0.15 m/s) stay
+    # zeroed, which backstops against a misconfigured recovery behaviour lurching backwards. A
+    # caller that deliberately commands -0.60 -- g1_base_approach backing away from a workbench,
+    # because turning to walk away would sweep the arm across the table it just picked from --
+    # gets through on purpose.
     rev_engage: 0.55
 
     # Yaw rate at or above which the command becomes a pure in-place turn.
@@ -47,9 +47,8 @@ g1_gait_shaper:
     # yaw_clamp matches max_velocity[2]: the shaper should never hand the bridge something the
     # bridge would clamp.
     #
-    # Nav2 never reaches these. Its controller commands no lateral on this robot, so in practice
-    # the only caller is g1_base_approach, which strafes to null the lateral error between where
-    # an object is and where the arm can reach it. That is the whole reason lateral stopped being
-    # dropped -- see gait_shaper.hpp.
+    # Nav2 never reaches these: its controller commands no lateral on this robot. The only caller
+    # is g1_base_approach, which strafes to null the lateral error between where an object is and
+    # where the arm can reach it -- see gait_shaper.hpp.
     lat_engage: 0.50
     lat_clamp: 0.50

--- a/workspace/src/g1_locomotion/config/g1_loco_authority.yaml
+++ b/workspace/src/g1_locomotion/config/g1_loco_authority.yaml
@@ -1,9 +1,8 @@
 # Lifecycle bracket around LocoClient velocity authority: active means the robot is
 # walk-capable, inactive means authority has been handed back. See g1_locomotion/README.md.
 #
-# Both values below were MEASURED, not guessed -- they were the only two numbers in the
-# milestone's design with no empirical grounding at all, so they were measured before this node
-# was written. Full distribution and method in the local engineering notes.
+# Both values below were MEASURED, not guessed -- they were the two numbers here with no
+# empirical grounding at all otherwise, so they were measured before this node was written.
 g1_loco_authority:
   ros__parameters:
     # The bridge's action, absolute. A parameter rather than a launch remap: remapping does not

--- a/workspace/src/g1_locomotion/config/g1_loco_bridge.yaml
+++ b/workspace/src/g1_locomotion/config/g1_loco_bridge.yaml
@@ -32,10 +32,9 @@
     # *** THIS IS A SIM BRING-UP VALUE, NOT A HARDWARE-SAFE DEFAULT. ***
     # It is chosen to clear the sim walking policy's measured gait-initiation
     # thresholds ([0.40, 0.50, 1.50]) with real headroom, and matches the range
-    # the reference package validated (~0.8 / 0.5 / 1.57). Below those
-    # thresholds this policy stands still instead of stepping, so the previous
-    # [0.3, 0.2, 0.5] clamped every axis under its own threshold and the robot
-    # could never take a step at all.
+    # the reference package validated (~0.8 / 0.5 / 1.57). A clamp under those
+    # thresholds on any axis means that axis can never step at all: the policy
+    # stands still below them rather than moving slowly.
     #
     # The conservative slow-by-default ceiling that hardware wants is a SEPARATE
     # decision to be made at hardware bring-up, against the real controller's own

--- a/workspace/src/g1_locomotion/include/g1_locomotion/approach_planner.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/approach_planner.hpp
@@ -23,19 +23,14 @@
  * forward step yaws +8 deg and an uncorrected sequence walks an arc; that aim loop is the only
  * yaw in the skill, and it belongs to the caller, not the plan.
  *
- * Two earlier versions planned turns, and both failed on it. An OBLIQUE forward step needs theta
- * near 75 degrees for a small remainder, which throws the robot half a metre sideways; a 45
- * degree CREEP-and-strafe costs 45 degrees of turning each way, and one live run spent 48 pulses
- * that way taking out 17 cm of lateral error that five strafes would have covered. A third
- * version kept a terminal heading gate after the position had converged, and the caller -- which
- * had dropped turning by then -- had no handler for the turn it demanded: the loop spun
- * silently, forever, mid-mission.
+ * Earlier versions planned turns as part of this decision, and each one failed differently: an
+ * oblique step throws the robot sideways for a small remainder, a turn-and-strafe hybrid burns
+ * far more pulses than strafing alone, and a terminal heading gate can deadlock the caller if it
+ * ever stops handling turns. Heading stays out of this decision entirely.
  *
  * Fine forward motion, which the gait cannot produce directly, is instead a forward drive that
  * stops at zero and a reverse that takes back whatever the coast added. Reverse resolves more
  * finely than forward does: -0.247 m/s against 0.35.
- *
- * Measurements and the rest of the rationale: the local engineering notes.
  */
 
 #include <cstdint>

--- a/workspace/src/g1_locomotion/include/g1_locomotion/g1_loco_bridge_node.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/g1_loco_bridge_node.hpp
@@ -57,9 +57,9 @@ private:
     /// defeating the whole point of re-issuing.
     bool readParameters();
 
-    rclcpp_action::GoalResponse
-    handleGoal(const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const SetLocoMode::Goal> goal);
-    rclcpp_action::CancelResponse
+    rclcpp_action::GoalResponse handleGoal(
+        const rclcpp_action::GoalUUID& uuid, const std::shared_ptr<const SetLocoMode::Goal>& goal);
+    static rclcpp_action::CancelResponse
          handleCancel(const std::shared_ptr<GoalHandleSetLocoMode>& goal_handle);
     void handleAccepted(const std::shared_ptr<GoalHandleSetLocoMode>& goal_handle);
     void onSetLocoModeResult(

--- a/workspace/src/g1_locomotion/include/g1_locomotion/gait_shaper.hpp
+++ b/workspace/src/g1_locomotion/include/g1_locomotion/gait_shaper.hpp
@@ -22,13 +22,9 @@ namespace g1_locomotion
  * class collapses its output onto the four motions that exist: stop, drive straight, strafe,
  * turn in place.
  *
- * Strafe was not always here. It was dropped originally because Nav2's controller cannot command
- * lateral on this robot anyway and the gait already produces uncommanded lateral drift, so
- * asking for more looked pointless. Milestone 9's base approach is the caller that changes
- * that: the mobile-manipulation answer to "park precisely enough for the arm to reach" is a
- * holonomic base, and this gait IS holonomic at the velocity level -- the policy measures
- * lateral motion from 0.50 m/s. Throwing that away meant every lateral correction cost a turn,
- * a step and a turn back.
+ * This gait IS holonomic at the velocity level -- the policy measures lateral motion from
+ * 0.50 m/s -- which is what makes strafe worth having: it lets a caller correct sideways error
+ * directly, rather than paying for a turn, a step and a turn back every time.
  *
  * **Subtractive only.** Every output is the input unchanged, the input clamped smaller, or
  * zero -- never larger. That is the invariant the whole design rests on: turning a small
@@ -88,9 +84,8 @@ public:
      * -0.247 m/s for a commanded -0.60 and exactly 0.000 for -0.40, so reverse exists but only
      * well past where a planner would ask for it: Nav2's backup speeds are 0.025 to 0.15 m/s and
      * stay zeroed, which is the backstop against a misconfigured recovery behaviour lurching
-     * backwards. What changed is that a caller who deliberately asks for -0.60 now gets it,
-     * because backing away from a workbench without turning is the only way to leave one without
-     * sweeping the arm across it.
+     * backwards. A caller that deliberately asks for -0.60, such as backing away from a
+     * workbench without turning, gets through that same backstop on purpose.
      *
      * Lateral is tested LAST, so it only survives a command carrying nothing else. That keeps
      * the primitives mutually exclusive, which the measured combined-command response demands:

--- a/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
@@ -4,8 +4,7 @@
  *
  * The missing step between navigation and manipulation. Nav2 parks the robot within 0.5 m of a
  * goal it chose from a map; the arm reaches 0.28 to 0.33 m and its usable window is about
- * 0.12 m wide. Nothing bridges that today, which is why navigate-then-pick does not work
- *.
+ * 0.12 m wide. Nothing bridges that today, which is why navigate-then-pick does not work.
  *
  * Lives in g1_locomotion, not in g1_manipulation, on one principle: everything that writes a
  * velocity command belongs to the package that owns the velocity path. A manipulation package
@@ -198,9 +197,9 @@ public:
 private:
     /// Hold a velocity until `done()` returns true, then stop and let the gait settle.
     ///
-    /// CONTINUOUS, not pulsed, and that is the point: repeated command-and-stop cycles wind the
-    /// walking policy down, from 8.3 degrees of yaw on the first pulse to nothing by the
-    /// twentieth. Nav2 drives this robot with a continuous stream and has never had the problem.
+    /// CONTINUOUS, not pulsed: repeated command-and-stop cycles wind the walking policy down,
+    /// from 8.3 degrees of yaw on the first pulse to nothing by the twentieth. Nav2 drives this
+    /// robot with a continuous stream and has never had the problem.
     template <typename DoneT>
     bool driveUntil(
         double vx, double vy, double vyaw, DoneT done, double max_s,
@@ -274,13 +273,11 @@ private:
             std::this_thread::sleep_for(period);
         }
 
-        // Then say nothing at all for a moment. This is the one thing that differed between the
-        // probe that produced every number in the config and this loop, and it is worth more
-        // than any of them: the same 0.60 s clockwise pulse turns 4 to 6 degrees when measured
-        // with a silent gap after it, and 0.5 degrees when the zeros never stop. Going quiet
-        // lets g1_loco_bridge's velocity gate fall idle instead of re-issuing SetVelocity(0) at
-        // 5 Hz, and the gait starts the next pulse from rest rather than from whatever the
-        // re-issue stream left it in.
+        // Then say nothing at all for a moment: the same 0.60 s clockwise pulse turns 4 to 6
+        // degrees when measured with a silent gap after it, and 0.5 degrees when the zeros
+        // never stop. Going quiet lets g1_loco_bridge's velocity gate fall idle instead of
+        // re-issuing SetVelocity(0) at 5 Hz, so the gait starts the next pulse from rest rather
+        // than from whatever the re-issue stream left it in.
         //
         // Nothing takes the channel during the gap: the shaper's override lapses after
         // override_timeout_s, but Nav2 publishes nothing between goals, so the output is silence
@@ -364,9 +361,8 @@ private:
                 return std::nullopt;
             }
         }
-        // The one path out of here that used to say nothing at all, and the abort it causes
-        // reads identically to a stale or untransformable pose. Worth a line: a live run
-        // aborted here with /objects publishing at 10 Hz and left no evidence of which.
+        // Logged explicitly: without it, this abort reads identically to a stale or
+        // untransformable pose, with no way to tell which one actually happened.
         RCLCPP_WARN(
             get_logger(),
             "'%s' is not among the %zu objects being reported",
@@ -418,8 +414,8 @@ private:
         int  pulses   = 0;
 
         // The heading held for the whole approach. Fixed up front rather than recomputed from
-        // the object each iteration: the object moves in the base frame as the robot walks, and
-        // chasing it is what made the previous version arrive square to nothing.
+        // the object each iteration: the object moves in the base frame as the robot walks, so
+        // chasing it would never let the approach arrive square to anything.
         const auto start_pose = basePose();
         if (!start_pose)
         {
@@ -455,9 +451,9 @@ private:
 
             // Re-read rather than give up on the first miss. Both of these can fail for a
             // moment for reasons that are not the skill's problem: a TF buffer that has not
-            // caught up after the base moved, or a sample arriving late. Aborting on one miss
-            // threw away an otherwise healthy approach mid-mission with /objects publishing at
-            // 10 Hz throughout. Bounded, so a genuinely absent object still ends the goal.
+            // caught up after the base moved, or a sample arriving late. Aborting on the first
+            // miss would throw away an otherwise healthy approach for a momentary hiccup.
+            // Bounded, so a genuinely absent object still ends the goal.
             std::optional<geometry_msgs::msg::PointStamped> object;
             std::optional<geometry_msgs::msg::PoseStamped>  here;
             const auto give_up_looking = deadlineIn(lookup_grace_s_);
@@ -523,8 +519,8 @@ private:
                     handle->publish_feedback(feedback);
 
                     // Aim first, ALWAYS. A forward pulse yaws the robot 8 degrees every time, so
-                    // without re-aiming before each one the approach walks an arc; that is what
-                    // the spiral in the first probe run was.
+                    // without re-aiming before each one the approach walks an arc instead of a
+                    // straight line.
                     RCLCPP_INFO(
                         get_logger(),
                         "step: forward error %.3f, lateral %.3f",
@@ -564,11 +560,10 @@ private:
                         command.forward_error_m,
                         command.lateral_error_m);
                     // The lead here MUST stay under forward_tolerance_m, and getting that
-                    // backwards livelocks rather than degrades. It used step_lead_m_ (0.22)
-                    // against a tolerance of 0.110, so every error between the two left the
-                    // planner demanding a reverse and driveUntil reporting itself already
-                    // arrived: the same "-0.138" logged every 2.7 s, forever, with no time
-                    // spent driving. Exactly the dead band the heading correction hit.
+                    // backwards livelocks rather than degrades: every error between the two
+                    // would leave the planner demanding a reverse and driveUntil reporting
+                    // itself already arrived, logged forever with no time spent driving. Exactly
+                    // the dead band the heading correction hits.
                     const double lead = std::min(reverse_lead_m_, 0.5 * limits.forward_tolerance_m);
                     const auto   back_far_enough = [&] {
                         const auto object_now = objectInBase(goal->object_id);
@@ -591,13 +586,6 @@ private:
                     // Continuous while there is real distance to cover, one short pulse for the
                     // last few centimetres. Same hybrid the heading correction uses, and for the
                     // same reason: neither primitive covers both ends.
-                    //
-                    // This was a fixed 0.15 s pulse for every correction, and it was the slowest
-                    // thing in the mission by a wide margin. Each one moved about 12 mm and then
-                    // spent settle + quiet standing still, so 3.9 s per centimetre and a half:
-                    // one live approach spent 54 of them closing a gap a single drive covers.
-                    // Forward and reverse had been continuous since the pulse decay was
-                    // measured; lateral was simply left behind.
                     const bool far = std::abs(command.lateral_error_m) > lateral_lead_m_;
                     RCLCPP_INFO(
                         get_logger(),
@@ -648,8 +636,7 @@ private:
     /// This gait's yaw is ASYMMETRIC, measured: a 0.15 s pulse turns +3.8 deg counter-clockwise
     /// but only -1.1 deg clockwise, and clockwise does not reach -3.5 deg until 0.60 s. That
     /// matters more than it sounds, because a forward step yaws +8 deg every time, so every
-    /// correction the approach needs is in the weak direction -- the first live run spent
-    /// fourteen pulses failing to take out 7 degrees.
+    /// correction the approach needs is in the weak direction.
     double turnPulseFor(double error_rad) const
     {
         return error_rad > 0.0 ? turn_pulse_ccw_s_ : turn_pulse_cw_s_;
@@ -697,14 +684,13 @@ private:
             //
             // Neither alone works. A continuous turn cannot stop inside the tolerance because
             // the gait coasts about 17 degrees after the command ends, wider than the 8 degree
-            // window; and a train of pulses winds the policy down to nothing, which is what the
-            // fully pulsed design failed on. So drive while the error is bigger than the coast,
-            // and pulse once it is not.
+            // window; and a train of pulses winds the policy down to nothing. So drive while
+            // the error is bigger than the coast, and pulse once it is not.
             //
-            // Getting this wrong deadlocks rather than degrades. With the stopping lead larger
-            // than the tolerance, every error between the two left the planner demanding a turn
-            // and driveUntil declaring itself already arrived, logged as the same +9.2 deg
-            // forever, 3.7 s apart, with no time spent driving.
+            // Getting this wrong deadlocks rather than degrades: with the stopping lead larger
+            // than the tolerance, every error between the two leaves the planner demanding a
+            // turn while driveUntil declares itself already arrived, logged forever with no
+            // time spent driving.
             const bool far = std::abs(error) > turn_lead_rad_;
             RCLCPP_INFO(
                 get_logger(),
@@ -752,13 +738,10 @@ private:
         const double timeout_s = goal->timeout_s > 0.0 ? goal->timeout_s : default_timeout_s_;
         const auto   deadline  = deadlineIn(timeout_s);
 
-        // Reverse, and that is the whole skill. No turn, no walk.
-        //
-        // It used to turn 180 degrees and walk the remaining distance, which was doing Nav2's job
-        // badly: a navigation goal follows immediately and is far better at going somewhere than a
-        // hand-rolled pulse controller. And the turn was actively harmful -- taken beside a
-        // workbench it swings the robot and whatever it is holding across the table, which is
-        // exactly what this exists to prevent.
+        // Reverse. No turn, no walk: a turn taken beside a workbench swings the robot and
+        // whatever it is holding across the table, which is exactly what this exists to
+        // prevent. A navigation goal follows immediately and is far better at going somewhere
+        // than a hand-rolled pulse controller would be anyway.
         //
         // Reverse is real but only just: the policy measures -0.247 m/s at a commanded -0.60 and
         // exactly nothing at -0.40, and g1_gait_shaper has a rev_engage above a planner's backup

--- a/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_base_approach_node.cpp
@@ -101,7 +101,7 @@ public:
         lateral_lead_m_ = declare_parameter<double>("lateral_lead_m", 0.055);
         // Kept under forward_tolerance_m; see the reverse case for why that ordering matters.
         reverse_lead_m_   = declare_parameter<double>("reverse_lead_m", 0.045);
-        max_aim_attempts_ = declare_parameter<int>("max_aim_attempts", 8);
+        max_aim_attempts_ = static_cast<int>(declare_parameter<int>("max_aim_attempts", 8));
         // The gait keeps stepping after the command stops. Measuring before it settles reports
         // the command plus whatever of the stride was still in flight.
         settle_s_    = declare_parameter<double>("settle_s", 1.5);
@@ -137,7 +137,7 @@ public:
         // How long a missing object pose or base transform is tolerated before the goal fails.
         lookup_grace_s_ = declare_parameter<double>("lookup_grace_s", 3.0);
 
-        max_pulses_        = declare_parameter<int>("max_pulses", 150);
+        max_pulses_        = static_cast<int>(declare_parameter<int>("max_pulses", 150));
         default_timeout_s_ = declare_parameter<double>("default_timeout_s", 900.0);
 
         if (!limitsAreUsable(limits_))
@@ -159,26 +159,26 @@ public:
         approach_server_ = rclcpp_action::create_server<ApproachObject>(
             this,
             "~/approach_object",
-            [](const rclcpp_action::GoalUUID&, ApproachObject::Goal::ConstSharedPtr) {
+            [](const rclcpp_action::GoalUUID&, const ApproachObject::Goal::ConstSharedPtr&) {
                 return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
             },
-            [](const std::shared_ptr<GoalHandleApproach>) {
+            [](const std::shared_ptr<GoalHandleApproach>&) {
                 return rclcpp_action::CancelResponse::ACCEPT;
             },
-            [this](const std::shared_ptr<GoalHandleApproach> handle) {
+            [this](const std::shared_ptr<GoalHandleApproach>& handle) {
                 std::thread{ [this, handle] { runApproach(handle); } }.detach();
             });
 
         retreat_server_ = rclcpp_action::create_server<Retreat>(
             this,
             "~/retreat",
-            [](const rclcpp_action::GoalUUID&, Retreat::Goal::ConstSharedPtr) {
+            [](const rclcpp_action::GoalUUID&, const Retreat::Goal::ConstSharedPtr&) {
                 return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
             },
-            [](const std::shared_ptr<GoalHandleRetreat>) {
+            [](const std::shared_ptr<GoalHandleRetreat>&) {
                 return rclcpp_action::CancelResponse::ACCEPT;
             },
-            [this](const std::shared_ptr<GoalHandleRetreat> handle) {
+            [this](const std::shared_ptr<GoalHandleRetreat>& handle) {
                 std::thread{ [this, handle] { runRetreat(handle); } }.detach();
             });
 
@@ -835,12 +835,22 @@ private:
 int main(int argc, char** argv)
 {
     rclcpp::init(argc, argv);
-    // Multi-threaded: a goal executes on its own thread and blocks on gait pulses for seconds
-    // at a time, while /objects, TF and cancellation all have to keep flowing underneath it.
-    rclcpp::executors::MultiThreadedExecutor executor;
-    auto node = std::make_shared<g1_locomotion::BaseApproachNode>();
-    executor.add_node(node);
-    executor.spin();
-    rclcpp::shutdown();
-    return 0;
+    try
+    {
+        // Multi-threaded: a goal executes on its own thread and blocks on gait pulses for
+        // seconds at a time, while /objects, TF and cancellation all have to keep flowing
+        // underneath it.
+        rclcpp::executors::MultiThreadedExecutor executor;
+        auto node = std::make_shared<g1_locomotion::BaseApproachNode>();
+        executor.add_node(node);
+        executor.spin();
+        rclcpp::shutdown();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        RCLCPP_ERROR(rclcpp::get_logger("g1_base_approach"), "fatal: %s", e.what());
+        rclcpp::shutdown();
+        return 1;
+    }
 }

--- a/workspace/src/g1_locomotion/src/g1_gait_shaper_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_gait_shaper_node.cpp
@@ -5,12 +5,12 @@
  * A stateless transform on a topic, so a plain node rather than a lifecycle one -- there is
  * nothing to activate. All the shaping logic worth testing is in GaitShaper, which needs no ROS.
  *
- * It also arbitrates. Since milestone 9 the velocity channel has two writers: Nav2, and
- * g1_base_approach walking the last half metre to a workbench because Nav2 cannot park the robot
- * accurately enough for the arm to reach anything. CLAUDE.md section 7 wants that ownership
- * explicit rather than merely well-sequenced, and this node is where it belongs -- it is already
- * the sole writer onto the bridge's input, so making it the sole arbiter of its own inputs adds
- * no new authority to the system.
+ * It also arbitrates: the velocity channel has two writers, Nav2 and g1_base_approach walking
+ * the last half metre to a workbench because Nav2 cannot park the robot accurately enough for
+ * the arm to reach anything. CLAUDE.md section 7 wants that ownership explicit rather than
+ * merely well-sequenced, and this node is where it belongs -- it is already the sole writer
+ * onto the bridge's input, so making it the sole arbiter of its own inputs adds no new
+ * authority to the system.
  *
  * twist_mux is the off-the-shelf answer and was tried first. ros-humble-twist-mux 4.3.0 links
  * libdiagnostic_updater.so, and the only ros-humble-diagnostic-updater this apt snapshot offers

--- a/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
@@ -143,8 +143,7 @@ public:
         }
 
         // The gait is not responsive the instant START returns. Measured across 8 fresh
-        // launches: 1.83-1.92 s for six of seven that moved. See
-        // Deliberately not the p90; see the distribution this was measured from.
+        // launches: 1.83-1.92 s for six of seven that moved, deliberately not the p90.
         std::this_thread::sleep_for(std::chrono::duration<double>(settle_after_start_s_));
 
         RCLCPP_INFO(
@@ -395,8 +394,7 @@ static_assert(
 ///
 /// rclcpp's own signal handler invalidates the context before spin() returns, which leaves
 /// nothing able to send the release goal -- the node would exit from ACTIVE with the bridge
-/// still in kHeld. Verified on this stack before this handler existed: SIGINT left
-/// ~/status reporting authority 2, fsm_id 500, with nobody supervising it.
+/// still in kHeld, holding authority with nobody supervising it.
 ///
 /// Note that on_shutdown() does NOT cover this. It only runs for an explicit
 /// TRANSITION_ACTIVE_SHUTDOWN, which neither launch_ros nor a signal ever issues.

--- a/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_authority_node.cpp
@@ -382,6 +382,9 @@ private:
 
 namespace
 {
+// Mutable by necessity: a signal handler cannot capture, so a flag at namespace scope is the
+// only way back into the process.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<bool> g_stopping{ false };
 // The handler below only stores to this. That is async-signal-safe if and only if the store
 // is lock-free; if it were not, the "just a flag" argument would smuggle a lock into the
@@ -413,46 +416,75 @@ int main(int argc, char** argv)
     init_options.shutdown_on_signal = false;
     rclcpp::init(argc, argv, init_options);
 
-    // Two threads, not the hardware default: on_activate blocks on an action result that this
-    // same node must service, so the result callback needs a thread the transition is not
-    // holding. Two is exactly enough and bounds the deviation. See the package README.
-    rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), 2);
-    auto node = std::make_shared<g1_locomotion::G1LocoAuthority>(rclcpp::NodeOptions());
-    executor.add_node(node->get_node_base_interface());
-
-    std::signal(SIGINT, onSignal);
-    std::signal(SIGTERM, onSignal);
-
-    std::thread watcher([&executor] {
-        while (!g_stopping.load())
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        }
-        executor.cancel();
-    });
-
-    executor.spin();
-    g_stopping.store(true);  // covers spin() returning for any other reason, so watcher joins
-    watcher.join();
-
-    // The context is still valid here, so the release can actually reach the bridge. It runs on
-    // its own thread because sendMode blocks on futures that only the executor can resolve.
-    std::atomic<bool> released{ false };
-    std::thread       releaser([&node, &released] {
-        node->releaseOnExit();
-        released.store(true);
-    });
-    // The loop stops pumping after 8 s; the join after it is deliberately unbounded. Detaching
-    // instead would let the releaser touch the node while shutdown() tears the context down.
-    // Without the executor pumping, the futures inside can only run out their own timeouts, so
-    // this terminates -- at worst 2 x acquire_timeout_s.
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(8);
-    while (!released.load() && std::chrono::steady_clock::now() < deadline)
+    // Nothing below may escape uncaught: unwinding past main() does not guarantee the release
+    // logic runs, which is this file's entire reason to exist past on_activate.
+    try
     {
-        executor.spin_some(std::chrono::milliseconds(50));
-    }
-    releaser.join();
+        // Two threads, not the hardware default: on_activate blocks on an action result that this
+        // same node must service, so the result callback needs a thread the transition is not
+        // holding. Two is exactly enough and bounds the deviation. See the package README.
+        rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), 2);
+        auto node = std::make_shared<g1_locomotion::G1LocoAuthority>(rclcpp::NodeOptions());
+        executor.add_node(node->get_node_base_interface());
 
-    rclcpp::shutdown();
-    return 0;
+        // Checked: a handler that failed to install means Ctrl-C kills the process with
+        // authority still held, which is the leak the whole watcher/releaser dance below exists
+        // to close.
+        const auto previous_int  = std::signal(SIGINT, onSignal);
+        const auto previous_term = std::signal(SIGTERM, onSignal);
+        if (previous_int == SIG_ERR || previous_term == SIG_ERR)
+        {
+            RCLCPP_ERROR(
+                node->get_logger(),
+                "could not install the SIGINT/SIGTERM handlers -- an interrupt will now exit "
+                "without releasing locomotion authority");
+        }
+
+        std::thread watcher([&executor] {
+            while (!g_stopping.load())
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+            executor.cancel();
+        });
+
+        try
+        {
+            executor.spin();
+        }
+        catch (const std::exception& e)
+        {
+            // A callback that throws must not skip the release below.
+            RCLCPP_ERROR(node->get_logger(), "executor.spin() threw: %s", e.what());
+        }
+        g_stopping.store(true);  // covers spin() returning for any other reason, so watcher joins
+        watcher.join();
+
+        // The context is still valid here, so the release can actually reach the bridge. It runs on
+        // its own thread because sendMode blocks on futures that only the executor can resolve.
+        std::atomic<bool> released{ false };
+        std::thread       releaser([&node, &released] {
+            node->releaseOnExit();
+            released.store(true);
+        });
+        // The loop stops pumping after 8 s; the join after it is deliberately unbounded. Detaching
+        // instead would let the releaser touch the node while shutdown() tears the context down.
+        // Without the executor pumping, the futures inside can only run out their own timeouts, so
+        // this terminates -- at worst 2 x acquire_timeout_s.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(8);
+        while (!released.load() && std::chrono::steady_clock::now() < deadline)
+        {
+            executor.spin_some(std::chrono::milliseconds(50));
+        }
+        releaser.join();
+
+        rclcpp::shutdown();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        RCLCPP_ERROR(rclcpp::get_logger("g1_loco_authority"), "fatal: %s", e.what());
+        rclcpp::shutdown();
+        return 1;
+    }
 }

--- a/workspace/src/g1_locomotion/src/g1_loco_bridge_node.cpp
+++ b/workspace/src/g1_locomotion/src/g1_loco_bridge_node.cpp
@@ -157,13 +157,13 @@ G1LocoBridge::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
         get_node_logging_interface(),
         get_node_waitables_interface(),
         "~/set_mode",
-        [this](const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const SetLocoMode::Goal> goal) {
-            return handleGoal(uuid, goal);
-        },
-        [this](const std::shared_ptr<GoalHandleSetLocoMode> goal_handle) {
+        [this](
+            const rclcpp_action::GoalUUID&                  uuid,
+            const std::shared_ptr<const SetLocoMode::Goal>& goal) { return handleGoal(uuid, goal); },
+        [](const std::shared_ptr<GoalHandleSetLocoMode>& goal_handle) {
             return handleCancel(goal_handle);
         },
-        [this](const std::shared_ptr<GoalHandleSetLocoMode> goal_handle) {
+        [this](const std::shared_ptr<GoalHandleSetLocoMode>& goal_handle) {
             handleAccepted(goal_handle);
         },
         rcl_action_server_get_default_options(),
@@ -268,7 +268,7 @@ G1LocoBridge::on_error(const rclcpp_lifecycle::State& /*previous_state*/)
 }
 
 rclcpp_action::GoalResponse G1LocoBridge::handleGoal(
-    const rclcpp_action::GoalUUID& /*uuid*/, std::shared_ptr<const SetLocoMode::Goal> goal)
+    const rclcpp_action::GoalUUID& /*uuid*/, const std::shared_ptr<const SetLocoMode::Goal>& goal)
 {
     // Self-gated: the action server has no lifecycle awareness in Humble,
     // so we must check state ourselves.

--- a/workspace/src/g1_locomotion/src/gait_shaper.cpp
+++ b/workspace/src/g1_locomotion/src/gait_shaper.cpp
@@ -27,8 +27,7 @@ GaitShaper::GaitShaper(const Config& config)
     }
     // Not merely a bad tuning value: it makes the third motion this class exists to produce
     // unreachable. Every turn that clears yaw_engage is then clamped back under it, so the
-    // shaper emits a turn the gait cannot step for. Nav2's max_rotational_vel had exactly this
-    // shape at 1.0 against yaw_engage 1.20, shipped, and was only caught in review.
+    // shaper emits a turn the gait cannot step for.
     if (config_.yaw_clamp < config_.yaw_engage)
     {
         throw std::invalid_argument(
@@ -64,9 +63,8 @@ GaitShaper::Command GaitShaper::shape(const Command& in) const
     // still a stop, which is where a planner's backup speeds live.
     //
     // Finiteness is checked HERE and not on the forward branch because an infinity fails
-    // `>= fwd_engage` on its own only in the positive direction. -inf satisfies this comparison
-    // perfectly well, and used to be caught by the blanket refusal of reverse that this branch
-    // replaced.
+    // `>= fwd_engage` on its own only in the positive direction: -inf satisfies that comparison
+    // perfectly well and would otherwise reach the gait as a real reverse command.
     if (std::isfinite(in.vx) && in.vx <= -config_.rev_engage)
     {
         return Command{ in.vx, 0.0, 0.0 };

--- a/workspace/src/g1_locomotion/test/test_approach_planner.cpp
+++ b/workspace/src/g1_locomotion/test/test_approach_planner.cpp
@@ -98,10 +98,9 @@ TEST(ApproachPlanner, ForwardIsCorrectedBeforeLateral)
 TEST(ApproachPlanner, EveryRegionMapsToAMoveTheCallerHandles)
 {
     const auto limits = defaults();
-    // The planner once kept a terminal heading gate after the caller had dropped its turn
-    // handler, and the pair spun silently mid-mission -- a plan with no handler is a hang, not
-    // an error. The move set is closed now; this sweep pins every position to a move that is
-    // not kInvalid, so a new move can only be added alongside its handling.
+    // A plan the caller has no handler for is a hang, not an error -- silent and mid-mission.
+    // This sweep pins every position to a move that is not kInvalid, so a new move can only be
+    // added alongside its handling.
     for (double fwd : { -0.30, -0.05, 0.05, 0.30, 1.00 })
     {
         for (double lat : { -0.30, 0.0, 0.30 })

--- a/workspace/src/g1_locomotion/test/test_gait_shaper.cpp
+++ b/workspace/src/g1_locomotion/test/test_gait_shaper.cpp
@@ -145,9 +145,9 @@ TEST(GaitShaper, ReverseEngagesOnlyPastItsOwnHigherThreshold)
 {
     const auto shaper = makeShaper();
     // Reverse exists on this policy but only well past where a planner asks for it: -0.60
-    // measures -0.247 m/s and -0.40 measures exactly zero. So a deliberate -0.60 gets through
-    // and Nav2's 0.025..0.15 m/s backup speeds do not, which is the backstop this used to get
-    // by refusing reverse outright.
+    // measures -0.247 m/s and -0.40 measures exactly zero. A deliberate -0.60 gets through while
+    // Nav2's 0.025..0.15 m/s backup speeds stay blocked -- the same backstop against a
+    // misconfigured recovery behaviour lurching backwards.
     EXPECT_DOUBLE_EQ(shaper.shape({ -0.60, 0.0, 0.0 }).vx, -0.60);
     for (double vx : { -0.02, -0.15, -0.30, -0.40, -0.54 })
     {

--- a/workspace/src/g1_locomotion/test/test_gait_shaper.cpp
+++ b/workspace/src/g1_locomotion/test/test_gait_shaper.cpp
@@ -190,10 +190,12 @@ TEST(GaitShaper, NeverAmplifiesAnyAxis)
     // Turning a small command into a large motion is exactly what this stack's control-mode
     // rules exist to prevent, so it is swept rather than spot-checked.
     const auto shaper = makeShaper();
-    for (double vx = -2.0; vx <= 2.0; vx += 0.05)
+    for (int ix = 0; - 2.0 + ix * 0.05 <= 2.0; ++ix)
     {
-        for (double vyaw = -2.0; vyaw <= 2.0; vyaw += 0.05)
+        const double vx = -2.0 + ix * 0.05;
+        for (int iyaw = 0; - 2.0 + iyaw * 0.05 <= 2.0; ++iyaw)
         {
+            const double vyaw = -2.0 + iyaw * 0.05;
             for (double vy : { -0.5, 0.0, 0.5 })
             {
                 const GaitShaper::Command in{ vx, vy, vyaw };
@@ -211,9 +213,10 @@ TEST(GaitShaper, NeverFlipsASign)
     // Weaker than the magnitude invariant but independent of it: reversing a command would
     // also be "not amplifying", and would be just as wrong.
     const auto shaper = makeShaper();
-    for (double vyaw = -2.0; vyaw <= 2.0; vyaw += 0.05)
+    for (int i = 0; - 2.0 + i * 0.05 <= 2.0; ++i)
     {
-        const auto out = shaper.shape({ 0.0, 0.0, vyaw });
+        const double vyaw = -2.0 + i * 0.05;
+        const auto   out  = shaper.shape({ 0.0, 0.0, vyaw });
         if (out.vyaw != 0.0)
         {
             EXPECT_GT(out.vyaw * vyaw, 0.0) << "vyaw " << vyaw;

--- a/workspace/src/g1_locomotion/test/test_loco_bridge_node.cpp
+++ b/workspace/src/g1_locomotion/test/test_loco_bridge_node.cpp
@@ -49,7 +49,7 @@ rclcpp::QoS cmdVelWriterQos()
 }
 
 /**
- * @brief Drives a G1LocoBridge in-process against a fake /api/sport/* responder: no sim, no
+ * @brief Drives a G1LocoBridge in-process against a fake /api/sport/... responder: no sim, no
  * launch_testing, just DDS loopback on an isolated domain.
  * The fake responder answers SET_FSM_ID immediately and never answers SET_VELOCITY.
  */
@@ -59,6 +59,8 @@ protected:
     void SetUp() override
     {
         // Isolated domain to avoid collision with a live sim or concurrent tests.
+        // Before any node or thread exists, so the thread-safety this warns about does not apply.
+        // NOLINTNEXTLINE(concurrency-mt-unsafe)
         setenv("ROS_DOMAIN_ID", "67", 1);
         rclcpp::init(0, nullptr);
 
@@ -181,6 +183,8 @@ protected:
 
     std::optional<unitree_api::msg::Request> lastRequest(std::int64_t api_id) const
     {
+        // std::ranges::reverse_view breaks clang-tidy's Clang-14 parser against libstdc++ here.
+        // NOLINTNEXTLINE(modernize-loop-convert)
         for (auto it = requests_.rbegin(); it != requests_.rend(); ++it)
         {
             if (it->header.identity.api_id == api_id)

--- a/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
+++ b/workspace/src/g1_locomotion/test/test_loco_correlator.cpp
@@ -68,7 +68,7 @@ TEST(LocoRequestCorrelator, TwoOverlappingRequestsBothCompleteCorrectly)
         correlator.send(kApiIdSetFsmId, "{\"data\":4}", now, recordInto(first));
     const auto request_two = correlator.send(
         kApiIdSetVelocity,
-        "{\"velocity\":[0,0,0],\"duration\":1.0}",
+        R"({"velocity":[0,0,0],"duration":1.0})",
         now,
         recordInto(second));
     ASSERT_TRUE(request_one.has_value());

--- a/workspace/src/g1_locomotion/test/test_velocity_gate.cpp
+++ b/workspace/src/g1_locomotion/test/test_velocity_gate.cpp
@@ -232,19 +232,19 @@ TEST(VelocityGate, CountsNonZeroCommandsInEveryStateThatIsNotHeld)
     VelocityGate released(VelocityGate::Config{ kCmdVelTimeoutS, kFailureStreakLimit });
     ASSERT_EQ(released.authority(), LocoAuthority::kReleased);
     released.setCommand(0.6, 0.0, 0.0, now);
-    EXPECT_EQ(released.ignoredCommandCount(), 1u);
+    EXPECT_EQ(released.ignoredCommandCount(), 1U);
 
     VelocityGate acquiring(VelocityGate::Config{ kCmdVelTimeoutS, kFailureStreakLimit });
     acquiring.beginAcquire();
     ASSERT_EQ(acquiring.authority(), LocoAuthority::kAcquiring);
     acquiring.setCommand(0.6, 0.0, 0.0, now);
-    EXPECT_EQ(acquiring.ignoredCommandCount(), 1u) << "mid-acquire the command is still dropped";
+    EXPECT_EQ(acquiring.ignoredCommandCount(), 1U) << "mid-acquire the command is still dropped";
 
     auto releasing = makeHeldGate();
     releasing.beginRelease();
     ASSERT_EQ(releasing.authority(), LocoAuthority::kReleasing);
     releasing.setCommand(0.6, 0.0, 0.0, now);
-    EXPECT_EQ(releasing.ignoredCommandCount(), 1u);
+    EXPECT_EQ(releasing.ignoredCommandCount(), 1U);
 }
 
 TEST(VelocityGate, NeverCountsWhileHeld)
@@ -255,7 +255,7 @@ TEST(VelocityGate, NeverCountsWhileHeld)
     {
         gate.setCommand(0.6, 0.1, 0.3, now);
     }
-    EXPECT_EQ(gate.ignoredCommandCount(), 0u)
+    EXPECT_EQ(gate.ignoredCommandCount(), 0U)
         << "a held gate acts on commands, it does not drop them";
 }
 
@@ -269,11 +269,11 @@ TEST(VelocityGate, NeverCountsAZeroCommand)
     {
         gate.setCommand(0.0, 0.0, 0.0, now);
     }
-    EXPECT_EQ(gate.ignoredCommandCount(), 0u);
+    EXPECT_EQ(gate.ignoredCommandCount(), 0U);
 
     // One non-zero axis is enough to count.
     gate.setCommand(0.0, 0.0, 0.2, now);
-    EXPECT_EQ(gate.ignoredCommandCount(), 1u);
+    EXPECT_EQ(gate.ignoredCommandCount(), 1U);
 }
 
 TEST(VelocityGate, IsMonotonicAcrossAnAcquire)
@@ -284,18 +284,18 @@ TEST(VelocityGate, IsMonotonicAcrossAnAcquire)
     const auto   now = std::chrono::steady_clock::now();
     gate.setCommand(0.6, 0.0, 0.0, now);
     gate.setCommand(0.6, 0.0, 0.0, now);
-    ASSERT_EQ(gate.ignoredCommandCount(), 2u);
+    ASSERT_EQ(gate.ignoredCommandCount(), 2U);
 
     gate.beginAcquire();
     gate.onAcquireResult(/*success=*/true);
-    EXPECT_EQ(gate.ignoredCommandCount(), 2u) << "acquiring must not reset the tally";
+    EXPECT_EQ(gate.ignoredCommandCount(), 2U) << "acquiring must not reset the tally";
 
     gate.setCommand(0.6, 0.0, 0.0, now);
-    EXPECT_EQ(gate.ignoredCommandCount(), 2u) << "and held commands do not add to it";
+    EXPECT_EQ(gate.ignoredCommandCount(), 2U) << "and held commands do not add to it";
 
     gate.forceRelease();
     gate.setCommand(0.6, 0.0, 0.0, now);
-    EXPECT_EQ(gate.ignoredCommandCount(), 3u) << "but dropping resumes after a release";
+    EXPECT_EQ(gate.ignoredCommandCount(), 3U) << "but dropping resumes after a release";
 }
 
 }  // namespace

--- a/workspace/src/g1_manipulation/CMakeLists.txt
+++ b/workspace/src/g1_manipulation/CMakeLists.txt
@@ -99,8 +99,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_manipulation
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -108,7 +108,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_manipulation PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_manipulation test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_manipulation test")
   endif()
 endif()
 

--- a/workspace/src/g1_manipulation/CMakeLists.txt
+++ b/workspace/src/g1_manipulation/CMakeLists.txt
@@ -93,6 +93,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_manipulation test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_manipulation
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_manipulation PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_manipulation test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_manipulation/config/g1_manipulation_server.yaml
+++ b/workspace/src/g1_manipulation/config/g1_manipulation_server.yaml
@@ -18,8 +18,7 @@ g1_manipulation_server:
     # MEASURED, not chosen: standing at the facility workbench, the hand only clears the table's
     # octomap at pelvis z 0.22 and above (m9-checks/why_blocked.py sweeps it). The cube sits at
     # pelvis z 0.0375, so anything under 0.185 of approach height puts the pregrasp inside the
-    # map. At the old 0.12 it failed every time with GOAL_STATE_INVALID and the contact pair
-    # <octomap> <-> right_hand_thumb_2_link -- the thumb, by a couple of centimetres.
+    # map.
     #
     # This cannot be fixed by exempting the octomap instead. The pregrasp transit is deliberately
     # collision-checked so the planner cannot route the arm through the table on the way in; the
@@ -27,7 +26,7 @@ g1_manipulation_server:
     approach_height_m: 0.22
 
     # How far ABOVE the object's top face the grasp frame is aimed, using the height the
-    # object pose source reports. Not its centre, which is what this used to do.
+    # object pose source reports, not its centre.
     #
     # The roll points the hand's closing axis at the floor and the fingertips sit about 24 mm
     # beyond the grasp frame along it, so this offset is what decides where the fingers land.
@@ -48,8 +47,8 @@ g1_manipulation_server:
     lift_height_m: 0.20
 
     # Well under joint_limits.yaml's own 0.8 rad/s per-joint cap. Arm motion measurably
-    # disturbs a standing humanoid, and scaling the
-    # whole trajectory is preferred to clamping joints, which bends the path itself.
+    # disturbs a standing humanoid, and scaling the whole trajectory is preferred to clamping
+    # joints, which bends the path itself.
     velocity_scaling: 0.3
     planning_time_s: 10.0
     grasp_rpy: [-1.5707963, 0.0, 0.0]

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
@@ -98,9 +98,9 @@ private:
     /// The pose to give the arm's grasp frame so the object ends up at `object_pose`. Position
     /// passes straight through -- the grasp frame IS where the object goes -- and only the
     /// orientation is chosen here. Handed: the two hands hold at mirrored rolls.
-    /// Where the grasp frame has to end up. `object_height_m` is the object's FULL height: the
-    /// grasp is taken just under its top face, not at its centre, or the fingers close through
-    /// whatever the object is standing on.
+    ///
+    /// `object_height_m` is the object's FULL height: the grasp is taken just under its top
+    /// face, not at its centre, or the fingers close through whatever the object is standing on.
     geometry_msgs::msg::Pose graspFrameGoal(
         const geometry_msgs::msg::Pose& object_pose, double object_height_m,
         const ArmContext& arm) const;

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
@@ -87,7 +87,7 @@ private:
 
     /// Latest pose for `object_id`, or nullopt if it is unknown or older than the timeout.
     std::optional<vision_msgs::msg::Detection3D> lookUpObject(const std::string& object_id);
-    void onObjects(const vision_msgs::msg::Detection3DArray::SharedPtr msg);
+    void onObjects(const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg);
 
     /// Into the planning frame, or nullopt with the reason logged. Everything a goal carries
     /// goes through here: /objects is in odom, the planner works in pelvis, and the two differ

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_object_pose_source_node.hpp
@@ -31,9 +31,9 @@ namespace g1_manipulation
 enum class ObjectSource
 {
     /// MuJoCo body poses, sampled inside the simulator and carried by g1_sensor_relay.
-    SimGroundTruth,
+    kSimGroundTruth,
     /// Not implemented. Refuses to configure; see the node's on_configure.
-    Hardware,
+    kHardware,
 };
 
 /// False if the name is not a known source, leaving `out` untouched.
@@ -52,10 +52,10 @@ public:
 
 private:
     bool readParameters();
-    void onGroundTruth(const vision_msgs::msg::Detection3DArray::SharedPtr msg);
+    void onGroundTruth(vision_msgs::msg::Detection3DArray::SharedPtr msg);
     void publishMarkers(const vision_msgs::msg::Detection3DArray& objects);
 
-    ObjectSource source_{ ObjectSource::Hardware };
+    ObjectSource source_{ ObjectSource::kHardware };
     bool         publish_markers_{ false };
     std::string  source_frame_id_;
     std::string  output_frame_id_;

--- a/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
@@ -77,7 +77,7 @@ G1ManipulationServer::G1ManipulationServer(const rclcpp::NodeOptions& options)
     objects_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
         "/objects",
         objectsQos(),
-        std::bind(&G1ManipulationServer::onObjects, this, std::placeholders::_1));
+        [this](const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg) { onObjects(msg); });
 
     tf_buffer_   = std::make_unique<tf2_ros::Buffer>(get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -260,39 +260,39 @@ void G1ManipulationServer::initialize()
     pick_server_ = rclcpp_action::create_server<Pick>(
         this,
         "~/pick",
-        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const Pick::Goal>) {
+        [](const rclcpp_action::GoalUUID&, const std::shared_ptr<const Pick::Goal>&) {
             return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
         },
-        [](const std::shared_ptr<GoalHandle<Pick>>) {
+        [](const std::shared_ptr<GoalHandle<Pick>>&) {
             return rclcpp_action::CancelResponse::ACCEPT;
         },
-        [this](const std::shared_ptr<GoalHandle<Pick>> handle) {
+        [this](const std::shared_ptr<GoalHandle<Pick>>& handle) {
             std::thread{ [this, handle] { executePick(handle); } }.detach();
         });
 
     place_server_ = rclcpp_action::create_server<Place>(
         this,
         "~/place",
-        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const Place::Goal>) {
+        [](const rclcpp_action::GoalUUID&, const std::shared_ptr<const Place::Goal>&) {
             return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
         },
-        [](const std::shared_ptr<GoalHandle<Place>>) {
+        [](const std::shared_ptr<GoalHandle<Place>>&) {
             return rclcpp_action::CancelResponse::ACCEPT;
         },
-        [this](const std::shared_ptr<GoalHandle<Place>> handle) {
+        [this](const std::shared_ptr<GoalHandle<Place>>& handle) {
             std::thread{ [this, handle] { executePlace(handle); } }.detach();
         });
 
     posture_server_ = rclcpp_action::create_server<SetArmPosture>(
         this,
         "~/set_arm_posture",
-        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const SetArmPosture::Goal>) {
+        [](const rclcpp_action::GoalUUID&, const std::shared_ptr<const SetArmPosture::Goal>&) {
             return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
         },
-        [](const std::shared_ptr<GoalHandle<SetArmPosture>>) {
+        [](const std::shared_ptr<GoalHandle<SetArmPosture>>&) {
             return rclcpp_action::CancelResponse::ACCEPT;
         },
-        [this](const std::shared_ptr<GoalHandle<SetArmPosture>> handle) {
+        [this](const std::shared_ptr<GoalHandle<SetArmPosture>>& handle) {
             std::thread{ [this, handle] { executeSetArmPosture(handle); } }.detach();
         });
 
@@ -303,7 +303,7 @@ void G1ManipulationServer::initialize()
         planning_frame_.c_str());
 }
 
-void G1ManipulationServer::onObjects(const vision_msgs::msg::Detection3DArray::SharedPtr msg)
+void G1ManipulationServer::onObjects(const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg)
 {
     std::lock_guard<std::mutex> lock(objects_mutex_);
     objects_ = *msg;

--- a/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
@@ -59,8 +59,8 @@ G1ManipulationServer::G1ManipulationServer(const rclcpp::NodeOptions& options)
     // How far a released object may be from where it was aimed before the place is a failure.
     place_tolerance_m_ = declare_parameter<double>("place_tolerance_m", 0.08);
     // Well under the joint limits' own 0.8 rad/s cap. Arm motion disturbs a standing humanoid
-    // measurably, and slowing the whole path is
-    // preferred over clamping joints, which would bend the path itself.
+    // measurably, and slowing the whole path is preferred over clamping joints, which would
+    // bend the path itself.
     velocity_scaling_ = declare_parameter<double>("velocity_scaling", 0.3);
     planning_time_s_  = declare_parameter<double>("planning_time_s", 5.0);
 
@@ -105,9 +105,8 @@ bool G1ManipulationServer::allowHandContact(
     links.push_back(side + "_wrist_pitch_link");
     links.push_back(side + "_wrist_yaw_link");
     // All THREE wrist joints, matching the touch_links the pick attaches the object with. Roll
-    // was missing here while the other two were present, and it is the one that reaches: a
-    // place beside the storage bench aborted with the start state in collision, `<octomap>` vs
-    // right_wrist_roll_link, on a plan whose every other link was exempt.
+    // is easy to miss but is the one that reaches during a grasp, so omitting it leaves the
+    // exemption silently incomplete.
     links.push_back(side + "_wrist_roll_link");
 
     // The current matrix has to be read first: ApplyPlanningScene replaces the whole ACM
@@ -378,8 +377,7 @@ geometry_msgs::msg::Pose G1ManipulationServer::graspFrameGoal(
     const geometry_msgs::msg::Pose& object_pose, double object_height_m, const ArmContext& arm) const
 {
     // Horizontally the grasp frame goes straight to the object: that frame is defined as the
-    // point the hand closes on, so putting it at the object IS the grasp, and the offset
-    // arithmetic that used to live here was the source of two separate bugs.
+    // point the hand closes on, so putting it at the object IS the grasp.
     geometry_msgs::msg::Pose goal;
     goal.position = object_pose.position;
 
@@ -387,13 +385,8 @@ geometry_msgs::msg::Pose G1ManipulationServer::graspFrameGoal(
     //
     // The roll points the closing axis at the floor and the fingertips sit about 24 mm beyond
     // the grasp frame along it, so this offset decides where the fingers end up. Aiming at the
-    // centre put them 6 mm above the table on a 60 mm cube -- inside the octomap's 20 mm
-    // padding, asking the hand to close through the surface.
-    //
-    // It then sat 15 mm BELOW the top face, which grips but does not look like a grasp: the
-    // palm ends up level with the cube's top rather than clearing it, and the fingers reach
-    // past the middle. Held slightly ABOVE the face, the palm clears the object and the
-    // fingers close around its upper half, which is both what a hand does and a shorter reach.
+    // centre would put them inside the octomap's 20 mm padding around the surface, closing
+    // through it rather than around the object's upper half.
     const double top = object_pose.position.z + 0.5 * object_height_m;
     goal.position.z  = top + grasp_height_above_top_m_;
 
@@ -451,18 +444,13 @@ bool G1ManipulationServer::moveToNamed(MoveGroup& group, const std::string& name
     // Plan then execute, NOT move(). They are not equivalent: move() runs through MoveIt's
     // PlanExecution, which re-checks the whole remaining path against every planning-scene
     // update and aborts the moment one invalidates it. Against a live octomap fed by a chest
-    // camera that is staring at the arm, something invalidates it constantly.
+    // camera staring at the arm, the arm's own freshly integrated voxels invalidate it
+    // constantly, so a plan that started fine can die partway through against itself.
     //
-    // That is what failed the carry: the plan was found and started, then died two thirds of the
-    // way through with "<octomap> vs right_wrist_roll_link" -- the arm colliding with voxels of
-    // ITSELF, freshly integrated while it moved. Three retries, three different links, no
-    // progress. The tucks survived only because the tree retries them, which is what the
-    // "sampled a path that clips the live octomap" note in the tree was really describing.
-    //
-    // execute() checks nothing during the motion, which is what every other motion in this file
-    // already does -- Pick and Place plan and execute for the pregrasp, descent and lift. Both
-    // paths are fully collision-checked at PLAN time; this only drops a during-flight recheck
-    // that on this stack reports the robot's own arm.
+    // execute() checks nothing during the motion, matching every other move in this file: Pick
+    // and Place plan and execute for the pregrasp, descent and lift, all fully collision-checked
+    // at PLAN time. This only drops a during-flight recheck that, on this stack, reports the
+    // robot's own arm.
     MoveGroup::Plan plan;
     const auto      planned = group.plan(plan);
     if (planned != moveit::core::MoveItErrorCode::SUCCESS)
@@ -600,10 +588,9 @@ void G1ManipulationServer::executePick(const std::shared_ptr<GoalHandle<Pick>>& 
     attached.link_name        = arm.palm_link;
     attached.object           = object;
     attached.object.operation = moveit_msgs::msg::CollisionObject::ADD;
-    // The hand's own links, plus the palm and the WRIST. The wrist matters and was missing: a
-    // 60 mm cube gripped just under its top face reaches past the fingers, and without the
-    // wrist in touch_links every later plan starts with `right_wrist_yaw_link <-> red_cube
-    // (Robot attached)` and OMPL refuses to initialise its start tree.
+    // The hand's own links, plus the palm and the WRIST: a cube gripped just under its top face
+    // reaches past the fingers to touch it, and without the wrist in touch_links every later
+    // plan starts with the attached object already in collision.
     //
     // Same set allowHandContact() exempts, and for the same reason: these are the links that
     // unavoidably touch what is being carried.
@@ -619,9 +606,8 @@ void G1ManipulationServer::executePick(const std::shared_ptr<GoalHandle<Pick>>& 
     // Extended to the object only now that it is attached and about to be lifted OUT of the
     // surface it was resting on. Its own voxels, and the table's underneath it, are still in
     // the octomap from before the grasp -- the ShapeMask stops new clouds re-adding it, but it
-    // does not erase what is already there. Without this the lift fails before it starts, with
-    // "start state appears to be in collision", which is the attached cube against the table
-    // it is still sitting on.
+    // does not erase what is already there. Without this exemption the lift starts with the
+    // attached cube already in collision against the table it is still sitting on.
     allowHandContact(arm, { "<octomap>", goal->object_id }, true);
 
     feedback->phase = Pick::Feedback::PHASE_LIFT;
@@ -673,14 +659,11 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
         }
     }
 
-    // The octomap AND the object being carried. Exempting only the octomap was wrong in the
-    // same way the missing wrist joint was: an attached body is part of the robot for
+    // The octomap AND the object being carried: an attached body is part of the robot for
     // kinematics but is still its own collision entity, so exempting the palm it hangs off
-    // does nothing for it. A place aborted with "<octomap> vs red_cube (attached)" at waypoint
-    // 101 of 153 -- the carried cube clipping the bench on the way in, on a path where every
-    // link around it was already allowed through.
+    // does nothing for it.
     //
-    // Pick already exempted both for the lift, which is the same motion in reverse.
+    // Pick already exempts both for the lift, which is the same motion in reverse.
     const std::vector<std::string> touchables =
         held_id.empty() ? std::vector<std::string>{ "<octomap>" } :
                           std::vector<std::string>{ "<octomap>", held_id };
@@ -693,20 +676,19 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
     };
 
     // The carried object may pass through the surface's voxels on the way in; the ARM may not.
-    // Exempting the hand this early let plans route the arm into the bench, and the strike shoved
-    // the base 0.12 to 0.17 m, which then put the re-aimed descent out of reach. Same hazard the
-    // pick defers its exemption for; the descent below gets the full one.
+    // Exempting the hand this early let plans route the arm into the bench, and the collision
+    // shoved the base off its stance, putting the re-aimed descent out of reach. Same hazard
+    // the pick defers its exemption for; the descent below gets the full one.
     allowHandContact(arm, touchables, true, /*include_links=*/false);
 
     // Prefer a surface read from /objects over the caller's coordinate.
     //
-    // Not a convenience. A tree writes its drop point in the MAP frame, while the base approach
-    // that parked the robot drove against /objects, which is published in ODOM -- and those two
-    // frames are only as close as AMCL is right. Measured mid-mission at the storage bench:
-    // map->odom was (0.077, -0.214), so a target correct on the map landed 0.14 m outside the
-    // arm's 0.04 m lateral window and the preplace had no IK solution at all. Resolving the
-    // surface from the stream the approach used makes the two agree by construction, however
-    // far localization has drifted.
+    // A tree writes its drop point in the MAP frame, while the base approach that parked the
+    // robot drove against /objects, published in ODOM -- and those two frames are only as
+    // close as AMCL is right. A realistic map->odom drift is bigger than the arm's 0.04 m
+    // lateral window, so a target correct on the map can leave the preplace with no IK
+    // solution at all. Resolving the surface from the stream the approach used makes the two
+    // agree by construction, however far localization has drifted.
     std::optional<geometry_msgs::msg::Pose>      target;
     std::optional<vision_msgs::msg::Detection3D> surface;
     if (!goal->surface_object_id.empty())
@@ -853,7 +835,7 @@ void G1ManipulationServer::executePlace(const std::shared_ptr<GoalHandle<Place>>
         if (const auto landed = lookUpObject(held_id))
         {
             const geometry_msgs::msg::Pose& pose = landed->results.front().pose.pose;
-            // Binds without a temporary; `target` is checked engaged above.
+            // Binds without a temporary; `target` was already checked engaged above.
             const geometry_msgs::msg::Point& aim = expected ? *expected : target->position;
 
             std::optional<geometry_msgs::msg::Point> where = pose.position;

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -32,12 +32,12 @@ bool parseObjectSource(const std::string& name, ObjectSource& out)
 {
     if (name == "sim_ground_truth")
     {
-        out = ObjectSource::SimGroundTruth;
+        out = ObjectSource::kSimGroundTruth;
         return true;
     }
     if (name == "hardware")
     {
-        out = ObjectSource::Hardware;
+        out = ObjectSource::kHardware;
         return true;
     }
     return false;
@@ -64,7 +64,7 @@ bool G1ObjectPoseSource::readParameters()
         return false;
     }
 
-    if (source_ == ObjectSource::Hardware)
+    if (source_ == ObjectSource::kHardware)
     {
         // Long on purpose. Anyone who reaches this is about to go looking for a perception
         // stack that does not exist yet, and the alternative -- publishing nothing, quietly --
@@ -114,7 +114,9 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_configure(const rclcpp
     source_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
         "~/object_poses",
         sourceQos(),
-        std::bind(&G1ObjectPoseSource::onGroundTruth, this, std::placeholders::_1));
+        [this](vision_msgs::msg::Detection3DArray::SharedPtr msg) {
+            onGroundTruth(std::move(msg));
+        });
 
     RCLCPP_INFO(
         get_logger(),
@@ -142,12 +144,12 @@ G1ObjectPoseSource::CallbackReturn G1ObjectPoseSource::on_cleanup(const rclcpp_l
 // carries, so what rviz shows is what a skill acts on rather than a second computation of it.
 void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray& objects)
 {
-    visualization_msgs::msg::MarkerArray markers;
+    auto markers = std::make_unique<visualization_msgs::msg::MarkerArray>();
     // Rebuilt every message, so a vanished object must not leave its marker on screen.
     visualization_msgs::msg::Marker clear;
     clear.action = visualization_msgs::msg::Marker::DELETEALL;
-    markers.markers.reserve(1 + 2 * objects.detections.size());
-    markers.markers.push_back(clear);
+    markers->markers.reserve(1 + 2 * objects.detections.size());
+    markers->markers.push_back(clear);
 
     int id = 0;
     for (const vision_msgs::msg::Detection3D& detection : objects.detections)
@@ -160,11 +162,11 @@ void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray
         box.action  = visualization_msgs::msg::Marker::ADD;
         box.pose    = detection.bbox.center;
         box.scale   = detection.bbox.size;
-        box.color.r = 0.1f;
-        box.color.g = 0.8f;
-        box.color.b = 1.0f;
-        box.color.a = 0.6f;
-        markers.markers.push_back(box);
+        box.color.r = 0.1F;
+        box.color.g = 0.8F;
+        box.color.b = 1.0F;
+        box.color.a = 0.6F;
+        markers->markers.push_back(box);
 
         visualization_msgs::msg::Marker label = box;
         label.id                              = id++;
@@ -174,13 +176,16 @@ void G1ObjectPoseSource::publishMarkers(const vision_msgs::msg::Detection3DArray
         label.scale                           = geometry_msgs::msg::Vector3();
         label.scale.z                         = 0.06;
         label.pose.position.z += 0.5 * detection.bbox.size.z + 0.05;
-        label.color.a = 1.0f;
-        markers.markers.push_back(label);
+        label.color.a = 1.0F;
+        markers->markers.push_back(label);
     }
     markers_pub_->publish(std::move(markers));
 }
 
-void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray::SharedPtr msg)
+// By value, not const-ref: this mutates the message in place, and rclcpp has no const-ref
+// dispatch for a mutable pointee.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void G1ObjectPoseSource::onGroundTruth(vision_msgs::msg::Detection3DArray::SharedPtr msg)
 {
     if (!objects_pub_->is_activated())
     {
@@ -249,7 +254,7 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
     {
         publishMarkers(out);
     }
-    objects_pub_->publish(std::move(out));
+    objects_pub_->publish(std::make_unique<vision_msgs::msg::Detection3DArray>(std::move(out)));
 }
 
 }  // namespace g1_manipulation

--- a/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_object_pose_source_node.cpp
@@ -188,8 +188,7 @@ void G1ObjectPoseSource::onGroundTruth(const vision_msgs::msg::Detection3DArray:
     }
     // The detector reports from the frame it measured in, which rides on the robot. Rewriting
     // that label to a fixed frame is only correct while the two coincide, and they stop
-    // coinciding the moment odom is an estimate rather than ground truth -- an earlier version
-    // relabelled, and the base approach then chased a point 2 m from where the object was.
+    // coinciding the moment odom is an estimate rather than ground truth.
     if (msg->header.frame_id != source_frame_id_)
     {
         RCLCPP_WARN_THROTTLE(

--- a/workspace/src/g1_manipulation/test/test_grasp_geometry.cpp
+++ b/workspace/src/g1_manipulation/test/test_grasp_geometry.cpp
@@ -81,8 +81,7 @@ TEST(ResolveArm, RejectsAnythingElseWithoutAssigning)
 TEST(GraspFrameGoal, PutsTheGraspFrameExactlyOnTheObject)
 {
     // The whole point of moving the offset into the URDF: the goal position IS the object
-    // position, with no arithmetic left in this file to get wrong. Two separate bugs lived in
-    // the arithmetic this replaced.
+    // position, with no arithmetic left in this file to get wrong.
     const std::vector<double> rpy{ -M_PI_2, 0.0, 0.0 };
     const auto                target = objectAt(0.35, -0.20, 0.83);
 
@@ -97,8 +96,8 @@ TEST(GraspFrameGoal, PointsTheClosingAxisAtTheFloor)
 {
     // The Dex3's fingers curl toward the palm's +y, so it is THAT axis that has to end up
     // pointing down for a grasp off a table -- and the palm's +x has to stay forward, so the
-    // arm reaches out rather than the wrist contorting. Getting this wrong made the first
-    // version unplannable anywhere useful, so it is pinned rather than left to inspection.
+    // arm reaches out rather than the wrist contorting. Getting this wrong is easy to miss by
+    // inspection, so it is pinned here instead.
     const auto palm = graspFrameGoal(objectAt(0.4, 0.0, 0.8), { -M_PI_2, 0.0, 0.0 }, false);
 
     tf2::Quaternion rotation;

--- a/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
@@ -151,9 +151,9 @@ staticTf(const std::string& parent, const std::string& child, double x, double y
 
 }  // namespace
 
-// The regression this whole change exists for. Before it, the node rewrote the frame label and
-// left the numbers alone, which is correct only while the two frames coincide -- and they stop
-// coinciding the moment odometry is an estimate. A relabel would leave x at 1.0 here.
+// Transform, not relabel: rewriting only the frame label while leaving the numbers alone is
+// correct only while the two frames coincide, and they stop coinciding the moment odometry is
+// an estimate. A relabel-only bug would leave x at 1.0 here.
 TEST(ObjectPoseSource, TransformsThePoseRatherThanRelabellingTheFrame)
 {
     auto    tf_node = staticTf("odom", "camera_color_optical_frame", 2.0, -3.0, 0.5);

--- a/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
+++ b/workspace/src/g1_manipulation/test/test_object_pose_source_node.cpp
@@ -102,7 +102,7 @@ public:
         objects_sub_ = peer_->create_subscription<vision_msgs::msg::Detection3DArray>(
             "/g1_object_pose_source/objects",
             rclcpp::QoS(rclcpp::KeepLast(1)).reliable(),
-            [this](const vision_msgs::msg::Detection3DArray::SharedPtr msg) { last_ = *msg; });
+            [this](const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg) { last_ = *msg; });
     }
 
     unsigned int configure() { return node_->configure().id(); }
@@ -168,7 +168,7 @@ TEST(ObjectPoseSource, TransformsThePoseRatherThanRelabellingTheFrame)
     ASSERT_TRUE(harness.last().has_value());
     const auto& out = *harness.last();
     EXPECT_EQ(out.header.frame_id, "odom");
-    ASSERT_EQ(out.detections.size(), 1u);
+    ASSERT_EQ(out.detections.size(), 1U);
     const auto& pose = out.detections[0].results[0].pose.pose;
     EXPECT_NEAR(pose.position.x, 3.0, 1e-6);
     EXPECT_NEAR(pose.position.y, -2.5, 1e-6);
@@ -195,16 +195,16 @@ TEST(ObjectPoseSource, PublishesNothingWhenTheTransformIsMissing)
 
 TEST(ObjectSource, ParsesTheSourcesItKnowsAndRejectsTheRest)
 {
-    ObjectSource source = ObjectSource::Hardware;
+    ObjectSource source = ObjectSource::kHardware;
     ASSERT_TRUE(parseObjectSource("sim_ground_truth", source));
-    EXPECT_EQ(source, ObjectSource::SimGroundTruth);
+    EXPECT_EQ(source, ObjectSource::kSimGroundTruth);
     ASSERT_TRUE(parseObjectSource("hardware", source));
-    EXPECT_EQ(source, ObjectSource::Hardware);
+    EXPECT_EQ(source, ObjectSource::kHardware);
 
-    ObjectSource untouched = ObjectSource::SimGroundTruth;
+    ObjectSource untouched = ObjectSource::kSimGroundTruth;
     EXPECT_FALSE(parseObjectSource("ground_truth", untouched));
     EXPECT_FALSE(parseObjectSource("", untouched));
-    EXPECT_EQ(untouched, ObjectSource::SimGroundTruth) << "a rejected name must not assign";
+    EXPECT_EQ(untouched, ObjectSource::kSimGroundTruth) << "a rejected name must not assign";
 }
 
 TEST(ObjectPoseSource, RefusesToConfigureOnHardware)
@@ -240,11 +240,11 @@ TEST(ObjectPoseSource, RepublishesGroundTruthInTheOutputFrame)
     ASSERT_TRUE(harness.last().has_value());
     const auto& out = *harness.last();
     EXPECT_EQ(out.header.frame_id, "odom");
-    ASSERT_EQ(out.detections.size(), 1u);
+    ASSERT_EQ(out.detections.size(), 1U);
     // The per-detection header is relabelled too: a consumer that reads that one instead of
     // the array's would otherwise be told the pose is in a frame that is not in the TF tree.
     EXPECT_EQ(out.detections[0].header.frame_id, "odom");
-    ASSERT_EQ(out.detections[0].results.size(), 1u);
+    ASSERT_EQ(out.detections[0].results.size(), 1U);
     EXPECT_EQ(out.detections[0].results[0].hypothesis.class_id, "red_cube");
     EXPECT_DOUBLE_EQ(out.detections[0].results[0].pose.pose.position.x, 4.1);
     EXPECT_DOUBLE_EQ(out.detections[0].results[0].pose.pose.position.z, 0.78);
@@ -265,7 +265,7 @@ TEST(ObjectPoseSource, CarriesTheSourceStampRatherThanRestampingIt)
     // message carries RCL_ROS_TIME, the literal would be RCL_SYSTEM_TIME, and rclcpp throws
     // on comparing the two rather than answering.
     EXPECT_EQ(harness.last()->header.stamp.sec, 123);
-    EXPECT_EQ(harness.last()->header.stamp.nanosec, 456u);
+    EXPECT_EQ(harness.last()->header.stamp.nanosec, 456U);
 }
 
 TEST(ObjectPoseSource, DropsPosesStampedWithAFrameItWasNotConfiguredFor)
@@ -294,6 +294,8 @@ TEST(ObjectPoseSource, StaysQuietUntilActivated)
 int main(int argc, char** argv)
 {
     // Isolated domain: a running sim on the default domain must not be able to feed this.
+    // Before any node or thread exists, so the thread-safety this warns about does not apply.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     setenv("ROS_DOMAIN_ID", "78", 1);
     ::testing::InitGoogleMock(&argc, argv);
     rclcpp::init(argc, argv);

--- a/workspace/src/g1_motion_service_sim/CMakeLists.txt
+++ b/workspace/src/g1_motion_service_sim/CMakeLists.txt
@@ -142,6 +142,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_motion_service_sim test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_motion_service_sim
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_motion_service_sim PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_motion_service_sim test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_motion_service_sim/CMakeLists.txt
+++ b/workspace/src/g1_motion_service_sim/CMakeLists.txt
@@ -148,8 +148,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_motion_service_sim
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -157,7 +157,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_motion_service_sim PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_motion_service_sim test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_motion_service_sim test")
   endif()
 endif()
 

--- a/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
+++ b/workspace/src/g1_motion_service_sim/config/motion_service_sim.yaml
@@ -46,7 +46,7 @@
     # SIM-ONLY, and it removes an artifact rather than adding one: without it the hold target is
     # the first /lowstate sample, by which point the arms have been falling freely since the
     # simulator started. The real robot's onboard controller holds the arms and none of this
-    # code runs there. Measurements in the local engineering notes.
+    # code runs there.
     arm_hold_rad: [-0.70,  0.15, 0.0, 1.50, 0.0, 0.0, 0.0,
                    -0.70, -0.15, 0.0, 1.50, 0.0, 0.0, 0.0]
 
@@ -54,7 +54,7 @@
     # last-action instead of what /arm_sdk is actually doing. This is a SIM-FIDELITY fix, not a
     # crutch -- the real onboard controller is not this policy and does not have its
     # out-of-distribution problem, so an unmasked sim fails in a way hardware will not. See the
-    # comment in lowstateCallback() and the local engineering notes.
+    # comment in lowstateCallback().
     # false reproduces the old behaviour, which is only useful for demonstrating the failure.
     mask_arm_observations: true
 

--- a/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/blend_math.hpp
+++ b/workspace/src/g1_motion_service_sim/include/g1_motion_service_sim/blend_math.hpp
@@ -27,7 +27,7 @@ inline constexpr int kNumArmMotors  = 14;
 /**
  * @brief 29 total, matching the sim's G1 MJCF.
  *
- * 29-DoF, no hands -- confirmed in the milestone-1 spike.
+ * 29-DoF, no hands.
  */
 inline constexpr int         kNumBodyMotors    = kFirstArmMotor + kNumArmMotors;
 inline constexpr std::size_t kWeightMotorIndex = 29;

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -384,8 +384,9 @@ void MotionServiceSim::lowstateCallback(const unitree_hg::msg::LowState::ConstSh
     // dimensions are arm position, arm velocity and arm last-action. During training the arms
     // only ever sat within the policy's own action distribution around the default posture --
     // about one action-scale unit, and the arm scales are 0.438577, which is exactly the
-    // plus/minus 0.4 rad envelope M3 measured as stable. A MoveIt goal of "arms straight ahead"
-    // is roughly four units out, so the policy is extrapolating on a third of its input.
+    // measured plus/minus 0.4 rad envelope this robot holds stably. A MoveIt goal of "arms
+    // straight ahead" is roughly four units out, so the policy is extrapolating on a third of
+    // its input.
     //
     // The real G1 has no equivalent failure: its onboard controller is not this policy, and per
     // CMU's G1 notes it "is not aware of how the arms are being controlled" -- it rejects arm

--- a/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
+++ b/workspace/src/g1_motion_service_sim/src/motion_service_sim_node.cpp
@@ -138,7 +138,7 @@ MotionServiceSim::MotionServiceSim(const rclcpp::NodeOptions& options)
     {
         RCLCPP_ERROR(
             get_logger(),
-            "arm_hold_rad needs %zu values (left arm then right, motors 15 to 28) but got %zu -- "
+            "arm_hold_rad needs %d values (left arm then right, motors 15 to 28) but got %zu -- "
             "ignoring it and holding whatever the arms fell into at startup",
             kNumArmMotors,
             arm_hold_rad_.size());

--- a/workspace/src/g1_motion_service_sim/src/walk_policy_session.cpp
+++ b/workspace/src/g1_motion_service_sim/src/walk_policy_session.cpp
@@ -83,23 +83,24 @@ std::array<float, kActionDim> WalkPolicySession::run(const std::array<float, kOb
     // not write through this pointer for an input tensor.
     auto input_tensor = Ort::Value::CreateTensor<float>(
         memory_info_,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         const_cast<float*>(observation.data()),
         observation.size(),
         kInputShape.data(),
         kInputShape.size());
 
-    const char* input_names[]  = { input_name_.c_str() };
-    const char* output_names[] = { output_name_.c_str() };
+    const std::array<const char*, 1> input_names{ input_name_.c_str() };
+    const std::array<const char*, 1> output_names{ output_name_.c_str() };
 
     // In-place overload: fills output_buffer_ through the tensor bound at construction. The
     // returning overload allocates a std::vector<Ort::Value> per call, which this path runs
     // 50 times a second alongside a 500 Hz publish loop.
     session_->Run(
         Ort::RunOptions{ nullptr },
-        input_names,
+        input_names.data(),
         &input_tensor,
         1,
-        output_names,
+        output_names.data(),
         &output_tensor_,
         1);
 

--- a/workspace/src/g1_motion_service_sim/test/test_walk_policy.cpp
+++ b/workspace/src/g1_motion_service_sim/test/test_walk_policy.cpp
@@ -285,8 +285,8 @@ TEST(WalkPolicyVelocity, NoLatchMeansZeroCommand)
 
 // --- leg-authority fallback (B1) and guarded inference (B2) -------------------------------------
 //
-// Both blocking review findings lived on this path, and both were fixed by inspection alone. These
-// force the path rather than assuming the fix.
+// Both were real regressions on this path, fixed once and pinned here so neither comes back
+// silently.
 
 std::array<double, kNumLowerMotors> makePolicyQ()
 {

--- a/workspace/src/g1_motion_service_sim/test/test_walk_policy.cpp
+++ b/workspace/src/g1_motion_service_sim/test/test_walk_policy.cpp
@@ -37,7 +37,7 @@ PolicyConfig makeConfig()
 
 std::vector<std::string> ddsOrderAsVector()
 {
-    return std::vector<std::string>(kDdsMotorOrder.begin(), kDdsMotorOrder.end());
+    return { kDdsMotorOrder.begin(), kDdsMotorOrder.end() };
 }
 
 // --- joint order -----------------------------------------------------------------------------

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_robot_model test/test_robot_model.cpp)
   if(TARGET test_robot_model)
+    target_compile_features(test_robot_model PUBLIC cxx_std_20)
     add_dependencies(test_robot_model g1_moveit_config_expanded_urdf)
     target_compile_definitions(test_robot_model PRIVATE
       G1_TEST_URDF_PATH="${_expanded_urdf}"
@@ -105,6 +106,23 @@ if(BUILD_TESTING)
   else()
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_moveit_config test")
+  endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_moveit_config
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_moveit_config PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_moveit_config test")
   endif()
 endif()
 

--- a/workspace/src/g1_moveit_config/CMakeLists.txt
+++ b/workspace/src/g1_moveit_config/CMakeLists.txt
@@ -113,8 +113,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_moveit_config
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -122,7 +122,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_moveit_config PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_moveit_config test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_moveit_config test")
   endif()
 endif()
 

--- a/workspace/src/g1_moveit_config/config/g1.srdf
+++ b/workspace/src/g1_moveit_config/config/g1.srdf
@@ -97,15 +97,12 @@
        (/check_state_validity, both_arms) before being written here, not chosen on a diagram.
        `home` is the posture the simulator holds the arms at, and the arrow points this way
        round: g1_motion_service_sim's `arm_hold_rad` is set from these values, and the drift
-       test pins the pair. It used to be the other way, a measurement of wherever the arms
-       happened to fall at startup, which is how it ended up a few hundredths from putting the
-       palm against the thigh once the hands had their real mass.
+       test pins the pair, rather than the SRDF being derived from wherever the arms happen to
+       fall at startup: that direction leaves no margin against a heavier hand closing the
+       palm-to-thigh gap.
 
        The small shoulder roll is what buys that margin: it swings each arm off the torso so
        neither the sag nor a heavier hand closes the gap.
-
-       An earlier version of this file said zero "may well self collide" and left these out on
-       that suspicion. It does not: checked, valid. The suspicion was wrong.
 
        roll and yaw mirror between the arms so a positive value swings each arm away from the
        torso on its own side; pitch and elbow do not mirror.
@@ -298,9 +295,9 @@
        The shoulder roll is 0.60, and it is the one value in this pose with a measurement behind
        it. Rolling the shoulder away from the body is what buys the thumb room off the hip: at
        0.25 the pose is invalid outright (right_hand_thumb_2_link <-> right_hip_roll_link), the
-       same hand-versus-hip clearance M8 met from the other side.
+       same hand-versus-hip clearance problem met elsewhere, from the other side.
 
-       0.40 fixed that and was left there, valid but with 4.6 DEGREES OF MARGIN. The arm droops
+       0.40 fixed that and was left there, valid but with 4.6 degrees of margin. The arm droops
        more than that carrying the cube through a walk, and a start state in collision cannot be
        planned out of: fix_start_state_collision jitters the start, plans from the jitter, and
        the path check rejects the result against the original.
@@ -397,7 +394,7 @@
        reports the robot as colliding with itself before it has moved, and RRTConnect refuses
        to seed its tree: "Skipping invalid start state".
 
-       Deliberately NOT generated: the "never in collision" pairs the Setup Assistant's
+       Deliberately not generated: the "never in collision" pairs the Setup Assistant's
        collisions_updater finds by random sampling. Those are a planning-speed optimisation,
        not a correctness requirement, and on this model the sampling does not finish in a
        usable time: the URDF's collision geometry is its full visual meshes, about 525k

--- a/workspace/src/g1_moveit_config/config/joint_limits.yaml
+++ b/workspace/src/g1_moveit_config/config/joint_limits.yaml
@@ -1,6 +1,6 @@
 # Velocity and acceleration limits MoveIt times its trajectories against.
 #
-# These are NOT the URDF's limits, and the difference is the point. The URDF says 22 to 37 rad/s,
+# These are not the URDF's limits. The URDF says 22 to 37 rad/s,
 # which is the motor; the arm reaches the robot through g1_hardware_interface, which slew-clamps
 # every joint at max_joint_velocity_rad_s = 1.0 rad/s (g1_description/config/arm_sdk_params.yaml).
 # Time a trajectory against the motor and the bridge stretches it by a factor of thirty-odd,

--- a/workspace/src/g1_moveit_config/config/kinematics.yaml
+++ b/workspace/src/g1_moveit_config/config/kinematics.yaml
@@ -11,7 +11,7 @@
 # what pick_ik already provides is not worth the pin. Swapping back to KDL is one line:
 #   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
 #
-# both_arms has no entry here ON PURPOSE, and adding one breaks dual-arm IK. See g1.srdf.
+# both_arms has no entry here on purpose, and adding one breaks dual-arm IK. See g1.srdf.
 
 left_arm:
   kinematics_solver: pick_ik/PickIkPlugin

--- a/workspace/src/g1_moveit_config/config/sensors_3d.yaml
+++ b/workspace/src/g1_moveit_config/config/sensors_3d.yaml
@@ -1,6 +1,6 @@
 # The 3D LiDAR into the planning scene, so move_group plans around what the robot can see.
 #
-# octomap_resolution is read at the NODE root, not inside a sensor block -- move_group's
+# octomap_resolution is read at the node root, not inside a sensor block -- move_group's
 # to_dict() flat-merges this whole file into its parameters, which is the only reason a
 # top-level key here becomes a node parameter. Without it move_group logs "Resolution not
 # specified for Octomap. Assuming resolution = 0.1".
@@ -13,17 +13,17 @@
 # an SRDF virtual joint to odom, argued in g1.srdf, not a setting here.
 octomap_resolution: 0.025
 
-# `sensors` is a flat list of NAMES, each a sibling top-level key below. It is NOT a list of
+# `sensors` is a flat list of names, each a sibling top-level key below. It is not a list of
 # dicts -- ROS 2 parameters cannot represent that, which is why the Humble perception tutorial
 # (still an unmigrated ROS 1 page, its source begins ":moveit1:") cannot be copied.
 sensors:
   - mid360_cloud
 
 # PointCloudOctomapUpdater rather than DepthImageOctomapUpdater, and not by preference.
-# On 2.5.9 the depth-image plugin's initialize() runs BEFORE setParams()
+# On 2.5.9 the depth-image plugin's initialize() runs before setParams()
 # (occupancy_map_monitor.cpp L97 then L100), and initialize() is where the clipping planes,
 # shadow threshold and padding are pushed into the mesh filter -- so none of its YAML ever
-# applies. Padding IS the self-filter, and an untunable self-filter is not usable. That plugin
+# applies. Padding is the self-filter, and an untunable self-filter is not usable. That plugin
 # also links OpenGL, which a CPU-only machine cannot load.
 #
 # Every key below is mandatory: setParams() ANDs all seven, and dropping one skips the sensor
@@ -32,8 +32,8 @@ sensors:
 mid360_cloud:
   sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
 
-  # The LiDAR, not the depth camera, and that was not the first choice. The camera publishes a
-  # depth IMAGE, and turning it into a cloud needs depth_image_proc, whose point_cloud_xyz node
+  # The LiDAR, not the depth camera. The camera publishes a
+  # depth image, and turning it into a cloud needs depth_image_proc, whose point_cloud_xyz node
   # would not receive from our relay: the relay publishes SensorDataQoS (best effort) and that
   # node's image_transport subscription is reliable, so it sat silent with the image publishing
   # at 10 Hz beside it. Remapping was correct (verified with `ros2 node info`) and a
@@ -42,7 +42,6 @@ mid360_cloud:
   #
   # The LiDAR sidesteps all of it: already a PointCloud2, and the octomap updater subscribes
   # with rmw_qos_profile_sensor_data, which matches the relay. No converter node at all.
-  # The camera path was tried first and does not work; see the note above.
   point_cloud_topic: /livox/lidar
 
   # Past this a ray is carved as free space instead of marking an endpoint. The arms reach

--- a/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
+++ b/workspace/src/g1_moveit_config/launch/moveit_sim.launch.py
@@ -4,7 +4,7 @@ Includes g1_bringup rather than the other way round, the same direction as g1_na
 nav_sim.launch.py. Manipulation sits above bring-up, and a moveit:=true argument on
 sim.launch.py would give g1_bringup a dependency on all of MoveIt.
 
-Every argument is forwarded EXPLICITLY, including ones whose values match this file's own
+Every argument is forwarded explicitly, including ones whose values match this file's own
 defaults. An included launch file inherits the parent's configurations, so a child's
 DeclareLaunchArgument default never fires for anything declared here -- relying on it is how
 this stack has already shipped two silent bugs.

--- a/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_config_drift.py
@@ -198,12 +198,11 @@ def test_each_hand_has_an_open_and_a_closed_posture(side, srdf):
 
 
 def test_the_simulator_holds_the_arms_at_home(srdf):
-    """`home` claims to be where the simulator holds the arms. This is what makes it true.
+    """`home` claims to be where the simulator holds the arms; this test pins that pairing.
 
-    The claim used to run the other way, `home` being a measurement of wherever the arms fell
-    at startup, and that is how it drifted to within hundredths of putting the palm against the
-    thigh once the hands had their real mass. Now motion_service_sim is told the posture and
-    this pins the pair.
+    motion_service_sim is told the posture from the SRDF's `home` state, rather than the SRDF
+    being derived from wherever the arms happen to fall at startup: that direction would leave
+    no margin against a heavier hand closing the palm-to-thigh gap.
     """
     sim = _load(SIM_CONFIG_DIR, "motion_service_sim.yaml")["/**"]["ros__parameters"]
     home = next(
@@ -222,7 +221,7 @@ def test_the_simulator_holds_the_arms_at_home(srdf):
 
 
 def test_chain_groups_have_a_solver_and_the_composite_one_does_not(srdf, kinematics):
-    """The composite group must NOT appear in kinematics.yaml.
+    """The composite group must not appear in kinematics.yaml.
 
     pick_ik rejects any group that is not a chain, and MoveIt only builds the per-subgroup
     solver map for groups that have no solver of their own. Naming both_arms here suppresses
@@ -335,7 +334,7 @@ def test_every_sensor_block_is_fully_specified(sensors_3d):
 
 
 def test_the_self_filter_padding_is_not_disabled(sensors_3d):
-    """Padding IS the self-filter margin. At zero the robot's own arms get mapped as obstacles
+    """Padding is the self-filter margin. At zero the robot's own arms get mapped as obstacles
     the moment a link's TF is a little late."""
     for name in sensors_3d["sensors"]:
         assert sensors_3d[name]["padding_scale"] >= 1.0, f"{name} shrinks the robot's own shapes"

--- a/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
+++ b/workspace/src/g1_moveit_config/test/test_moveit_plan_execute.launch.py
@@ -3,7 +3,7 @@
 Covers the properties that only exist once every layer is running together, and that no config
 test can see: that MoveIt refuses to execute before the arm is acquired, that a coordinated
 14-joint both_arms plan reaches the controller as one trajectory, that planned motion respects
-the bridge's speed clamp, and that the arm chain is placed correctly when the waist is NOT at
+the bridge's speed clamp, and that the arm chain is placed correctly when the waist is not at
 zero -- the case a robot standing square hides completely.
 
 Run via `colcon test --packages-select g1_moveit_config`.
@@ -243,7 +243,7 @@ class TestMoveItPlanExecute(unittest.TestCase):
             moved = max(abs(self.joint_state[n] - before[n]) for n in joints)
             self.assertGreater(moved, 0.02, f"{side} arm did not move during a both_arms plan")
 
-    # 5. The cross-package coupling this milestone introduces.
+    # 5. The cross-package coupling between MoveIt's planned speed and the hardware bridge's clamp.
     def test_06_planned_motion_respects_the_bridge_clamp(self):
         # Well above the jitter a stiff-held arm shows at rest, so this cannot pass on noise
         # while the plan above quietly failed to execute.

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -198,10 +198,10 @@ TEST_F(RobotModelTest, TheDualArmGroupIsNotAChainAndHasBothArmsAsSubgroups)
 
 TEST_F(RobotModelTest, NoArmGroupCommandsTheHand)
 {
-    // The hand is a separate device on its own topics with its own authority
-    //, and it has its own group and its own controller. An arm group
-    // that reached into one would plan a trajectory no single controller can execute, so
-    // MoveIt would either split it or refuse it.
+    // The hand is a separate device on its own topics with its own authority, and it has its
+    // own group and its own controller. An arm group that reached into one would plan a
+    // trajectory no single controller can execute, so MoveIt would either split it or refuse
+    // it.
     for (const auto* name : { "left_arm", "right_arm", "both_arms" })
     {
         const auto* group = model_->getJointModelGroup(name);
@@ -269,10 +269,10 @@ TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
 
 TEST_F(RobotModelTest, EachHandIsExactlyItsSevenFingerJoints)
 {
-    // A SET, not a sequence, and that is the point worth recording: a group declared as a joint
-    // list comes back SORTED, not in document order, where a chain group keeps chain order. So
-    // left_hand reads index, middle, thumb here while the wire, the URDF component and the
-    // controller all say thumb, middle, index.
+    // A set, not a sequence: a group declared as a joint list comes back sorted, not in
+    // document order, where a chain group keeps chain order. So left_hand reads index, middle,
+    // thumb here while the wire, the URDF component and the controller all say thumb, middle,
+    // index.
     //
     // Harmless as long as nothing lines a MoveIt trajectory up against HandCmd positionally:
     // the JTC remaps by name, and G1Dex3System takes its order from the URDF. The wire order

--- a/workspace/src/g1_moveit_config/test/test_robot_model.cpp
+++ b/workspace/src/g1_moveit_config/test/test_robot_model.cpp
@@ -91,8 +91,9 @@ protected:
         {
             for (const double direction : { -1.0, 1.0 })
             {
-                for (double delta = kMarginStepRad; delta <= cap + 1e-9; delta += kMarginStepRad)
+                for (int step = 1; step * kMarginStepRad <= cap + 1e-9; ++step)
                 {
+                    const double        delta = step * kMarginStepRad;
                     std::vector<double> probe = base;
                     probe[i] += direction * delta;
                     moveit::core::RobotState moved(state);
@@ -242,14 +243,14 @@ TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
     std::map<std::string, int>                           group_count;
     for (const auto& state : states)
     {
-        if (arm_groups.count(state.group_) == 0)
+        if (!arm_groups.contains(state.group_))
         {
             continue;  // the hand postures are two groups, not three; see below
         }
         group_count[state.name_]++;
         for (const auto& [joint, values] : state.joint_values_)
         {
-            ASSERT_EQ(values.size(), 1u) << joint << " in " << state.name_;
+            ASSERT_EQ(values.size(), 1U) << joint << " in " << state.name_;
             auto [it, fresh] = by_pose[state.name_].emplace(joint, values.front());
             if (!fresh)
             {
@@ -263,7 +264,7 @@ TEST_F(RobotModelTest, TheNamedPosesAgreeAcrossTheThreeGroups)
     {
         EXPECT_EQ(count, 3) << "pose '" << pose << "' should exist for left_arm, right_arm and "
                             << "both_arms";
-        EXPECT_EQ(by_pose[pose].size(), 14u) << "pose '" << pose << "' should name all 14 joints";
+        EXPECT_EQ(by_pose[pose].size(), 14U) << "pose '" << pose << "' should name all 14 joints";
     }
 }
 
@@ -302,7 +303,7 @@ TEST_F(RobotModelTest, EachHandIsItsArmsEndEffector)
     {
         by_group.emplace(effector.component_group_, effector);
     }
-    ASSERT_EQ(by_group.size(), 2u) << "expected one end effector per hand";
+    ASSERT_EQ(by_group.size(), 2U) << "expected one end effector per hand";
 
     for (const auto* side : { "left", "right" })
     {
@@ -323,7 +324,7 @@ TEST_F(RobotModelTest, EachHandHasAnOpenAndAClosedPosture)
         if (state.group_ == "left_hand" || state.group_ == "right_hand")
         {
             poses_by_group[state.group_].insert(state.name_);
-            EXPECT_EQ(state.joint_values_.size(), 7u)
+            EXPECT_EQ(state.joint_values_.size(), 7U)
                 << state.group_ << " posture '" << state.name_ << "' does not cover the hand";
         }
     }
@@ -363,7 +364,7 @@ TEST_F(RobotModelTest, TheCollisionMatrixExists)
     // Deliberately a conservative matrix: adjacent pairs plus what touches at rest, and nothing
     // found by random sampling. Enough that the robot is not in collision before it moves, which
     // is what RRTConnect needs to seed. The bound is a floor, not a target.
-    EXPECT_GT(srdf_->getDisabledCollisionPairs().size(), 40u)
+    EXPECT_GT(srdf_->getDisabledCollisionPairs().size(), 40U)
         << "g1.srdf carries no generated collision matrix; see the package README";
 }
 
@@ -398,7 +399,7 @@ TEST_F(RobotModelTest, AdjacentLinksAreDisabled)
         }
         // Links joined by a joint touch by construction. This is the category a careless hand
         // edit drops, and dropping it makes every plan start in collision.
-        EXPECT_TRUE(disabled.count({ parent, child }) > 0)
+        EXPECT_TRUE(disabled.contains({ parent, child }))
             << "adjacent pair " << parent << " / " << child << " is not disabled";
     }
 }

--- a/workspace/src/g1_msgs/action/ApproachObject.action
+++ b/workspace/src/g1_msgs/action/ApproachObject.action
@@ -3,7 +3,7 @@
 # Exists because navigation cannot hand manipulation a pose it can work with: Nav2's
 # xy_goal_tolerance is 0.5 m and the arm's whole reach envelope is about 0.13 m wide.
 #
-# This does NOT converge on a distance setpoint. The gait's smallest forward pulse measures
+# This does not converge on a distance setpoint. The gait's smallest forward pulse measures
 # 0.3 to 0.6 m -- larger than the reach tolerance -- so no control law can hit a 5 cm target
 # head-on. It walks in pulses, re-reads the object between each one, and approaches obliquely
 # once the remaining distance is under one pulse, so the advance per pulse is what shrinks
@@ -19,7 +19,7 @@ string ARM_RIGHT=right
 string arm
 # The heading to hold while approaching, in the odometry frame, radians.
 #
-# NOT derived from where the object is, deliberately. The standard mobile-manipulation pattern is
+# Not derived from where the object is, deliberately. The standard mobile-manipulation pattern is
 # a stand-off pose on the surface normal, already facing the working direction, closed straight
 # in; Nav2 has GoalAngleCritic for exactly that. An approach that re-aims at the object from a
 # metre out walks in on a curve and arrives square to nothing. Pass the same yaw the staging

--- a/workspace/src/g1_msgs/action/Place.action
+++ b/workspace/src/g1_msgs/action/Place.action
@@ -1,10 +1,10 @@
 # Put down whatever the given arm is holding.
 #
-# The pose is where the OBJECT should end up, not where the palm should go: the caller knows the
+# The pose is where the object should end up, not where the palm should go: the caller knows the
 # target surface, and only the server knows how the object is currently held. It is transformed
 # into the planning frame on arrival, so a goal in odom survives the robot having walked.
 
-# Put the held object down on top of this DETECTED surface, ignoring `pose`. Prefer this to a
+# Put the held object down on top of this detected surface, ignoring `pose`. Prefer this to a
 # fixed coordinate, because a fixed coordinate is written in the map frame and the base approach
 # parks the robot against the object stream, which is published in odom. AMCL has been measured
 # 0.23 m apart from odom mid-mission, against an arm whose lateral window is 0.04 m -- so a map

--- a/workspace/src/g1_msgs/action/Retreat.action
+++ b/workspace/src/g1_msgs/action/Retreat.action
@@ -1,7 +1,7 @@
 # Reverse away from a surface, far enough that whatever happens next does not drag the arm across
 # it.
 #
-# It reverses and STOPS. It does not turn, and it does not walk anywhere: a navigation goal
+# It reverses and stops. It does not turn, and it does not walk anywhere: a navigation goal
 # normally follows, and Nav2 is far better at going somewhere than a hand-rolled pulse controller.
 # The only job here is to get the base clear.
 #

--- a/workspace/src/g1_navigation/config/localization.yaml
+++ b/workspace/src/g1_navigation/config/localization.yaml
@@ -37,8 +37,8 @@ amcl:
     # object, and the gait adds 0.22-0.30 m/s of uncommanded lateral motion on top. A
     # differential model cannot express that at all -- it factors every delta into
     # rotate/translate/rotate, so sideways motion enters the filter as a rotation that never
-    # happened. Measured cost of getting this wrong: a mission that ended with map -> odom at
-    # 177 deg of yaw error, the particle cloud having flipped end for end.
+    # happened. Getting this wrong is not subtle: the particle cloud can flip end for end,
+    # landing map -> odom at roughly 180 degrees of yaw error.
     robot_model_type: "nav2_amcl::OmniMotionModel"
     # Nav2's defaults. The 0.02 they replace said "the odometry is exact", which was true only
     # of the sportmodestate track's MuJoCo ground truth. fast_lio drifts, so a filter told to

--- a/workspace/src/g1_navigation/launch/localization.launch.py
+++ b/workspace/src/g1_navigation/launch/localization.launch.py
@@ -4,7 +4,8 @@ The alternative to slam.launch.py, never run alongside it -- both would broadcas
 Neither includes the scan pipeline; scan.launch.py does, and both need it.
 
 Structure mirrors nav2_bringup's own localization_launch.py, including the composed and
-non-composed branches, so PR B's server set drops into the same container.
+non-composed branches, so this file's servers drop into the same shared container as the rest
+of the navigation stack.
 """
 
 import os

--- a/workspace/src/g1_navigation/launch/nav2.launch.py
+++ b/workspace/src/g1_navigation/launch/nav2.launch.py
@@ -1,41 +1,26 @@
 """Nav2 servers, plus the two G1-specific nodes that make their output usable.
 
 Adapted from nav2_bringup's own navigation_launch.py (Humble 1.1.20), keeping its structure:
-the same composed/non-composed split and the same /tf remappings. What differs from upstream is
-listed below, because each difference is a decision rather than drift.
+the same composed/non-composed split and the same /tf remappings. Differences from upstream:
 
-  * Three servers are NOT launched. velocity_smoother smooths toward zero, which on this robot
-    means decelerating into the gait's dead zone and stopping dead; smoother_server smooths
-    paths for a robot with two motion primitives; waypoint_follower has no caller. All three
-    are in upstream's list, so their absence is deliberate, not an oversight.
+  * velocity_smoother, smoother_server and waypoint_follower are NOT launched: smoothing toward
+    zero decelerates this robot into the gait's dead zone and stops it dead, path smoothing is
+    for a robot with more than two motion primitives, and nothing calls waypoint_follower.
   * controller_server's cmd_vel goes to /cmd_vel rather than upstream's cmd_vel_nav, because
-    g1_gait_shaper is what sits between Nav2 and the robot here, in place of velocity_smoother.
-    The shaper is also what arbitrates Nav2 against g1_base_approach's higher-priority
-    /cmd_vel_approach, so nothing else has to sit in that path.
-  * controller_server also REMAPS odom. Its OdomSmoother is built with the C++ default topic
+    g1_gait_shaper sits between Nav2 and the robot here, in place of velocity_smoother, and also
+    arbitrates Nav2 against g1_base_approach's higher-priority /cmd_vel_approach.
+  * controller_server also REMAPS odom. Its OdomSmoother is built with the C++ default topic,
     and controller_server declares no odom_topic parameter on Humble -- setting one is silently
-    ignored, and Nav2 then believes the robot is permanently stationary.
-  * g1_gait_shaper, g1_loco_authority and g1_base_approach are added; none of them exists
-    upstream.
+    ignored, leaving Nav2 believing the robot is permanently stationary.
+  * g1_gait_shaper, g1_loco_authority and g1_base_approach are added; none exists upstream.
 
-use_composition defaults to FALSE here, unlike scan.launch.py and localization.launch.py.
-
-Measured, not assumed. Composed, the costmaps silently come up on Costmap2DROS's built-in
-defaults: /local_costmap/local_costmap reported robot_base_frame "base_link", global_frame
-"map" and robot_radius 0.1 while config/nav2_params.yaml plainly says base_footprint, odom and
-0.45. controller_server then hangs forever in Activating, waiting on a transform from a frame
-that does not exist, and the whole bringup stalls behind it. Run non-composed and the identical
-file delivers every value and controller_server, planner_server and behavior_server all reach
-active.
-
-Three ways of passing the file were tried under composition -- a bare path, RewrittenYaml as
-upstream uses, and ParameterFile(allow_substs=True) as upstream wraps it -- and all three
-behaved the same. The nested sections belong to differently-named nodes than the ComposableNode
-being loaded, which is the shape of the problem, but the root cause was not chased further:
-composition here is an optimisation, and correctness is not negotiable for it.
-
-PR A's scan and localization nodes still compose, and do get their parameters. Their sections
-are flat and named for the node itself, which is consistent with that diagnosis.
+use_composition defaults to FALSE here, unlike scan.launch.py and localization.launch.py:
+composed, the nested costmap parameter sections never reach the ComposableNode being loaded --
+they resolve against differently-named nodes instead -- so Costmap2DROS comes up on its own
+built-in defaults (base_link/map/0.1) instead of this package's config (base_footprint/odom/
+0.45), and controller_server hangs forever in Activating, waiting on a transform from a frame
+that does not exist. Uncomposed, the identical file delivers every value correctly. Composition
+here is an optimisation; correctness is not negotiable for it.
 """
 
 import os
@@ -99,8 +84,8 @@ def generate_launch_description():
 
     remappings = [("/tf", "tf"), ("/tf_static", "tf_static")]
     # Nav2's controller publishes here; the shaper reduces it onto the gait's achievable
-    # motions and forwards to the bridge. Since milestone 9 it is the LOW-priority of two
-    # sources, and the shaper is what decides between them.
+    # motions and forwards to the bridge. It is the LOW-priority of two sources, and the
+    # shaper is what decides between them.
     controller_remappings = remappings + [
         ("cmd_vel", "/cmd_vel"),
         ("odom", "/g1_odometry_publisher/odom"),

--- a/workspace/src/g1_orchestration/CMakeLists.txt
+++ b/workspace/src/g1_orchestration/CMakeLists.txt
@@ -114,6 +114,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_orchestration test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_orchestration
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_orchestration PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_orchestration test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_orchestration/CMakeLists.txt
+++ b/workspace/src/g1_orchestration/CMakeLists.txt
@@ -120,8 +120,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_orchestration
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -129,7 +129,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_orchestration PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_orchestration test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_orchestration test")
   endif()
 endif()
 

--- a/workspace/src/g1_orchestration/include/g1_orchestration/port_types.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/port_types.hpp
@@ -34,10 +34,10 @@ struct Point3
 namespace BT
 {
 template <>
-g1_orchestration::Station convertFromString(StringView text);
+g1_orchestration::Station convertFromString(StringView str);
 
 template <>
-g1_orchestration::Point3 convertFromString(StringView text);
+g1_orchestration::Point3 convertFromString(StringView str);
 }  // namespace BT
 
 #endif  // G1_ORCHESTRATION__PORT_TYPES_HPP_

--- a/workspace/src/g1_orchestration/include/g1_orchestration/ports.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/ports.hpp
@@ -28,8 +28,7 @@ inline Port objectId()
 }
 
 /// Sent to the SERVER as part of the goal. Distinct from serviceTimeout(): this one bounds the
-/// skill, that one bounds a local call. Both used to be called `timeout_s` with no way for a
-/// tree author to tell them apart.
+/// skill, that one bounds a local call, named apart so a tree author does not confuse the two.
 inline Port goalTimeout()
 {
     return BT::InputPort<double>("timeout_s", 0.0, "0 uses the server's own default.");

--- a/workspace/src/g1_orchestration/include/g1_orchestration/skills/clear_octomap.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/skills/clear_octomap.hpp
@@ -13,8 +13,8 @@ namespace g1_orchestration
 /// the arm plans against.
 ///
 /// Manipulating beside a surface leaves the octomap holding the arm and whatever it picked up,
-/// where they used to be. Those voxels do not decay, so later plans route around a ghost: one
-/// mission died at `carry` on <octomap> against the carried cube, a metre clear of the bench.
+/// where they used to be. Those voxels do not decay, so a later plan can route around -- or
+/// collide with -- a ghost of something that was cleared out of the world minutes ago.
 ///
 /// Succeeds even when the clear fails, for ClearCostmaps' reason: housekeeping, not a
 /// precondition.

--- a/workspace/src/g1_orchestration/src/arm_authority.cpp
+++ b/workspace/src/g1_orchestration/src/arm_authority.cpp
@@ -142,6 +142,8 @@ void releaseArm(const rclcpp::Logger& logger, double timeout_s)
     // its controller still claims its interfaces is the failure this order avoids.
     const rclcpp::Node::SharedPtr      node  = makeClientNode("g1_arm_authority_client");
     const std::vector<ControlledPart>& parts = controlledParts();
+    // std::ranges::reverse_view breaks clang-tidy's Clang-14 parser against libstdc++ here.
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto it = parts.rbegin(); it != parts.rend(); ++it)
     {
         switchController(node, {}, { it->controller }, timeout_s);

--- a/workspace/src/g1_orchestration/src/g1_bt_executor_main.cpp
+++ b/workspace/src/g1_orchestration/src/g1_bt_executor_main.cpp
@@ -37,9 +37,10 @@ constexpr double kReleaseTimeoutS = 15.0;
 
 /// Releases the arm and hands when it goes out of scope, however that happens.
 ///
-/// The bracket used to be a call at the end of main, correct only for as long as every path out
-/// kept reaching it. Making it a destructor moves that from a property of the control flow to a
-/// property of the type: control-mode rule 4 is then enforced by the language.
+/// A destructor rather than a call at the end of main: releasing only stays correct if every
+/// path out actually reaches it, and a destructor turns that from a property of the control
+/// flow into a property of the type -- control-mode rule 4 is then enforced by the language
+/// itself.
 class ArmBracket
 {
 public:

--- a/workspace/src/g1_orchestration/src/g1_bt_executor_main.cpp
+++ b/workspace/src/g1_orchestration/src/g1_bt_executor_main.cpp
@@ -28,7 +28,9 @@ namespace
 {
 
 // Set from the signal handler, so it must be exactly this type: everything else is undefined
-// behaviour in a handler, including rclcpp::shutdown.
+// behaviour in a handler, including rclcpp::shutdown. Mutable at namespace scope because a
+// handler cannot capture.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<bool> g_interrupted{ false };
 
 void onSignal(int) { g_interrupted = true; }
@@ -44,8 +46,8 @@ constexpr double kReleaseTimeoutS = 15.0;
 class ArmBracket
 {
 public:
-    ArmBracket(rclcpp::Logger logger, double timeout_s)
-      : logger_(std::move(logger))
+    ArmBracket(const rclcpp::Logger& logger, double timeout_s)
+      : logger_(logger)
       , timeout_s_(timeout_s)
     {}
 
@@ -64,100 +66,126 @@ private:
 int main(int argc, char** argv)
 {
     rclcpp::init(argc, argv);
-    auto node = std::make_shared<rclcpp::Node>("g1_bt_executor");
 
-    const std::string tree_file    = node->declare_parameter<std::string>("tree_file", "");
-    const double      tick_rate_hz = node->declare_parameter<double>("tick_rate_hz", 10.0);
-    // 0 disables. 1667 is Groot2's own default, and the container runs with host networking,
-    // so the editor on the host reaches it at localhost with nothing to configure.
-    const int groot2_port = node->declare_parameter<int>("groot2_port", 1667);
-
-    if (tree_file.empty())
+    // Unwinding past main() uncaught doesn't guarantee ArmBracket's destructor runs.
+    try
     {
-        RCLCPP_ERROR(node->get_logger(), "tree_file is required");
+        auto node = std::make_shared<rclcpp::Node>("g1_bt_executor");
+
+        const std::string tree_file    = node->declare_parameter<std::string>("tree_file", "");
+        const double      tick_rate_hz = node->declare_parameter<double>("tick_rate_hz", 10.0);
+        // 0 disables. 1667 is Groot2's own default, and the container runs with host
+        // networking, so the editor on the host reaches it at localhost with nothing to
+        // configure.
+        const int groot2_port = static_cast<int>(node->declare_parameter<int>("groot2_port", 1667));
+
+        if (tree_file.empty())
+        {
+            RCLCPP_ERROR(node->get_logger(), "tree_file is required");
+            rclcpp::shutdown();
+            return 1;
+        }
+
+        // Installed before anything is acquired, so a Ctrl-C during the run reaches the release
+        // below rather than killing the process with the arm still active. Checked, because a
+        // failed install silently removes that guarantee.
+        const auto previous_int  = std::signal(SIGINT, onSignal);
+        const auto previous_term = std::signal(SIGTERM, onSignal);
+        if (previous_int == SIG_ERR || previous_term == SIG_ERR)
+        {
+            RCLCPP_ERROR(
+                node->get_logger(),
+                "could not install the SIGINT/SIGTERM handlers -- an interrupt will now exit "
+                "without releasing the arm");
+        }
+
+        rclcpp::executors::SingleThreadedExecutor executor;
+        executor.add_node(node);
+        std::thread spinner([&executor] {
+            while (rclcpp::ok() && !g_interrupted)
+            {
+                executor.spin_some(std::chrono::milliseconds(10));
+            }
+        });
+
+        int exit_code = 0;
+        {
+            // Closes when this scope ends, on every path out of it.
+            const ArmBracket bracket(node->get_logger(), kReleaseTimeoutS);
+
+            try
+            {
+                BT::BehaviorTreeFactory      factory;
+                g1_orchestration::RosContext context{ node };
+                g1_orchestration::registerSkillNodes(factory, context);
+
+                BT::Tree tree = factory.createTreeFromFile(tree_file);
+                RCLCPP_INFO(node->get_logger(), "loaded %s", tree_file.c_str());
+
+                BT::StdCoutLogger                    cout_logger(tree);
+                std::unique_ptr<BT::Groot2Publisher> groot2;
+                if (groot2_port > 0)
+                {
+                    groot2 = std::make_unique<BT::Groot2Publisher>(tree, groot2_port);
+                    RCLCPP_INFO(
+                        node->get_logger(),
+                        "Groot2 can connect on port %d. Note the free tier monitors at most 20 "
+                        "nodes.",
+                        groot2_port);
+                }
+
+                // Ticked by hand rather than with tickWhileRunning, so the interrupt is checked
+                // between ticks and a halt still runs every leaf's own cancellation.
+                const auto     period = std::chrono::duration<double>(1.0 / tick_rate_hz);
+                BT::NodeStatus status = BT::NodeStatus::RUNNING;
+                while (rclcpp::ok() && !g_interrupted && status == BT::NodeStatus::RUNNING)
+                {
+                    status = tree.tickOnce();
+                    std::this_thread::sleep_for(
+                        std::chrono::duration_cast<std::chrono::steady_clock::duration>(period));
+                }
+
+                if (g_interrupted)
+                {
+                    RCLCPP_WARN(node->get_logger(), "interrupted; halting the tree");
+                    tree.haltTree();
+                    exit_code = 130;
+                }
+                else
+                {
+                    RCLCPP_INFO(
+                        node->get_logger(),
+                        "mission finished: %s",
+                        status == BT::NodeStatus::SUCCESS ? "SUCCESS" : "FAILURE");
+                    exit_code = status == BT::NodeStatus::SUCCESS ? 0 : 1;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                // A tree that failed to load is a normal enough mistake; leaving the arm
+                // acquired after one is not.
+                RCLCPP_ERROR(node->get_logger(), "mission aborted: %s", e.what());
+                exit_code = 1;
+            }
+
+            // Spinning stops before the bracket closes: releaseArm blocks on service calls and
+            // needs the executor out of the way to make them.
+            g_interrupted = true;
+            spinner.join();
+            executor.remove_node(node);
+        }
+
+        rclcpp::shutdown();
+        return exit_code;
+    }
+    catch (const std::exception& e)
+    {
+        // Nothing here has acquired the arm yet, so there is nothing to release.
+        RCLCPP_ERROR(
+            rclcpp::get_logger("g1_bt_executor"),
+            "startup or shutdown failed: %s",
+            e.what());
+        rclcpp::shutdown();
         return 1;
     }
-
-    // Installed before anything is acquired, so a Ctrl-C during the run reaches the release
-    // below rather than killing the process with the arm still active.
-    std::signal(SIGINT, onSignal);
-    std::signal(SIGTERM, onSignal);
-
-    rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(node);
-    std::thread spinner([&executor] {
-        while (rclcpp::ok() && !g_interrupted)
-        {
-            executor.spin_some(std::chrono::milliseconds(10));
-        }
-    });
-
-    int exit_code = 0;
-    {
-        // Closes when this scope ends, on every path out of it.
-        const ArmBracket bracket(node->get_logger(), kReleaseTimeoutS);
-
-        try
-        {
-            BT::BehaviorTreeFactory      factory;
-            g1_orchestration::RosContext context{ node };
-            g1_orchestration::registerSkillNodes(factory, context);
-
-            BT::Tree tree = factory.createTreeFromFile(tree_file);
-            RCLCPP_INFO(node->get_logger(), "loaded %s", tree_file.c_str());
-
-            BT::StdCoutLogger                    cout_logger(tree);
-            std::unique_ptr<BT::Groot2Publisher> groot2;
-            if (groot2_port > 0)
-            {
-                groot2 = std::make_unique<BT::Groot2Publisher>(tree, groot2_port);
-                RCLCPP_INFO(
-                    node->get_logger(),
-                    "Groot2 can connect on port %d. Note the free tier monitors at most 20 nodes.",
-                    groot2_port);
-            }
-
-            // Ticked by hand rather than with tickWhileRunning, so the interrupt is checked
-            // between ticks and a halt still runs every leaf's own cancellation.
-            const auto     period = std::chrono::duration<double>(1.0 / tick_rate_hz);
-            BT::NodeStatus status = BT::NodeStatus::RUNNING;
-            while (rclcpp::ok() && !g_interrupted && status == BT::NodeStatus::RUNNING)
-            {
-                status = tree.tickOnce();
-                std::this_thread::sleep_for(
-                    std::chrono::duration_cast<std::chrono::steady_clock::duration>(period));
-            }
-
-            if (g_interrupted)
-            {
-                RCLCPP_WARN(node->get_logger(), "interrupted; halting the tree");
-                tree.haltTree();
-                exit_code = 130;
-            }
-            else
-            {
-                RCLCPP_INFO(
-                    node->get_logger(),
-                    "mission finished: %s",
-                    status == BT::NodeStatus::SUCCESS ? "SUCCESS" : "FAILURE");
-                exit_code = status == BT::NodeStatus::SUCCESS ? 0 : 1;
-            }
-        }
-        catch (const std::exception& e)
-        {
-            // A tree that failed to load is a normal enough mistake; leaving the arm acquired
-            // after one is not.
-            RCLCPP_ERROR(node->get_logger(), "mission aborted: %s", e.what());
-            exit_code = 1;
-        }
-
-        // Spinning stops before the bracket closes: releaseArm blocks on service calls and
-        // needs the executor out of the way to make them.
-        g_interrupted = true;
-        spinner.join();
-        executor.remove_node(node);
-    }
-
-    rclcpp::shutdown();
-    return exit_code;
 }

--- a/workspace/src/g1_orchestration/src/port_types.cpp
+++ b/workspace/src/g1_orchestration/src/port_types.cpp
@@ -7,12 +7,12 @@ namespace BT
 {
 
 template <>
-g1_orchestration::Station convertFromString(StringView text)
+g1_orchestration::Station convertFromString(StringView str)
 {
-    const std::vector<StringView> parts = splitString(text, ';');
+    const std::vector<StringView> parts = splitString(str, ';');
     if (parts.size() != 3)
     {
-        throw RuntimeError("a station is 'x;y;yaw', got: ", std::string(text));
+        throw RuntimeError("a station is 'x;y;yaw', got: ", std::string(str));
     }
     g1_orchestration::Station station;
     station.x   = convertFromString<double>(parts[0]);
@@ -22,12 +22,12 @@ g1_orchestration::Station convertFromString(StringView text)
 }
 
 template <>
-g1_orchestration::Point3 convertFromString(StringView text)
+g1_orchestration::Point3 convertFromString(StringView str)
 {
-    const std::vector<StringView> parts = splitString(text, ';');
+    const std::vector<StringView> parts = splitString(str, ';');
     if (parts.size() != 3)
     {
-        throw RuntimeError("a point is 'x;y;z', got: ", std::string(text));
+        throw RuntimeError("a point is 'x;y;z', got: ", std::string(str));
     }
     g1_orchestration::Point3 point;
     point.x = convertFromString<double>(parts[0]);

--- a/workspace/src/g1_orchestration/src/skills/approach_object.cpp
+++ b/workspace/src/g1_orchestration/src/skills/approach_object.cpp
@@ -9,7 +9,7 @@ namespace g1_orchestration
 
 ApproachObject::ApproachObject(
     const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : SkillActionNode(name, config, context, "/g1_base_approach/approach_object")
+  : SkillActionNode(name, config, std::move(context), "/g1_base_approach/approach_object")
 {}
 
 BT::PortsList ApproachObject::providedPorts()

--- a/workspace/src/g1_orchestration/src/skills/navigate_to_pose.cpp
+++ b/workspace/src/g1_orchestration/src/skills/navigate_to_pose.cpp
@@ -29,7 +29,7 @@ geometry_msgs::msg::PoseStamped toPose(const Station& station, const std::string
 
 NavigateToPose::NavigateToPose(
     const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : RosActionNode(name, config, context, "/navigate_to_pose")
+  : RosActionNode(name, config, std::move(context), "/navigate_to_pose")
 {}
 
 BT::PortsList NavigateToPose::providedPorts()

--- a/workspace/src/g1_orchestration/src/skills/navigate_to_pose.cpp
+++ b/workspace/src/g1_orchestration/src/skills/navigate_to_pose.cpp
@@ -59,8 +59,8 @@ bool NavigateToPose::fillGoal(Goal& goal)
     // Nav2 picks its own default when this is empty, so a tree that does not care says nothing.
     goal.behavior_tree = getInput<std::string>("behavior_tree").value_or("");
 
-    // Published so the approach that follows can hold the heading this goal arrived on. It used
-    // to be retyped as a literal in both places and kept equal by hand.
+    // Published so the approach that follows can hold the heading this goal arrived on, rather
+    // than needing a matching literal typed by hand in both places.
     setOutput("goal_yaw", station->yaw);
     return true;
 }

--- a/workspace/src/g1_orchestration/src/skills/pick.cpp
+++ b/workspace/src/g1_orchestration/src/skills/pick.cpp
@@ -8,7 +8,7 @@ namespace g1_orchestration
 {
 
 Pick::Pick(const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : SkillActionNode(name, config, context, "/g1_manipulation_server/pick")
+  : SkillActionNode(name, config, std::move(context), "/g1_manipulation_server/pick")
 {}
 
 BT::PortsList Pick::providedPorts()

--- a/workspace/src/g1_orchestration/src/skills/place.cpp
+++ b/workspace/src/g1_orchestration/src/skills/place.cpp
@@ -8,7 +8,7 @@ namespace g1_orchestration
 {
 
 Place::Place(const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : SkillActionNode(name, config, context, "/g1_manipulation_server/place")
+  : SkillActionNode(name, config, std::move(context), "/g1_manipulation_server/place")
 {}
 
 BT::PortsList Place::providedPorts()

--- a/workspace/src/g1_orchestration/src/skills/retreat.cpp
+++ b/workspace/src/g1_orchestration/src/skills/retreat.cpp
@@ -8,7 +8,7 @@ namespace g1_orchestration
 {
 
 Retreat::Retreat(const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : SkillActionNode(name, config, context, "/g1_base_approach/retreat")
+  : SkillActionNode(name, config, std::move(context), "/g1_base_approach/retreat")
 {}
 
 BT::PortsList Retreat::providedPorts()

--- a/workspace/src/g1_orchestration/src/skills/set_arm_posture.cpp
+++ b/workspace/src/g1_orchestration/src/skills/set_arm_posture.cpp
@@ -7,7 +7,7 @@ namespace g1_orchestration
 
 SetArmPosture::SetArmPosture(
     const std::string& name, const BT::NodeConfig& config, RosContext context)
-  : SkillActionNode(name, config, context, "/g1_manipulation_server/set_arm_posture")
+  : SkillActionNode(name, config, std::move(context), "/g1_manipulation_server/set_arm_posture")
 {}
 
 BT::PortsList SetArmPosture::providedPorts()

--- a/workspace/src/g1_orchestration/test/test_authority_drift.cpp
+++ b/workspace/src/g1_orchestration/test/test_authority_drift.cpp
@@ -52,7 +52,7 @@ TEST(AuthorityDrift, TheArmComesFirstAndBothHandsFollow)
     // Order is not cosmetic. The arm is the part whose failure fails the whole acquire, and
     // the hands are best-effort behind it, so the arm has to be parts.front().
     const auto& parts = g1_orchestration::controlledParts();
-    ASSERT_EQ(parts.size(), 3u);
+    ASSERT_EQ(parts.size(), 3U);
     EXPECT_EQ(parts[0].component, "G1ArmSdkSystem");
     EXPECT_EQ(parts[1].component, "G1Dex3SystemLeft");
     EXPECT_EQ(parts[2].component, "G1Dex3SystemRight");

--- a/workspace/src/g1_orchestration/test/test_node_model.cpp
+++ b/workspace/src/g1_orchestration/test/test_node_model.cpp
@@ -41,6 +41,8 @@ TEST(NodeModel, TheCheckedInPaletteMatchesTheRegisteredNodes)
 
 int main(int argc, char** argv)
 {
+    // Before any node or thread exists, so the thread-safety this warns about does not apply.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     setenv("ROS_DOMAIN_ID", "79", 1);
     ::testing::InitGoogleMock(&argc, argv);
     rclcpp::init(argc, argv);

--- a/workspace/src/g1_orchestration/test/test_tree_loads.cpp
+++ b/workspace/src/g1_orchestration/test/test_tree_loads.cpp
@@ -114,9 +114,9 @@ TEST(TreeLoads, TheMissionTreeUsesTheLeavesItIsSupposedTo)
 
 TEST(TreeLoads, EveryFallibleLeafInTheMissionIsRetried)
 {
-    // Pinned because losing a retry wrapper is invisible until it costs a whole mission. The
-    // closing tucks originally had none, and a run that had already placed the cube failed on a
-    // single clipped waypoint, 30 of 142, with everything else done.
+    // Pinned because losing a retry wrapper is invisible until it costs a whole mission: a
+    // single clipped waypoint near the very end can fail a run that had already done everything
+    // else.
     //
     // Counted rather than located: the count is what a careless edit drops, and asserting the
     // exact tree shape here would make every legitimate restructure a test change.
@@ -135,7 +135,8 @@ TEST(TreeLoads, EveryFallibleLeafInTheMissionIsRetried)
     }
 
     // Five postures, two navigation goals, the object approach, the pick, and the
-    // approach-and-place pair. Nav2 aborts a plan transiently and used to fail the mission.
+    // approach-and-place pair, each wrapped because Nav2 aborts a plan transiently often enough
+    // to fail an otherwise-healthy mission if nothing retries it.
     EXPECT_EQ(seen["RetryUntilSuccessful"], 10);
 }
 

--- a/workspace/src/g1_orchestration/test/test_tree_loads.cpp
+++ b/workspace/src/g1_orchestration/test/test_tree_loads.cpp
@@ -149,7 +149,7 @@ TEST(TreeLoads, RejectsALeafNobodyRegistered)
 
     EXPECT_THROW(
         {
-            factory.createTreeFromText(
+            (void)factory.createTreeFromText(
                 R"(<root BTCPP_format="4"><BehaviorTree ID="M">
                      <Sequence><NoSuchSkill/></Sequence>
                    </BehaviorTree></root>)");
@@ -166,7 +166,9 @@ TEST(Ports, AStationParsesAsThreeNumbers)
 
     // Rejected rather than silently zero-filled: a goal short one number would drive the base
     // somewhere nobody asked for.
-    EXPECT_THROW(BT::convertFromString<g1_orchestration::Station>("4.5;-4.5"), BT::RuntimeError);
+    EXPECT_THROW(
+        (void)BT::convertFromString<g1_orchestration::Station>("4.5;-4.5"),
+        BT::RuntimeError);
 }
 
 TEST(Ports, APointParsesAsThreeNumbers)
@@ -176,11 +178,13 @@ TEST(Ports, APointParsesAsThreeNumbers)
     EXPECT_DOUBLE_EQ(point.y, 4.0);
     EXPECT_DOUBLE_EQ(point.z, 0.78);
 
-    EXPECT_THROW(BT::convertFromString<g1_orchestration::Point3>("7.0;4.0"), BT::RuntimeError);
+    EXPECT_THROW((void)BT::convertFromString<g1_orchestration::Point3>("7.0;4.0"), BT::RuntimeError);
 }
 
 int main(int argc, char** argv)
 {
+    // Before any node or thread exists, so the thread-safety this warns about does not apply.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     setenv("ROS_DOMAIN_ID", "79", 1);
     ::testing::InitGoogleMock(&argc, argv);
     rclcpp::init(argc, argv);

--- a/workspace/src/g1_orchestration/trees/pick_and_place.xml
+++ b/workspace/src/g1_orchestration/trees/pick_and_place.xml
@@ -27,10 +27,10 @@
 <root BTCPP_format="4" main_tree_to_execute="PickAndPlace">
   <BehaviorTree ID="PickAndPlace">
     <Sequence name="mission">
-      <!-- FIRST, before any arm motion. It used to sit just before the pick, which left
-           tuck_to_travel depending on bringup's activate_arm:=true having already run: launch
-           the mission a moment early and the tree fails on its first leaf with "Controller is
-           not running". A tree that needs the arm should take the arm.
+      <!-- FIRST, before any arm motion: a tree that needs the arm should take the arm rather
+           than depending on activate_arm:=true having already run at bring-up, which would fail
+           the first leaf with "Controller is not running" if the mission launched a moment
+           early.
 
            Idempotent by design, so acquiring here and finding it already acquired costs
            nothing. -->
@@ -104,8 +104,8 @@
       <!-- The 3D counterpart, and a different subsystem: ClearCostmaps wipes Nav2's grids, which
            the base plans over, and leaves the planning scene the ARM plans against untouched.
            Reaching over the workbench leaves the octomap holding the arm and the cube where they
-           were, and those voxels do not decay: one mission died here with <octomap> against the
-           carried cube at the third waypoint of the carry, a metre clear of the bench. -->
+           were, and those voxels do not decay: a later plan can collide with a ghost of
+           something that was cleared out of the world minutes ago. -->
       <ClearOctomap name="forget_the_workbench_in_3d"/>
 
       <RetryUntilSuccessful name="carry_with_retries" num_attempts="3">
@@ -130,10 +130,10 @@
         </Sequence>
       </RetryUntilSuccessful>
 
-      <!-- The approach and the place RETRY TOGETHER, and that pairing is the point.
-           The robot is balancing, so extending a loaded arm forward shifts its centre of mass
-           and the walking policy steps to keep up: measured at 0.182 m of base travel during
-           one reach. The place re-aims mid-motion to price that in, but past about 0.1 m the
+      <!-- The approach and the place RETRY TOGETHER: the robot is balancing, so extending a
+           loaded arm forward shifts its centre of mass and the walking policy steps to keep up,
+           measured at 0.182 m of base travel during one reach. The place re-aims mid-motion to
+           price that in, but past about 0.1 m the
            surface has left the arm's band entirely and no arm motion can recover it: the BASE
            has to move, which means approaching again. Retrying the place alone would re-plan
            forever against a target that is simply out of range. -->
@@ -142,12 +142,10 @@
           <ApproachObject name="close_on_the_pad" object_id="drop_pad" arm="right"
                           working_yaw="{storage_yaw}"/>
 
-          <!-- Named, not a coordinate, and that is the whole point. This used to read
-               target="6.50;6.25;0.855", which is exactly right ON THE MAP and still failed
-               every time with "preplace: planning failed (-27)": a coordinate here is in the
-               map frame, while the approach immediately above parks the base against /objects
-               in odom. AMCL was measured 0.23 m from odom at this bench, and the arm's lateral
-               window is 0.04 m, so the target landed 0.14 m outside anything the arm can
+          <!-- Named, not a coordinate: a coordinate here is in the MAP frame, while the
+               approach immediately above parks the base against /objects in ODOM. AMCL was
+               measured 0.23 m from odom at this bench, well outside the arm's 0.04 m lateral
+               window, so a map coordinate can land the target outside anything the arm can
                reach. Naming the surface makes the place and the approach read the same stream,
                so they cannot disagree. -->
           <Place name="put_it_on_the_pad" surface="drop_pad" arm="right"/>
@@ -173,8 +171,7 @@
 
        Retried because the failure here is per-attempt, not structural: "Motion plan was found
        but it seems to be invalid" is OMPL having sampled a path that clips the live octomap,
-       and the posture is verified collision-free against the robot model. A completed mission
-       was once failed by the closing pair having no retry, on one clipped waypoint. -->
+       and the posture is verified collision-free against the robot model. -->
   <BehaviorTree ID="TuckBothArms">
     <Sequence name="tuck_both">
       <RetryUntilSuccessful name="tuck_right_with_retries" num_attempts="3">

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -95,8 +95,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_sensor_relay
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -104,7 +104,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_sensor_relay PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_sensor_relay test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_sensor_relay test")
   endif()
 endif()
 

--- a/workspace/src/g1_sensor_relay/CMakeLists.txt
+++ b/workspace/src/g1_sensor_relay/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(livox_custom_msg PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+target_compile_features(livox_custom_msg PUBLIC cxx_std_20)
 ament_target_dependencies(livox_custom_msg PUBLIC rclcpp sensor_msgs livox_ros_driver2)
 
 # Restates the relay's own output in the format FAST-LIO wants. Separate executable so the
@@ -87,6 +88,23 @@ if(BUILD_TESTING)
   else()
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_sensor_relay test")
+  endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_sensor_relay
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_sensor_relay PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_sensor_relay test")
   endif()
 endif()
 

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/frame_reader.hpp
@@ -9,6 +9,7 @@
  * graph, same discipline as g1_state_estimation's odom_math.
  */
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -18,15 +19,15 @@
 namespace g1_sensor_relay
 {
 
-/// Why a frame was rejected. Anything but Ok means the bytes are not trustworthy.
+/// Why a frame was rejected. Anything but kOk means the bytes are not trustworthy.
 enum class FrameStatus
 {
-    Ok,
-    Incomplete,  ///< Not enough bytes yet; wait for more.
-    BadMagic,    ///< Not our stream, or the stream desynchronised.
-    BadVersion,  ///< Producer and consumer disagree on the layout.
-    BadKind,     ///< A frame type this build does not know.
-    BadLength,   ///< payload_bytes disagrees with point_count, or exceeds the sane cap.
+    kOk,
+    kIncomplete,  ///< Not enough bytes yet; wait for more.
+    kBadMagic,    ///< Not our stream, or the stream desynchronised.
+    kBadVersion,  ///< Producer and consumer disagree on the layout.
+    kBadKind,     ///< A frame type this build does not know.
+    kBadLength,   ///< payload_bytes disagrees with point_count, or exceeds the sane cap.
 };
 
 /// Refuses an object frame with more records than this. Same reasoning as kMaxPoints, at a
@@ -36,10 +37,10 @@ inline constexpr std::uint32_t kMaxObjects = 1024;
 /// What a validated frame turned out to be.
 enum class FrameKind
 {
-    PointCloud,
-    Depth,
-    ObjectPoses,
-    Imu,
+    kPointCloud,
+    kDepth,
+    kObjectPoses,
+    kImu,
 };
 
 /// A validated frame. `kind` says which payload interpretation applies: `points` is xyz
@@ -47,19 +48,19 @@ enum class FrameKind
 /// ground-truth body poses in the simulator's world frame.
 struct CloudFrame
 {
-    FrameKind          kind     = FrameKind::PointCloud;
+    FrameKind          kind     = FrameKind::kPointCloud;
     std::uint32_t      width    = 0;
     std::uint32_t      height   = 0;
-    float              fovy_deg = 0.0f;
+    float              fovy_deg = 0.0F;
     std::vector<float> depth;
     /// rgb8, row-major, top-down, same dimensions as `depth`. Empty when colour is off.
     std::vector<std::uint8_t>               rgb;
     double                                  sim_time_s = 0.0;
-    double                                  sensor_pos[3]{};
-    double                                  sensor_quat[4]{};
+    std::array<double, 3>                   sensor_pos{};
+    std::array<double, 4>                   sensor_quat{};
     std::vector<float>                      points;
     std::vector<grove_g1::ObjectPoseRecord> objects;
-    /// Rates at the sensor's own frame. Only meaningful on FrameKind::Imu, where the pose
+    /// Rates at the sensor's own frame. Only meaningful on FrameKind::kImu, where the pose
     /// fields above carry the IMU's attitude.
     grove_g1::ImuSampleRecord imu{};
 };
@@ -75,8 +76,8 @@ inline constexpr std::uint32_t kMaxPoints = 4'000'000;
 /**
  * @brief Attempts to take one frame from the front of `buffer`.
  *
- * On FrameStatus::Ok the consumed bytes are erased from `buffer` and `out` is filled. On
- * Incomplete nothing is consumed. On any other status the caller must drop the connection:
+ * On FrameStatus::kOk the consumed bytes are erased from `buffer` and `out` is filled. On
+ * kIncomplete nothing is consumed. On any other status the caller must drop the connection:
  * the stream cannot be resynchronised, and pretending otherwise turns a framing bug into
  * plausible-looking point clouds.
  */

--- a/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
+++ b/workspace/src/g1_sensor_relay/include/g1_sensor_relay/sensor_frame.h
@@ -12,6 +12,10 @@
 namespace grove_g1
 {
 
+// The enum spellings and C arrays below are the wire layout itself, fixed by the sizeof
+// assertions and shared with the simulator, so they are not ours to restyle.
+// NOLINTBEGIN(readability-identifier-naming,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
 // rather than reinterpreting bytes. v2 added the depth-image fields; v3 appends colour
 // to the depth payload; v4 adds the ObjectPoses kind; v5 gives its records a size; v6 adds
@@ -111,6 +115,8 @@ struct SensorFrameHeader
 };
 
 static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");
+
+// NOLINTEND(readability-identifier-naming,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 
 }  // namespace grove_g1
 

--- a/workspace/src/g1_sensor_relay/src/frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/src/frame_reader.cpp
@@ -12,7 +12,7 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
 
     if (buffer.size() < sizeof(SensorFrameHeader))
     {
-        return FrameStatus::Incomplete;
+        return FrameStatus::kIncomplete;
     }
 
     SensorFrameHeader header;
@@ -20,11 +20,11 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
 
     if (header.magic != grove_g1::kSensorFrameMagic)
     {
-        return FrameStatus::BadMagic;
+        return FrameStatus::kBadMagic;
     }
     if (header.version != grove_g1::kSensorFrameVersion)
     {
-        return FrameStatus::BadVersion;
+        return FrameStatus::kBadVersion;
     }
     const bool is_cloud   = header.kind == static_cast<std::uint32_t>(SensorFrameKind::PointCloud);
     const bool is_depth   = header.kind == static_cast<std::uint32_t>(SensorFrameKind::Depth);
@@ -32,23 +32,24 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     const bool is_imu     = header.kind == static_cast<std::uint32_t>(SensorFrameKind::Imu);
     if (!is_cloud && !is_depth && !is_objects && !is_imu)
     {
-        return FrameStatus::BadKind;
+        return FrameStatus::kBadKind;
     }
     // Every length is checked before it is trusted for anything: a desynchronised stream
     // otherwise reserves whatever garbage it read.
     if (is_cloud)
     {
         if (header.point_count > kMaxPoints ||
-            header.payload_bytes != header.point_count * 3u * sizeof(float))
+            header.payload_bytes !=
+                static_cast<std::size_t>(header.point_count) * 3U * sizeof(float))
         {
-            return FrameStatus::BadLength;
+            return FrameStatus::kBadLength;
         }
     }
     else if (is_imu)
     {
         if (header.payload_bytes != sizeof(grove_g1::ImuSampleRecord))
         {
-            return FrameStatus::BadLength;
+            return FrameStatus::kBadLength;
         }
     }
     else if (is_objects)
@@ -58,7 +59,7 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
         if (header.payload_bytes % sizeof(grove_g1::ObjectPoseRecord) != 0 ||
             header.payload_bytes / sizeof(grove_g1::ObjectPoseRecord) > kMaxObjects)
         {
-            return FrameStatus::BadLength;
+            return FrameStatus::kBadLength;
         }
     }
     else
@@ -68,30 +69,30 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
         const std::uint64_t expect =
             pixels * sizeof(float) + static_cast<std::uint64_t>(header.rgb_bytes);
         if (pixels == 0 || pixels > kMaxPoints || header.payload_bytes != expect ||
-            (header.rgb_bytes != 0 && header.rgb_bytes != pixels * 3u))
+            (header.rgb_bytes != 0 && header.rgb_bytes != pixels * 3U))
         {
-            return FrameStatus::BadLength;
+            return FrameStatus::kBadLength;
         }
     }
 
     const std::size_t total = sizeof(header) + header.payload_bytes;
     if (buffer.size() < total)
     {
-        return FrameStatus::Incomplete;
+        return FrameStatus::kIncomplete;
     }
 
     out.sim_time_s = header.sim_time_s;
-    std::memcpy(out.sensor_pos, header.sensor_pos, sizeof(out.sensor_pos));
-    std::memcpy(out.sensor_quat, header.sensor_quat, sizeof(out.sensor_quat));
+    std::memcpy(out.sensor_pos.data(), header.sensor_pos, sizeof(out.sensor_pos));
+    std::memcpy(out.sensor_quat.data(), header.sensor_quat, sizeof(out.sensor_quat));
     out.width    = header.width;
     out.height   = header.height;
     out.fovy_deg = header.fovy_deg;
     if (is_cloud)
     {
-        out.kind = FrameKind::PointCloud;
+        out.kind = FrameKind::kPointCloud;
         out.depth.clear();
         out.objects.clear();
-        out.points.resize(static_cast<std::size_t>(header.point_count) * 3u);
+        out.points.resize(static_cast<std::size_t>(header.point_count) * 3U);
         if (header.payload_bytes > 0)
         {
             std::memcpy(out.points.data(), buffer.data() + sizeof(header), header.payload_bytes);
@@ -99,7 +100,7 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     }
     else if (is_imu)
     {
-        out.kind = FrameKind::Imu;
+        out.kind = FrameKind::kImu;
         out.depth.clear();
         out.rgb.clear();
         out.points.clear();
@@ -108,7 +109,7 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     }
     else if (is_objects)
     {
-        out.kind = FrameKind::ObjectPoses;
+        out.kind = FrameKind::kObjectPoses;
         out.depth.clear();
         out.points.clear();
         out.objects.resize(header.payload_bytes / sizeof(grove_g1::ObjectPoseRecord));
@@ -125,7 +126,7 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     }
     else
     {
-        out.kind = FrameKind::Depth;
+        out.kind = FrameKind::kDepth;
         out.points.clear();
         out.objects.clear();
         const std::size_t px          = static_cast<std::size_t>(header.width) * header.height;
@@ -143,24 +144,24 @@ FrameStatus tryReadFrame(std::vector<std::uint8_t>& buffer, CloudFrame& out)
     }
 
     buffer.erase(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(total));
-    return FrameStatus::Ok;
+    return FrameStatus::kOk;
 }
 
 const char* toString(FrameStatus status)
 {
     switch (status)
     {
-        case FrameStatus::Ok:
+        case FrameStatus::kOk:
             return "ok";
-        case FrameStatus::Incomplete:
+        case FrameStatus::kIncomplete:
             return "incomplete";
-        case FrameStatus::BadMagic:
+        case FrameStatus::kBadMagic:
             return "bad magic (stream desynchronised or not ours)";
-        case FrameStatus::BadVersion:
+        case FrameStatus::kBadVersion:
             return "version mismatch between simulator and relay";
-        case FrameStatus::BadKind:
+        case FrameStatus::kBadKind:
             return "unknown frame kind";
-        case FrameStatus::BadLength:
+        case FrameStatus::kBadLength:
             return "payload length inconsistent with point count";
     }
     return "unknown";

--- a/workspace/src/g1_sensor_relay/src/g1_livox_bridge_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_livox_bridge_node.cpp
@@ -45,14 +45,14 @@ public:
         cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
             declare_parameter<std::string>("cloud_topic", "/livox/lidar"),
             rclcpp::SensorDataQoS(),
-            [this](sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) { onCloud(*msg); });
+            [this](const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg) { onCloud(*msg); });
     }
 
 private:
     void onCloud(const sensor_msgs::msg::PointCloud2& cloud)
     {
-        livox_ros_driver2::msg::CustomMsg msg;
-        if (!toCustomMsg(cloud, msg))
+        auto msg = std::make_unique<livox_ros_driver2::msg::CustomMsg>();
+        if (!toCustomMsg(cloud, *msg))
         {
             RCLCPP_WARN_THROTTLE(
                 get_logger(),

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -15,6 +15,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
 #include <cmath>
 #include <cstring>
@@ -28,6 +29,7 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <string>
+#include <system_error>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <utility>
 #include <vector>
@@ -140,6 +142,10 @@ public:
     }
 
 private:
+    /// std::strerror() keeps its message in a shared static buffer and is not thread-safe;
+    /// system_category().message() allocates a fresh std::string per call instead.
+    static std::string lastErrorMessage() { return std::system_category().message(errno); }
+
     bool openListener()
     {
         // A leftover socket file from a crashed run makes bind() fail with EADDRINUSE, and
@@ -149,7 +155,7 @@ private:
         listen_fd_ = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
         if (listen_fd_ < 0)
         {
-            RCLCPP_ERROR(get_logger(), "socket(): %s", std::strerror(errno));
+            RCLCPP_ERROR(get_logger(), "socket(): %s", lastErrorMessage().c_str());
             return false;
         }
         sockaddr_un addr{};
@@ -157,12 +163,16 @@ private:
         std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
         if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
         {
-            RCLCPP_ERROR(get_logger(), "bind(%s): %s", socket_path_.c_str(), std::strerror(errno));
+            RCLCPP_ERROR(
+                get_logger(),
+                "bind(%s): %s",
+                socket_path_.c_str(),
+                lastErrorMessage().c_str());
             return false;
         }
         if (::listen(listen_fd_, 1) != 0)
         {
-            RCLCPP_ERROR(get_logger(), "listen(): %s", std::strerror(errno));
+            RCLCPP_ERROR(get_logger(), "listen(): %s", lastErrorMessage().c_str());
             return false;
         }
         return true;
@@ -194,13 +204,13 @@ private:
         // Drain whatever is available, then publish every complete frame in it. Draining
         // fully matters: at 500 Hz polling against 10 Hz frames the socket is usually
         // empty, but after any hiccup several frames can be queued.
-        std::uint8_t chunk[65536];
+        std::array<std::uint8_t, 65536> chunk;
         for (;;)
         {
-            const ssize_t n = ::recv(client_fd_, chunk, sizeof(chunk), MSG_DONTWAIT);
+            const ssize_t n = ::recv(client_fd_, chunk.data(), chunk.size(), MSG_DONTWAIT);
             if (n > 0)
             {
-                buffer_.insert(buffer_.end(), chunk, chunk + n);
+                buffer_.insert(buffer_.end(), chunk.data(), chunk.data() + n);
                 continue;
             }
             if (n == 0)
@@ -213,7 +223,7 @@ private:
             {
                 break;
             }
-            RCLCPP_WARN(get_logger(), "recv(): %s", std::strerror(errno));
+            RCLCPP_WARN(get_logger(), "recv(): %s", lastErrorMessage().c_str());
             closeClient();
             return;
         }
@@ -225,11 +235,11 @@ private:
         for (;;)
         {
             const FrameStatus status = tryReadFrame(buffer_, frame);
-            if (status == FrameStatus::Incomplete)
+            if (status == FrameStatus::kIncomplete)
             {
                 return;
             }
-            if (status != FrameStatus::Ok)
+            if (status != FrameStatus::kOk)
             {
                 // Unrecoverable by design: a desynchronised stream cannot be realigned, and
                 // guessing would publish plausible-looking nonsense.
@@ -239,16 +249,16 @@ private:
             }
             switch (frame.kind)
             {
-                case FrameKind::Depth:
+                case FrameKind::kDepth:
                     publishDepth(frame);
                     break;
-                case FrameKind::ObjectPoses:
+                case FrameKind::kObjectPoses:
                     publishObjects(frame);
                     break;
-                case FrameKind::PointCloud:
+                case FrameKind::kPointCloud:
                     publish(frame);
                     break;
-                case FrameKind::Imu:
+                case FrameKind::kImu:
                     publishImu(frame);
                     break;
             }
@@ -260,26 +270,26 @@ private:
     /// consistent by construction rather than by two nodes agreeing about wall time.
     void publishImu(const CloudFrame& frame)
     {
-        sensor_msgs::msg::Imu imu;
-        imu.header.stamp    = stampFor(frame.sim_time_s);
-        imu.header.frame_id = imu_frame_id_;
+        auto imu             = std::make_unique<sensor_msgs::msg::Imu>();
+        imu->header.stamp    = stampFor(frame.sim_time_s);
+        imu->header.frame_id = imu_frame_id_;
 
         // MuJoCo's framequat is wxyz.
-        imu.orientation.w = frame.sensor_quat[0];
-        imu.orientation.x = frame.sensor_quat[1];
-        imu.orientation.y = frame.sensor_quat[2];
-        imu.orientation.z = frame.sensor_quat[3];
+        imu->orientation.w = frame.sensor_quat[0];
+        imu->orientation.x = frame.sensor_quat[1];
+        imu->orientation.y = frame.sensor_quat[2];
+        imu->orientation.z = frame.sensor_quat[3];
 
-        imu.angular_velocity.x = frame.imu.gyro[0];
-        imu.angular_velocity.y = frame.imu.gyro[1];
-        imu.angular_velocity.z = frame.imu.gyro[2];
+        imu->angular_velocity.x = frame.imu.gyro[0];
+        imu->angular_velocity.y = frame.imu.gyro[1];
+        imu->angular_velocity.z = frame.imu.gyro[2];
 
         // Proper acceleration, gravity included, which is what MuJoCo's accelerometer sensor
         // reports and what a real IMU reads. FAST-LIO normalises by the measured magnitude
         // during its init, so the units only have to be self-consistent.
-        imu.linear_acceleration.x = frame.imu.acc[0];
-        imu.linear_acceleration.y = frame.imu.acc[1];
-        imu.linear_acceleration.z = frame.imu.acc[2];
+        imu->linear_acceleration.x = frame.imu.acc[0];
+        imu->linear_acceleration.y = frame.imu.acc[1];
+        imu->linear_acceleration.z = frame.imu.acc[2];
 
         imu_pub_->publish(std::move(imu));
     }
@@ -300,15 +310,15 @@ private:
             return;
         }
 
-        vision_msgs::msg::Detection3DArray msg;
-        msg.header.stamp    = now();
-        msg.header.frame_id = color_frame_id_;
-        msg.detections.reserve(frame.objects.size());
+        auto msg             = std::make_unique<vision_msgs::msg::Detection3DArray>();
+        msg->header.stamp    = now();
+        msg->header.frame_id = color_frame_id_;
+        msg->detections.reserve(frame.objects.size());
 
         for (const grove_g1::ObjectPoseRecord& record : frame.objects)
         {
             vision_msgs::msg::Detection3D detection;
-            detection.header = msg.header;
+            detection.header = msg->header;
             detection.id     = record.name;
 
             vision_msgs::msg::ObjectHypothesisWithPose hypothesis;
@@ -335,7 +345,7 @@ private:
             detection.bbox.size.y = record.size[1];
             detection.bbox.size.z = record.size[2];
             detection.results.push_back(hypothesis);
-            msg.detections.push_back(std::move(detection));
+            msg->detections.push_back(std::move(detection));
         }
         objects_pub_->publish(std::move(msg));
     }
@@ -386,21 +396,21 @@ private:
 
     void publishDepth(const CloudFrame& frame)
     {
-        sensor_msgs::msg::Image img;
-        img.header.stamp    = now();
-        img.header.frame_id = depth_frame_id_;
-        img.height          = frame.height;
-        img.width           = frame.width;
+        auto img             = std::make_unique<sensor_msgs::msg::Image>();
+        img->header.stamp    = now();
+        img->header.frame_id = depth_frame_id_;
+        img->height          = frame.height;
+        img->width           = frame.width;
         // 32FC1 metres. The simulator linearises MuJoCo's non-linear depth buffer before
         // sending, so nothing downstream has to know about znear/zfar.
-        img.encoding     = "32FC1";
-        img.is_bigendian = 0;
-        img.step         = frame.width * sizeof(float);
-        img.data.resize(frame.depth.size() * sizeof(float));
-        std::memcpy(img.data.data(), frame.depth.data(), img.data.size());
+        img->encoding     = "32FC1";
+        img->is_bigendian = 0;
+        img->step         = frame.width * sizeof(float);
+        img->data.resize(frame.depth.size() * sizeof(float));
+        std::memcpy(img->data.data(), frame.depth.data(), img->data.size());
 
         sensor_msgs::msg::CameraInfo info;
-        info.header           = img.header;
+        info.header           = img->header;
         info.height           = frame.height;
         info.width            = frame.width;
         info.distortion_model = "plumb_bob";
@@ -414,10 +424,8 @@ private:
         info.r          = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
         info.p          = { f, 0, cx, 0, 0, f, cy, 0, 0, 0, 1, 0 };
 
-        // Captured before the move: the colour image below is stamped from it, and reading it
-        // back off a moved-from message would put the shared-timestamp guarantee at the mercy
-        // of how Image happens to move its header.
-        const auto render_stamp = img.header.stamp;
+        // Captured before publish: img is a null pointer afterwards, only ownership moves.
+        const auto render_stamp = img->header.stamp;
 
         depth_pub_->publish(std::move(img));
         depth_info_pub_->publish(info);
@@ -429,15 +437,15 @@ private:
 
         if (!frame.rgb.empty())
         {
-            sensor_msgs::msg::Image color;
-            color.header.stamp    = render_stamp;
-            color.header.frame_id = color_frame_id_;
-            color.height          = frame.height;
-            color.width           = frame.width;
-            color.encoding        = "rgb8";
-            color.is_bigendian    = 0;
-            color.step            = frame.width * 3;
-            color.data.assign(frame.rgb.begin(), frame.rgb.end());
+            auto color             = std::make_unique<sensor_msgs::msg::Image>();
+            color->header.stamp    = render_stamp;
+            color->header.frame_id = color_frame_id_;
+            color->height          = frame.height;
+            color->width           = frame.width;
+            color->encoding        = "rgb8";
+            color->is_bigendian    = 0;
+            color->step            = frame.width * 3;
+            color->data.assign(frame.rgb.begin(), frame.rgb.end());
             color_pub_->publish(std::move(color));
         }
     }
@@ -492,34 +500,34 @@ private:
 
     void publish(const CloudFrame& frame)
     {
-        sensor_msgs::msg::PointCloud2 msg;
+        auto msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
         // The capture instant, mapped onto this node's clock -- NOT arrival. See stampFor().
-        msg.header.stamp    = stampFor(frame.sim_time_s);
-        msg.header.frame_id = frame_id_;
+        msg->header.stamp    = stampFor(frame.sim_time_s);
+        msg->header.frame_id = frame_id_;
 
         const std::size_t points = frame.points.size() / 3;
-        msg.height               = 1;
-        msg.width                = static_cast<std::uint32_t>(points);
-        msg.is_bigendian         = false;
-        msg.is_dense             = false;
-        msg.point_step           = 12;
-        msg.row_step             = msg.point_step * msg.width;
+        msg->height              = 1;
+        msg->width               = static_cast<std::uint32_t>(points);
+        msg->is_bigendian        = false;
+        msg->is_dense            = false;
+        msg->point_step          = 12;
+        msg->row_step            = msg->point_step * msg->width;
 
-        msg.fields.resize(3);
-        const char* names[3] = { "x", "y", "z" };
+        msg->fields.resize(3);
+        const std::array<const char*, 3> names = { "x", "y", "z" };
         for (int i = 0; i < 3; ++i)
         {
-            msg.fields[i].name     = names[i];
-            msg.fields[i].offset   = static_cast<std::uint32_t>(i * 4);
-            msg.fields[i].datatype = sensor_msgs::msg::PointField::FLOAT32;
-            msg.fields[i].count    = 1;
+            msg->fields[i].name     = names[i];
+            msg->fields[i].offset   = static_cast<std::uint32_t>(i * 4);
+            msg->fields[i].datatype = sensor_msgs::msg::PointField::FLOAT32;
+            msg->fields[i].count    = 1;
         }
 
-        msg.data.resize(frame.points.size() * sizeof(float));
-        std::memcpy(msg.data.data(), frame.points.data(), msg.data.size());
+        msg->data.resize(frame.points.size() * sizeof(float));
+        std::memcpy(msg->data.data(), frame.points.data(), msg->data.size());
 
         geometry_msgs::msg::PoseStamped pose;
-        pose.header             = msg.header;
+        pose.header             = msg->header;
         pose.header.frame_id    = world_frame_id_;
         pose.pose.position.x    = frame.sensor_pos[0];
         pose.pose.position.y    = frame.sensor_pos[1];

--- a/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
+++ b/workspace/src/g1_sensor_relay/src/g1_sensor_relay_node.cpp
@@ -290,9 +290,8 @@ private:
     /// inside the sim-only boundary, so g1_object_pose_source and the skills below it run the
     /// same code on the robot.
     ///
-    /// Publishing world coordinates under a fixed-frame label instead is what this replaced,
-    /// and it is exact only while that frame IS the world. It stopped being true the moment
-    /// odom became an estimate, and the base approach then drove at a point 2 m from the cube.
+    /// A world coordinate under a fixed-frame label is only correct while that frame IS the
+    /// world, which stops holding the moment odom becomes an estimate rather than ground truth.
     void publishObjects(const CloudFrame& frame)
     {
         geometry_msgs::msg::TransformStamped world_to_camera;

--- a/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
+++ b/workspace/src/g1_sensor_relay/test/test_frame_reader.cpp
@@ -7,7 +7,12 @@
 
 #include "g1_sensor_relay/frame_reader.hpp"
 
-using namespace g1_sensor_relay;
+using g1_sensor_relay::CloudFrame;
+using g1_sensor_relay::FrameKind;
+using g1_sensor_relay::FrameStatus;
+using g1_sensor_relay::kMaxObjects;
+using g1_sensor_relay::kMaxPoints;
+using g1_sensor_relay::tryReadFrame;
 using grove_g1::SensorFrameHeader;
 
 namespace
@@ -16,20 +21,21 @@ namespace
 std::vector<std::uint8_t> makeFrame(std::uint32_t point_count, double sim_time = 1.5)
 {
     SensorFrameHeader header{};
-    header.magic          = grove_g1::kSensorFrameMagic;
-    header.version        = grove_g1::kSensorFrameVersion;
-    header.kind           = static_cast<std::uint32_t>(grove_g1::SensorFrameKind::PointCloud);
-    header.point_count    = point_count;
-    header.payload_bytes  = point_count * 3u * sizeof(float);
+    header.magic       = grove_g1::kSensorFrameMagic;
+    header.version     = grove_g1::kSensorFrameVersion;
+    header.kind        = static_cast<std::uint32_t>(grove_g1::SensorFrameKind::PointCloud);
+    header.point_count = point_count;
+    header.payload_bytes =
+        static_cast<std::uint32_t>(static_cast<std::size_t>(point_count) * 3U * sizeof(float));
     header.sim_time_s     = sim_time;
     header.sensor_pos[2]  = 1.26;
     header.sensor_quat[0] = 1.0;
 
     std::vector<std::uint8_t> bytes(sizeof(header) + header.payload_bytes);
     std::memcpy(bytes.data(), &header, sizeof(header));
-    for (std::uint32_t i = 0; i < point_count * 3u; ++i)
+    for (std::uint32_t i = 0; i < point_count * 3U; ++i)
     {
-        const float v = static_cast<float>(i);
+        const auto v = static_cast<float>(i);
         std::memcpy(bytes.data() + sizeof(header) + i * sizeof(float), &v, sizeof(float));
     }
     return bytes;
@@ -40,7 +46,7 @@ std::vector<std::uint8_t> makeFrame(std::uint32_t point_count, double sim_time =
 std::vector<std::uint8_t> makeDepthFrame(std::uint32_t w, std::uint32_t h, bool with_color)
 {
     const std::uint32_t pixels = w * h;
-    const std::uint32_t rgb    = with_color ? pixels * 3u : 0u;
+    const std::uint32_t rgb    = with_color ? pixels * 3U : 0U;
 
     SensorFrameHeader header{};
     header.magic          = grove_g1::kSensorFrameMagic;
@@ -48,7 +54,7 @@ std::vector<std::uint8_t> makeDepthFrame(std::uint32_t w, std::uint32_t h, bool 
     header.kind           = static_cast<std::uint32_t>(grove_g1::SensorFrameKind::Depth);
     header.width          = w;
     header.height         = h;
-    header.fovy_deg       = 58.0f;
+    header.fovy_deg       = 58.0F;
     header.rgb_bytes      = rgb;
     header.payload_bytes  = pixels * sizeof(float) + rgb;
     header.sim_time_s     = 2.5;
@@ -58,7 +64,7 @@ std::vector<std::uint8_t> makeDepthFrame(std::uint32_t w, std::uint32_t h, bool 
     std::memcpy(bytes.data(), &header, sizeof(header));
     for (std::uint32_t i = 0; i < pixels; ++i)
     {
-        const float d = 1.0f + static_cast<float>(i);
+        const float d = 1.0F + static_cast<float>(i);
         std::memcpy(bytes.data() + sizeof(header) + i * sizeof(float), &d, sizeof(float));
     }
     for (std::uint32_t i = 0; i < rgb; ++i)
@@ -128,11 +134,11 @@ TEST(FrameReader, ReadsAWholeFrameAndConsumesExactlyIt)
     const auto size  = bytes.size();
     CloudFrame frame;
 
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
     EXPECT_TRUE(bytes.empty()) << "consumed " << (size - bytes.size()) << " of " << size;
-    EXPECT_EQ(frame.points.size(), 12u);
+    EXPECT_EQ(frame.points.size(), 12U);
     EXPECT_DOUBLE_EQ(frame.sim_time_s, 1.5);
-    EXPECT_FLOAT_EQ(frame.points[11], 11.0f);
+    EXPECT_FLOAT_EQ(frame.points[11], 11.0F);
 }
 
 TEST(FrameReader, WaitsWhenTheFrameIsOnlyPartlyArrived)
@@ -143,9 +149,11 @@ TEST(FrameReader, WaitsWhenTheFrameIsOnlyPartlyArrived)
     // A stream socket splits writes anywhere; every prefix must be safe to retry.
     for (std::size_t n = 0; n < full.size(); ++n)
     {
-        std::vector<std::uint8_t> partial(full.begin(), full.begin() + n);
-        const auto                before = partial.size();
-        EXPECT_EQ(tryReadFrame(partial, frame), FrameStatus::Incomplete) << "at " << n << " bytes";
+        std::vector<std::uint8_t> partial(
+            full.begin(),
+            full.begin() + static_cast<std::ptrdiff_t>(n));
+        const auto before = partial.size();
+        EXPECT_EQ(tryReadFrame(partial, frame), FrameStatus::kIncomplete) << "at " << n << " bytes";
         EXPECT_EQ(partial.size(), before) << "consumed bytes from an incomplete frame";
     }
 }
@@ -157,13 +165,13 @@ TEST(FrameReader, ReadsBackToBackFramesFromOneBuffer)
     bytes.insert(bytes.end(), second.begin(), second.end());
 
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
     EXPECT_DOUBLE_EQ(frame.sim_time_s, 1.0);
-    EXPECT_EQ(frame.points.size(), 6u);
+    EXPECT_EQ(frame.points.size(), 6U);
 
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
     EXPECT_DOUBLE_EQ(frame.sim_time_s, 2.0);
-    EXPECT_EQ(frame.points.size(), 9u);
+    EXPECT_EQ(frame.points.size(), 9U);
     EXPECT_TRUE(bytes.empty());
 }
 
@@ -173,29 +181,30 @@ TEST(FrameReader, RejectsGarbageRatherThanGuessing)
 
     auto bad_magic = makeFrame(2);
     bad_magic[0] ^= 0xFF;
-    EXPECT_EQ(tryReadFrame(bad_magic, frame), FrameStatus::BadMagic);
+    EXPECT_EQ(tryReadFrame(bad_magic, frame), FrameStatus::kBadMagic);
 
     auto                bad_version = makeFrame(2);
     const std::uint32_t v           = grove_g1::kSensorFrameVersion + 1;
     std::memcpy(bad_version.data() + 4, &v, sizeof(v));
-    EXPECT_EQ(tryReadFrame(bad_version, frame), FrameStatus::BadVersion);
+    EXPECT_EQ(tryReadFrame(bad_version, frame), FrameStatus::kBadVersion);
 
     auto                bad_kind = makeFrame(2);
     const std::uint32_t k        = 99;
     std::memcpy(bad_kind.data() + 8, &k, sizeof(k));
-    EXPECT_EQ(tryReadFrame(bad_kind, frame), FrameStatus::BadKind);
+    EXPECT_EQ(tryReadFrame(bad_kind, frame), FrameStatus::kBadKind);
 }
 
 TEST(FrameReader, RefusesALengthThatDoesNotMatchThePointCount)
 {
     // The failure mode that matters: a desynchronised stream yields a plausible header whose
     // length is nonsense. Trusting it means allocating whatever it says.
-    auto                bytes = makeFrame(4);
-    const std::uint32_t lie   = 4u * 3u * sizeof(float) + 4u;
+    auto       bytes = makeFrame(4);
+    const auto lie =
+        static_cast<std::uint32_t>(static_cast<std::size_t>(4) * 3U * sizeof(float) + 4U);
     std::memcpy(bytes.data() + 12, &lie, sizeof(lie));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, RefusesAnAbsurdPointCountBeforeAllocating)
@@ -204,18 +213,19 @@ TEST(FrameReader, RefusesAnAbsurdPointCountBeforeAllocating)
     const std::uint32_t huge  = kMaxPoints + 1;
     std::memcpy(bytes.data() + 80, &huge, sizeof(huge));
     // Keep payload_bytes consistent so only the cap can reject it.
-    const std::uint32_t payload = huge * 3u * sizeof(float);
+    const auto payload =
+        static_cast<std::uint32_t>(static_cast<std::size_t>(huge) * 3U * sizeof(float));
     std::memcpy(bytes.data() + 12, &payload, sizeof(payload));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, HandlesAnEmptyCloud)
 {
     auto       bytes = makeFrame(0);
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
     EXPECT_TRUE(frame.points.empty());
 }
 
@@ -226,11 +236,13 @@ TEST(WireFormat, TheTwoCopiesOfSensorFrameAreIdentical)
     const char* ours   = "include/g1_sensor_relay/sensor_frame.h";
     const char* theirs = "../../vendor/unitree_mujoco/sensor_frame.h";
 
-    std::ifstream a(ours), b(theirs);
+    std::ifstream a(ours);
+    std::ifstream b(theirs);
     ASSERT_TRUE(a.is_open()) << "cannot open " << ours;
     ASSERT_TRUE(b.is_open()) << "cannot open " << theirs;
 
-    std::stringstream sa, sb;
+    std::stringstream sa;
+    std::stringstream sb;
     sa << a.rdbuf();
     sb << b.rdbuf();
     EXPECT_EQ(sa.str(), sb.str())
@@ -241,26 +253,26 @@ TEST(FrameReader, ReadsADepthFrameWithColour)
 {
     auto       bytes = makeDepthFrame(4, 3, /*with_color=*/true);
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
     EXPECT_TRUE(bytes.empty());
-    EXPECT_EQ(frame.kind, FrameKind::Depth);
-    EXPECT_EQ(frame.width, 4u);
-    EXPECT_EQ(frame.height, 3u);
-    EXPECT_EQ(frame.depth.size(), 12u);
-    EXPECT_EQ(frame.rgb.size(), 36u);
-    EXPECT_FLOAT_EQ(frame.depth.front(), 1.0f);
-    EXPECT_FLOAT_EQ(frame.depth.back(), 12.0f);
+    EXPECT_EQ(frame.kind, FrameKind::kDepth);
+    EXPECT_EQ(frame.width, 4U);
+    EXPECT_EQ(frame.height, 3U);
+    EXPECT_EQ(frame.depth.size(), 12U);
+    EXPECT_EQ(frame.rgb.size(), 36U);
+    EXPECT_FLOAT_EQ(frame.depth.front(), 1.0F);
+    EXPECT_FLOAT_EQ(frame.depth.back(), 12.0F);
     // The colour bytes must come from behind the depth floats, not overlap them.
-    EXPECT_EQ(frame.rgb.front(), 0u);
-    EXPECT_EQ(frame.rgb.back(), 35u);
+    EXPECT_EQ(frame.rgb.front(), 0U);
+    EXPECT_EQ(frame.rgb.back(), 35U);
 }
 
 TEST(FrameReader, ReadsADepthFrameWithoutColour)
 {
     auto       bytes = makeDepthFrame(4, 3, /*with_color=*/false);
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
-    EXPECT_EQ(frame.depth.size(), 12u);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
+    EXPECT_EQ(frame.depth.size(), 12U);
     EXPECT_TRUE(frame.rgb.empty());
 }
 
@@ -277,7 +289,7 @@ TEST(FrameReader, RefusesAnRgbLengthThatDoesNotMatchThePixelCount)
     std::memcpy(bytes.data(), &header, sizeof(header));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, RefusesAnAbsurdImageSizeBeforeAllocating)
@@ -292,17 +304,17 @@ TEST(FrameReader, RefusesAnAbsurdImageSizeBeforeAllocating)
     std::memcpy(bytes.data(), &header, sizeof(header));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, ReadsAnObjectPoseFrame)
 {
     auto       bytes = makeObjectFrame({ "red_cube", "green_cylinder" });
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
 
-    EXPECT_EQ(frame.kind, FrameKind::ObjectPoses);
-    ASSERT_EQ(frame.objects.size(), 2u);
+    EXPECT_EQ(frame.kind, FrameKind::kObjectPoses);
+    ASSERT_EQ(frame.objects.size(), 2U);
     EXPECT_STREQ(frame.objects[0].name, "red_cube");
     EXPECT_STREQ(frame.objects[1].name, "green_cylinder");
     EXPECT_DOUBLE_EQ(frame.objects[1].pos[0], 2.0);
@@ -324,7 +336,7 @@ TEST(FrameReader, RefusesAnObjectPayloadThatIsNotAWholeNumberOfRecords)
     std::memcpy(bytes.data(), &header, sizeof(header));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, RefusesAnAbsurdObjectCountBeforeAllocating)
@@ -333,11 +345,11 @@ TEST(FrameReader, RefusesAnAbsurdObjectCountBeforeAllocating)
     SensorFrameHeader header{};
     std::memcpy(&header, bytes.data(), sizeof(header));
     header.payload_bytes =
-        (kMaxObjects + 1u) * static_cast<std::uint32_t>(sizeof(grove_g1::ObjectPoseRecord));
+        (kMaxObjects + 1U) * static_cast<std::uint32_t>(sizeof(grove_g1::ObjectPoseRecord));
     std::memcpy(bytes.data(), &header, sizeof(header));
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }
 
 TEST(FrameReader, TerminatesAnObjectNameThatArrivesUnterminated)
@@ -351,8 +363,8 @@ TEST(FrameReader, TerminatesAnObjectNameThatArrivesUnterminated)
         sizeof(grove_g1::ObjectPoseRecord::name));
 
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
-    ASSERT_EQ(frame.objects.size(), 1u);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
+    ASSERT_EQ(frame.objects.size(), 1U);
     EXPECT_EQ(std::strlen(frame.objects[0].name), sizeof(grove_g1::ObjectPoseRecord::name) - 1);
 }
 
@@ -360,9 +372,9 @@ TEST(FrameReader, ReadsAnImuFrame)
 {
     auto       bytes = makeImuFrame();
     CloudFrame frame;
-    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::Ok);
+    ASSERT_EQ(tryReadFrame(bytes, frame), FrameStatus::kOk);
 
-    EXPECT_EQ(frame.kind, FrameKind::Imu);
+    EXPECT_EQ(frame.kind, FrameKind::kImu);
     EXPECT_DOUBLE_EQ(frame.imu.gyro[1], 0.5);
     EXPECT_DOUBLE_EQ(frame.imu.acc[2], 9.81);
     EXPECT_DOUBLE_EQ(frame.sim_time_s, 12.25);
@@ -384,5 +396,5 @@ TEST(FrameReader, RefusesAnImuPayloadOfTheWrongSize)
     bytes.resize(bytes.size() + 8);
 
     CloudFrame frame;
-    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::BadLength);
+    EXPECT_EQ(tryReadFrame(bytes, frame), FrameStatus::kBadLength);
 }

--- a/workspace/src/g1_sensor_relay/test/test_livox_custom_msg.cpp
+++ b/workspace/src/g1_sensor_relay/test/test_livox_custom_msg.cpp
@@ -9,6 +9,7 @@
  */
 #include <gmock/gmock.h>
 
+#include <array>
 #include <cmath>
 #include <vector>
 
@@ -32,7 +33,7 @@ sensor_msgs::msg::PointCloud2 cloudOf(const std::vector<std::array<float, 3>>& p
     cloud.point_step           = 12;
     cloud.row_step             = cloud.point_step * cloud.width;
     cloud.fields.resize(3);
-    const char* names[3] = { "x", "y", "z" };
+    const std::array<const char*, 3> names = { "x", "y", "z" };
     for (std::size_t i = 0; i < 3; ++i)
     {
         cloud.fields[i].name     = names[i];

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -119,8 +119,8 @@ if(BUILD_TESTING)
   # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
   find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
   set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
-  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
-  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
     add_test(
       NAME clang_tidy_check_g1_state_estimation
       COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
@@ -128,7 +128,7 @@ if(BUILD_TESTING)
     set_tests_properties(clang_tidy_check_g1_state_estimation PROPERTIES LABELS clang_tidy TIMEOUT 900)
   else()
     message(WARNING
-      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_state_estimation test")
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_state_estimation test")
   endif()
 endif()
 

--- a/workspace/src/g1_state_estimation/CMakeLists.txt
+++ b/workspace/src/g1_state_estimation/CMakeLists.txt
@@ -113,6 +113,23 @@ if(BUILD_TESTING)
     message(WARNING
       "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_state_estimation test")
   endif()
+
+  # clang-tidy over this package's own translation units, gated by WarningsAsErrors in the
+  # workspace .clang-tidy. Minutes rather than the format check's milliseconds, so it carries a
+  # label: `--ctest-args -LE clang_tidy` skips it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy-14 run-clang-tidy)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set(_clang_tidy_db "${CMAKE_BINARY_DIR}/compile_commands.json")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}" AND EXISTS "${_clang_tidy_db}")
+    add_test(
+      NAME clang_tidy_check_g1_state_estimation
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_state_estimation PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy, the workspace .clang-tidy or compile_commands.json not found; skipping clang_tidy_check_g1_state_estimation test")
+  endif()
 endif()
 
 ament_package()

--- a/workspace/src/g1_state_estimation/config/fastlio_mid360_sim.yaml
+++ b/workspace/src/g1_state_estimation/config/fastlio_mid360_sim.yaml
@@ -28,9 +28,8 @@
       lid_topic: "/livox/custom_msg"
       imu_topic: "/livox/imu"
       time_sync_en: false
-      # 0.0, same as the reference and as hardware. The sim's scan-stamp lag used to be
-      # compensated here; g1_sensor_relay now stamps clouds from the simulator's own capture
-      # time instead, so there is no residual offset to remove.
+      # 0.0, same as the reference and as hardware: g1_sensor_relay stamps clouds from the
+      # simulator's own capture time, so there is no residual lag here to compensate for.
       time_offset_lidar_to_imu: 0.0
 
     preprocess:

--- a/workspace/src/g1_state_estimation/config/g1_lio_debug.rviz
+++ b/workspace/src/g1_state_estimation/config/g1_lio_debug.rviz
@@ -81,7 +81,7 @@ Visualization Manager:
         Reliability Policy: Best Effort
         Value: /livox/lidar
       Value: true
-    # FAST-LIO's own registered cloud. Where THIS disagrees with the map walls is where the
+    # FAST-LIO's own registered cloud. Where this disagrees with the map walls is where the
     # scan match is losing it -- the most direct view of LIO health there is.
     - Alpha: 1
       Autocompute Intensity Bounds: true
@@ -160,8 +160,8 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /g1_odometry_publisher/odom
       Value: true
-    # Ground truth, straight from the simulator. Frame is `world`, which is NOT connected to
-    # odom -- so it will sit apart from the robot. That separation IS the reading: it is the
+    # Ground truth, straight from the simulator. Frame is `world`, which is not connected to
+    # odom -- so it will sit apart from the robot. That separation is the reading: it is the
     # accumulated LIO error, and it grows as the robot drives.
     - Alpha: 1
       Axes Length: 0.6

--- a/workspace/src/g1_state_estimation/config/g1_odometry_publisher_fastlio.yaml
+++ b/workspace/src/g1_state_estimation/config/g1_odometry_publisher_fastlio.yaml
@@ -28,11 +28,10 @@ g1_odometry_publisher:
     # the floor is.
     #
     # MEASURED on the standing robot: /sportmodestate reports 0.7504 m over 23k samples, with a
-    # spread of 0.2 mm. The old value here was a 0.793 nominal, 43 mm high, and that error is
-    # not cosmetic: the costmap's obstacle layer cuts the floor out at min_obstacle_height 0.08,
-    # so believing the pelvis -- and with it the LiDAR -- sits 43 mm high pushes floor returns
-    # most of the way over that cut before FAST-LIO's own drift is counted. The symptom is
-    # concentric rings of floor marked as obstacle and a planner that can find no path.
+    # spread of 0.2 mm. Getting this even a few centimetres high is not cosmetic: the costmap's
+    # obstacle layer cuts the floor out at min_obstacle_height 0.08, so an inflated pelvis
+    # height pushes floor returns toward that cut before FAST-LIO's own drift is even counted,
+    # and the symptom is concentric rings of floor marked as obstacle with no path found.
     #
     # Re-measure if the stance changes. It is a property of this robot's standing pose, not a
     # constant of the G1.

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -87,9 +87,9 @@ private:
     std::string odom_frame_id_;
     std::string base_frame_id_;
     /// Body link hung under base_frame_id_, carrying the height and tilt the footprint drops.
-    /// Empty publishes a single odom -> base_frame_id_ edge with the full pose, which is what the
-    /// planar sandbox wants: its base has no z DoF and cannot tilt, so the split would be an
-    /// identity edge and an extra frame for nothing.
+    /// Empty publishes a single odom -> base_frame_id_ edge with the full pose; naming a link
+    /// here splits it into a ground-projected edge plus a second edge carrying the height and
+    /// tilt (see GroundSplit).
     std::string pelvis_frame_id_;
     /// Frame the LiDAR odometry reports the pose OF -- FAST-LIO's `body`, which is its IMU.
     /// Empty means that frame already is the body this node publishes. It is `mid360_imu` on
@@ -106,9 +106,8 @@ private:
     std::array<double, 36> twist_covariance_{};
 
     PlanarPose pose_;
-    /// Height and full orientation. The planar track has neither (its body has no z
-    /// DoF and cannot tilt); a walking G1 has both, so they are carried separately
-    /// rather than forced through PlanarPose.
+    /// Height and full orientation, carried separately from PlanarPose: a walking G1 has both a
+    /// height and a tilt that a flat 2D pose cannot express.
     double     pose_z_ = 0.0;
     Quaternion orientation_;
     /// Set once a usable orientation has arrived. Until then nothing is published:

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/g1_odometry_publisher_node.hpp
@@ -50,9 +50,9 @@ private:
     /// Reads and validates every parameter. False means configure must fail.
     bool readParameters();
 
-    void onSportModeState(const unitree_go::msg::SportModeState::SharedPtr msg);
-    void onLowState(const unitree_hg::msg::LowState::SharedPtr msg);
-    void onLidarOdometry(const nav_msgs::msg::Odometry::SharedPtr msg);
+    void onSportModeState(const unitree_go::msg::SportModeState::SharedPtr& msg);
+    void onLowState(const unitree_hg::msg::LowState::SharedPtr& msg);
+    void onLidarOdometry(const nav_msgs::msg::Odometry::SharedPtr& msg);
     /// Latches odom_from_lio_ so the first LiDAR sample lands at a canonical start pose.
     /// False until the IMU has supplied a gravity-aligned attitude to level it against.
     bool latchLidarOrigin(const Pose3d& lio_from_base);
@@ -80,7 +80,7 @@ private:
     std::shared_ptr<tf2_ros::TransformListener>                              tf_listener_;
     rclcpp::TimerBase::SharedPtr                                             timer_;
 
-    OdometrySource source_ = OdometrySource::Hardware;
+    OdometrySource source_ = OdometrySource::kHardware;
     /// Topic the configured source actually reads. Held as a string because only one
     /// of the two subscriptions exists, and the other is null.
     std::string source_topic_;

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
@@ -98,7 +98,7 @@ Quaternion yawToQuaternion(double yaw);
  * Round-trip inverse of yawToQuaternion(); result is wrapped to (-pi, pi].
  *
  * The general form matters on the converged track. The short `2*atan2(z, w)` is exact only for
- * a pure +z rotation, which the planar sandbox's base always is and a walking G1 never is.
+ * a pure +z rotation, and a walking G1 is never that.
  */
 double quaternionToYaw(const Quaternion& q);
 

--- a/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
+++ b/workspace/src/g1_state_estimation/include/g1_state_estimation/odom_math.hpp
@@ -19,9 +19,9 @@ namespace g1_state_estimation
 /// Where the base pose comes from. Anything else is a configuration error.
 enum class OdometrySource
 {
-    SimSportModeState,  ///< The converged track: pelvis pose from /sportmodestate. Sim-only.
-    FastLio,            ///< LiDAR-inertial odometry. The only source that runs on the robot.
-    Hardware,           ///< Not a source: the real G1 publishes no odometry of its own.
+    kSimSportModeState,  ///< The converged track: pelvis pose from /sportmodestate. Sim-only.
+    kFastLio,            ///< LiDAR-inertial odometry. The only source that runs on the robot.
+    kHardware,           ///< Not a source: the real G1 publishes no odometry of its own.
 };
 
 /**

--- a/workspace/src/g1_state_estimation/scripts/lio_bench
+++ b/workspace/src/g1_state_estimation/scripts/lio_bench
@@ -13,9 +13,9 @@ first produced a pose, and the robot does not spawn at a repeatable heading. So 
 aligned ONCE, from the pose the robot is actually standing in when the run starts, and never
 touched again. Every gap after that is divergence accumulated since that instant.
 
-Aligning by a best fit over the whole path -- which this used to do -- reads lower and means
-less: it rotates part of the real error away and smears the rest evenly along the run, so no
-row of the table is the error at that point in the run.
+Aligning by a best fit over the whole path reads lower and means less: it rotates part of the
+real error away and smears the rest evenly along the run, so no row of the table is the error
+at that point in the run.
 """
 import csv
 import math, os, signal, sys, time
@@ -33,16 +33,15 @@ from g1_msgs.action import SetLocoMode
 VX, WZ = 0.5, 1.6
 # An arbitrary wander, not a figure. Comparing two estimates OF THE SAME MOTION does not
 # care what shape that motion is, so there is no controller here and nothing to tune -- the
-# gait just has to move the robot and turn it now and then. Three attempts at steering this
-# policy produced three different bugs; none of them made the comparison any more valid.
+# gait just has to move the robot and turn it now and then.
 # (vx, wz, seconds)
 LEGS = [(VX, 0.0, 8.0), (0.0, WZ, 1.0), (VX, 0.0, 6.0), (0.0, -WZ, 1.4),
         (VX, 0.0, 7.0), (0.0, WZ, 1.2), (VX, 0.0, 5.0), (0.0, -WZ, 1.0),
         (VX, 0.0, 8.0), (0.0, WZ, 1.6), (VX, 0.0, 6.0)]
 # Standing pelvis height is 0.750 m (measured). Below this the robot is on the floor, and every
 # number after that point describes a fallen robot being dragged by a flailing gait rather than
-# the odometry under test. One run reported 73000 % drift that way and it read as an estimator
-# failure. Abort instead.
+# the odometry under test -- a huge drift number that has nothing to do with the estimator.
+# Abort instead.
 MIN_PELVIS_Z = 0.55
 # The robot does not always arrive at its spawn pose quietly: some launches lurch, some go over
 # entirely, and the heading it settles on varies by ten degrees or more between runs. A run that

--- a/workspace/src/g1_state_estimation/src/g1_livox_pointcloud_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_livox_pointcloud_node.cpp
@@ -45,14 +45,16 @@ public:
         custom_sub_ = create_subscription<livox_ros_driver2::msg::CustomMsg>(
             declare_parameter<std::string>("custom_msg_topic", "/livox/custom_msg"),
             rclcpp::QoS(20),
-            [this](livox_ros_driver2::msg::CustomMsg::ConstSharedPtr msg) { onCustom(*msg); });
+            [this](const livox_ros_driver2::msg::CustomMsg::ConstSharedPtr& msg) {
+                onCustom(*msg);
+            });
     }
 
 private:
     void onCustom(const livox_ros_driver2::msg::CustomMsg& custom)
     {
-        sensor_msgs::msg::PointCloud2 cloud;
-        toPointCloud2(custom, cloud);
+        auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+        toPointCloud2(custom, *cloud);
         cloud_pub_->publish(std::move(cloud));
     }
 

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -29,8 +29,8 @@ G1OdometryPublisher::G1OdometryPublisher(const rclcpp::NodeOptions& options)
     // REP-105: gravity-aligned and on the ground. Nav2's robot_base_frame and slam_toolbox's
     // base_frame both default to a frame like this, and a 2D costmap has nowhere to put tilt.
     declare_parameter<std::string>("base_frame_id", "base_footprint");
-    // Empty means one edge carrying the full pose; naming a link splits it in two. See the
-    // member's comment for why the planar sandbox leaves it empty.
+    // Empty means one edge carrying the full pose; naming a link splits it in two (see
+    // GroundSplit).
     declare_parameter<std::string>("pelvis_frame_id", "");
     declare_parameter<double>("max_tilt_deg", 80.0);
     // Empty means the LiDAR odometry already reports the frame this node publishes.
@@ -514,8 +514,8 @@ void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState
 
 void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr msg)
 {
-    // Full orientation, unlike the planar track: a walking robot rolls and pitches, and
-    // flattening that to yaw would tilt every sensor frame hanging off the base.
+    // Full orientation: a walking robot rolls and pitches, and flattening that to yaw would
+    // tilt every sensor frame hanging off the base.
     const Quaternion q{ msg->imu_state.quaternion[1],
                         msg->imu_state.quaternion[2],
                         msg->imu_state.quaternion[3],

--- a/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/src/g1_odometry_publisher_node.cpp
@@ -64,7 +64,7 @@ bool G1OdometryPublisher::readParameters()
         return false;
     }
 
-    if (source_ == OdometrySource::Hardware)
+    if (source_ == OdometrySource::kHardware)
     {
         // Deliberately long. Anyone hitting this needs to know the topic they are about to
         // go looking for does not carry what they think it does.
@@ -148,32 +148,35 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
     {
         odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("~/odom", rclcpp::QoS(10));
     }
-    if (source_ == OdometrySource::SimSportModeState)
+    // Every callback below takes its SharedPtr by value because rclcpp offers no const-ref
+    // dispatch for a mutable pointee; the handlers they forward to do take const-ref.
+    // NOLINTBEGIN(performance-unnecessary-value-param)
+    if (source_ == OdometrySource::kSimSportModeState)
     {
         sport_state_sub_ = create_subscription<unitree_go::msg::SportModeState>(
             "~/sport_state",
             baseStateQos(),
-            std::bind(&G1OdometryPublisher::onSportModeState, this, std::placeholders::_1));
+            [this](unitree_go::msg::SportModeState::SharedPtr msg) { onSportModeState(msg); });
         // Orientation comes from /lowstate, not /sportmodestate: unitree_mujoco leaves the
         // latter's imu_state at all zeros, and tf2 normalises a zero quaternion straight to
         // NaN, which it then silently drops.
         low_state_sub_ = create_subscription<unitree_hg::msg::LowState>(
             "~/imu_state",
             baseStateQos(),
-            std::bind(&G1OdometryPublisher::onLowState, this, std::placeholders::_1));
+            [this](unitree_hg::msg::LowState::SharedPtr msg) { onLowState(msg); });
     }
     else
     {
         lidar_odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
             "~/lidar_odometry",
             baseStateQos(),
-            std::bind(&G1OdometryPublisher::onLidarOdometry, this, std::placeholders::_1));
+            [this](nav_msgs::msg::Odometry::SharedPtr msg) { onLidarOdometry(msg); });
         // The attitude is needed once, to level the odom frame at the latch: the LiDAR
         // odometry's own start frame is wherever its IMU was pointing, which is not gravity.
         low_state_sub_ = create_subscription<unitree_hg::msg::LowState>(
             "~/imu_state",
             baseStateQos(),
-            std::bind(&G1OdometryPublisher::onLowState, this, std::placeholders::_1));
+            [this](unitree_hg::msg::LowState::SharedPtr msg) { onLowState(msg); });
 
         if (!lidar_body_frame_id_.empty())
         {
@@ -181,13 +184,14 @@ G1OdometryPublisher::on_configure(const rclcpp_lifecycle::State&)
             tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, false);
         }
     }
+    // NOLINTEND(performance-unnecessary-value-param)
 
     source_topic_ =
         sport_state_sub_ ? sport_state_sub_->get_topic_name() : lidar_odom_sub_->get_topic_name();
     const std::string chain = pelvis_frame_id_.empty() ? odom_frame_id_ + " -> " + base_frame_id_ :
                                                          odom_frame_id_ + " -> " + base_frame_id_ +
                                                              " -> " + pelvis_frame_id_;
-    if (source_ == OdometrySource::SimSportModeState)
+    if (source_ == OdometrySource::kSimSportModeState)
     {
         RCLCPP_INFO(
             get_logger(),
@@ -239,9 +243,10 @@ G1OdometryPublisher::on_activate(const rclcpp_lifecycle::State& previous_state)
         return base_result;
     }
     const auto period = std::chrono::duration<double>(1.0 / publish_rate_hz_);
-    timer_            = create_wall_timer(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-        std::bind(&G1OdometryPublisher::onTimer, this));
+    timer_ =
+        create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(period), [this] {
+            onTimer();
+        });
     return CallbackReturn::SUCCESS;
 }
 
@@ -354,7 +359,7 @@ bool G1OdometryPublisher::latchLidarOrigin(const Pose3d& lio_from_base)
     return true;
 }
 
-void G1OdometryPublisher::onLidarOdometry(const nav_msgs::msg::Odometry::SharedPtr msg)
+void G1OdometryPublisher::onLidarOdometry(const nav_msgs::msg::Odometry::SharedPtr& msg)
 {
     if (!lookUpLidarBodyOffset())
     {
@@ -483,7 +488,7 @@ void G1OdometryPublisher::applyOrientation(const Quaternion& q)
     last_orientation_wall_ = std::chrono::steady_clock::now();
 }
 
-void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState::SharedPtr msg)
+void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState::SharedPtr& msg)
 {
     // The converged track's ground truth. unitree_mujoco fills position and velocity from
     // framepos/framelinvel on the pelvis imu site, so this is exact MuJoCo state, not an
@@ -512,7 +517,7 @@ void G1OdometryPublisher::onSportModeState(const unitree_go::msg::SportModeState
     noteSample(now());
 }
 
-void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr msg)
+void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr& msg)
 {
     // Full orientation: a walking robot rolls and pitches, and flattening that to yaw would
     // tilt every sensor frame hanging off the base.
@@ -544,7 +549,7 @@ void G1OdometryPublisher::onLowState(const unitree_hg::msg::LowState::SharedPtr 
     // For fast_lio this stream levels the odom frame at the latch and then stays on as the
     // gravity reference levelledAttitude() corrects roll and pitch against. Heading is never
     // taken from it: that comes from the LiDAR solution, which is what does not drift.
-    if (source_ == OdometrySource::SimSportModeState)
+    if (source_ == OdometrySource::kSimSportModeState)
     {
         applyOrientation(imu_orientation_);
     }
@@ -565,7 +570,7 @@ void G1OdometryPublisher::noteSample(const rclcpp::Time& stamp)
 
 void G1OdometryPublisher::onTimer()
 {
-    if (source_ == OdometrySource::SimSportModeState && !have_orientation_)
+    if (source_ == OdometrySource::kSimSportModeState && !have_orientation_)
     {
         RCLCPP_WARN_THROTTLE(
             get_logger(),
@@ -588,7 +593,7 @@ void G1OdometryPublisher::onTimer()
     // Sim time alone cannot see a wedged simulator: /clock comes from the same process as
     // the base state, so it freezes too and `elapsed` stays at zero. Hence the wall budget.
     const double elapsed = (now() - last_sample_stamp_).seconds();
-    if (source_ == OdometrySource::SimSportModeState)
+    if (source_ == OdometrySource::kSimSportModeState)
     {
         const double orientation_age =
             std::chrono::duration<double>(std::chrono::steady_clock::now() - last_orientation_wall_)

--- a/workspace/src/g1_state_estimation/src/odom_math.cpp
+++ b/workspace/src/g1_state_estimation/src/odom_math.cpp
@@ -11,17 +11,17 @@ bool parseOdometrySource(const std::string& name, OdometrySource& out)
 {
     if (name == "sim_sportmodestate")
     {
-        out = OdometrySource::SimSportModeState;
+        out = OdometrySource::kSimSportModeState;
         return true;
     }
     if (name == "fast_lio")
     {
-        out = OdometrySource::FastLio;
+        out = OdometrySource::kFastLio;
         return true;
     }
     if (name == "hardware")
     {
-        out = OdometrySource::Hardware;
+        out = OdometrySource::kHardware;
         return true;
     }
     return false;

--- a/workspace/src/g1_state_estimation/test/test_odom_math.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odom_math.cpp
@@ -43,8 +43,8 @@ TEST(ParseOdometrySource, AcceptsEveryKnownName)
 TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
 {
     // A typo must not silently become a working source, which would fabricate transforms.
-    // sim_ground_truth is in the list because it used to BE one: the planar sandbox it read
-    // is gone, and a stale config naming it has to fail rather than quietly pick something.
+    // sim_ground_truth is in the list because it named a source this node no longer has: a
+    // stale config still naming it has to fail rather than quietly pick something else.
     OdometrySource source = OdometrySource::SimSportModeState;
     for (const char* name : { "",
                               "sim",

--- a/workspace/src/g1_state_estimation/test/test_odom_math.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odom_math.cpp
@@ -29,15 +29,15 @@ constexpr double kTol = 1e-12;
 
 TEST(ParseOdometrySource, AcceptsEveryKnownName)
 {
-    OdometrySource source = OdometrySource::Hardware;
+    OdometrySource source = OdometrySource::kHardware;
     ASSERT_TRUE(parseOdometrySource("sim_sportmodestate", source));
-    EXPECT_EQ(source, OdometrySource::SimSportModeState);
+    EXPECT_EQ(source, OdometrySource::kSimSportModeState);
 
     ASSERT_TRUE(parseOdometrySource("fast_lio", source));
-    EXPECT_EQ(source, OdometrySource::FastLio);
+    EXPECT_EQ(source, OdometrySource::kFastLio);
 
     ASSERT_TRUE(parseOdometrySource("hardware", source));
-    EXPECT_EQ(source, OdometrySource::Hardware);
+    EXPECT_EQ(source, OdometrySource::kHardware);
 }
 
 TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
@@ -45,7 +45,7 @@ TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
     // A typo must not silently become a working source, which would fabricate transforms.
     // sim_ground_truth is in the list because it named a source this node no longer has: a
     // stale config still naming it has to fail rather than quietly pick something else.
-    OdometrySource source = OdometrySource::SimSportModeState;
+    OdometrySource source = OdometrySource::kSimSportModeState;
     for (const char* name : { "",
                               "sim",
                               "sim_ground_truth",
@@ -57,14 +57,15 @@ TEST(ParseOdometrySource, RejectsAnythingElseAndLeavesTheOutputAlone)
                               "sim_sportmode" })
     {
         EXPECT_FALSE(parseOdometrySource(name, source)) << "accepted " << name;
-        EXPECT_EQ(source, OdometrySource::SimSportModeState);
+        EXPECT_EQ(source, OdometrySource::kSimSportModeState);
     }
 }
 
 TEST(YawQuaternion, RoundTripsOverTheFullCircle)
 {
-    for (double yaw = -M_PI + 1e-6; yaw < M_PI; yaw += 0.1)
+    for (int i = 0; - M_PI + 1e-6 + i * 0.1 < M_PI; ++i)
     {
+        const double yaw = -M_PI + 1e-6 + i * 0.1;
         EXPECT_NEAR(quaternionToYaw(yawToQuaternion(yaw)), yaw, 1e-9) << "yaw " << yaw;
     }
 }
@@ -130,8 +131,9 @@ TEST(ToBodyTwist, PreservesSpeedAndYawRate)
 {
     const PlanarTwist world{ 0.3, -0.7, 0.9 };
     const double      world_speed = std::hypot(world.vx, world.vy);
-    for (double yaw = -3.0; yaw < 3.0; yaw += 0.37)
+    for (int i = 0; - 3.0 + i * 0.37 < 3.0; ++i)
     {
+        const double      yaw  = -3.0 + i * 0.37;
         const PlanarTwist body = toBodyTwist(world, yaw);
         EXPECT_NEAR(std::hypot(body.vx, body.vy), world_speed, 1e-12) << "yaw " << yaw;
         EXPECT_NEAR(body.omega, world.omega, kTol) << "yaw rate is frame independent";
@@ -188,9 +190,10 @@ TEST(QuaternionToYaw, IgnoresRollAndPitch)
     // The measured standing attitude on the converged track: a few degrees of
     // pitch under a real heading. The old 2*atan2(z, w) form was exact only at
     // zero tilt.
-    for (double yaw = -3.0; yaw < 3.0; yaw += 0.41)
+    for (int i = 0; - 3.0 + i * 0.41 < 3.0; ++i)
     {
-        const Quaternion q = rpyToQuaternion(0.0, 0.0794, yaw);
+        const double     yaw = -3.0 + i * 0.41;
+        const Quaternion q   = rpyToQuaternion(0.0, 0.0794, yaw);
         EXPECT_NEAR(quaternionToYaw(q), wrapAngle(yaw), 1e-9) << "yaw " << yaw;
     }
 }
@@ -222,13 +225,16 @@ TEST(SplitGroundProjection, FootprintIsGravityAlignedAndTheOffsetIsPurelyVertica
 
 TEST(SplitGroundProjection, RecomposesToTheOriginalPose)
 {
-    for (double roll = -0.4; roll <= 0.4; roll += 0.19)
+    for (int ir = 0; - 0.4 + ir * 0.19 <= 0.4; ++ir)
     {
-        for (double pitch = -0.4; pitch <= 0.4; pitch += 0.19)
+        const double roll = -0.4 + ir * 0.19;
+        for (int ip = 0; - 0.4 + ip * 0.19 <= 0.4; ++ip)
         {
-            for (double yaw = -3.0; yaw < 3.0; yaw += 0.91)
+            const double pitch = -0.4 + ip * 0.19;
+            for (int iy = 0; - 3.0 + iy * 0.91 < 3.0; ++iy)
             {
-                const Quaternion  q = rpyToQuaternion(roll, pitch, yaw);
+                const double      yaw = -3.0 + iy * 0.91;
+                const Quaternion  q   = rpyToQuaternion(roll, pitch, yaw);
                 const GroundSplit split =
                     splitGroundProjection(1.5, 2.5, 0.75, q, quaternionToYaw(q));
                 const Quaternion recomposed =

--- a/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
@@ -567,8 +567,8 @@ TEST(OdometryPublisherSimTime, StopsPublishingWhenSimTimeItselfFreezes)
 
 // --- Converged track: the split chain and the tilt guard ------------------------------------
 //
-// The planar suites above never reach this code. sim_sportmodestate is the only source that
-// publishes two edges, and the tilt guard lives on a callback only that source subscribes to.
+// The suites above never reach this code: sim_sportmodestate is the only source that publishes
+// two edges, and the tilt guard lives on a callback only that source subscribes to.
 
 TEST(OdometryPublisherConverged, PublishesTheSplitChainWithOneStamp)
 {

--- a/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
+++ b/workspace/src/g1_state_estimation/test/test_odometry_publisher_node.cpp
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -161,11 +162,13 @@ public:
         tf_sub_ = helper_->create_subscription<tf2_msgs::msg::TFMessage>(
             "/tf",
             rclcpp::QoS(200),
-            [this](tf2_msgs::msg::TFMessage::SharedPtr msg) { batches.push_back(msg->transforms); });
+            [this](const tf2_msgs::msg::TFMessage::ConstSharedPtr& msg) {
+                batches.push_back(msg->transforms);
+            });
         odom_sub_ = helper_->create_subscription<nav_msgs::msg::Odometry>(
             "/g1_odometry_publisher/odom",
             rclcpp::QoS(200),
-            [this](nav_msgs::msg::Odometry::SharedPtr msg) { odoms.push_back(*msg); });
+            [this](const nav_msgs::msg::Odometry::ConstSharedPtr& msg) { odoms.push_back(*msg); });
         nodes_ = { node_->get_node_base_interface(), helper_->get_node_base_interface() };
         spinFor(nodes_, 200ms);
     }
@@ -187,6 +190,8 @@ public:
     std::optional<geometry_msgs::msg::TransformStamped>
     latest(const std::string& parent, const std::string& child) const
     {
+        // std::ranges::reverse_view breaks clang-tidy's Clang-14 parser against libstdc++ here.
+        // NOLINTNEXTLINE(modernize-loop-convert)
         for (auto batch = batches.rbegin(); batch != batches.rend(); ++batch)
         {
             for (const auto& tf : *batch)
@@ -246,12 +251,15 @@ private:
     {
         if (instance_ != nullptr)
         {
+            // va_copy is required here: previous_ below still needs an unconsumed *args.
             va_list copy;
+            // NOLINTNEXTLINE(clang-analyzer-valist.Uninitialized)
             va_copy(copy, *args);
-            char buffer[1024];
-            vsnprintf(buffer, sizeof(buffer), format, copy);
+            std::array<char, 1024> buffer;
+            // Truncation is fine here: this only has to be long enough to find the needle in.
+            (void)vsnprintf(buffer.data(), buffer.size(), format, copy);
             va_end(copy);
-            if (std::string(buffer).find(instance_->needle_) != std::string::npos)
+            if (std::string(buffer.data()).find(instance_->needle_) != std::string::npos)
             {
                 ++instance_->count_;
             }
@@ -265,9 +273,13 @@ private:
     std::string                      needle_;
     int                              count_    = 0;
     rcutils_logging_output_handler_t previous_ = nullptr;
-    static LogCapture*               instance_;
+    // Mutable and static because rcutils_logging_set_output_handler takes a bare function
+    // pointer, so this is the only route from the handler back to the instance.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    static LogCapture* instance_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 LogCapture* LogCapture::instance_ = nullptr;
 
 /// Drives a fast_lio node with a LiDAR pose and an attitude, and collects what comes out.
@@ -288,13 +300,13 @@ public:
         tf_sub_ = helper_->create_subscription<tf2_msgs::msg::TFMessage>(
             "/tf",
             rclcpp::QoS(200),
-            [this](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+            [this](const tf2_msgs::msg::TFMessage::ConstSharedPtr& msg) {
                 transforms.insert(transforms.end(), msg->transforms.begin(), msg->transforms.end());
             });
         odom_sub_ = helper_->create_subscription<nav_msgs::msg::Odometry>(
             "/g1_odometry_publisher/odom",
             rclcpp::QoS(200),
-            [this](nav_msgs::msg::Odometry::SharedPtr msg) { odoms.push_back(*msg); });
+            [this](const nav_msgs::msg::Odometry::ConstSharedPtr& msg) { odoms.push_back(*msg); });
         nodes_ = { node_->get_node_base_interface(), helper_->get_node_base_interface() };
         spinFor(nodes_, 200ms);
     }
@@ -341,8 +353,8 @@ TEST(OdometryPublisherHardwareBranch, ConfigureFailsAndCreatesNothing)
 
     // The point of failing in on_configure rather than at first tick. Advertising /tf and
     // then never publishing is the silent mode this node exists to rule out.
-    EXPECT_EQ(node->count_publishers("/tf"), 0u) << "a /tf publisher was created anyway";
-    EXPECT_EQ(node->count_publishers("/g1_odometry_publisher/odom"), 0u)
+    EXPECT_EQ(node->count_publishers("/tf"), 0U) << "a /tf publisher was created anyway";
+    EXPECT_EQ(node->count_publishers("/g1_odometry_publisher/odom"), 0U)
         << "an odom publisher was created anyway";
 }
 
@@ -360,7 +372,7 @@ TEST(OdometryPublisherHardwareBranch, UnknownSourceAlsoFailsToConfigure)
     auto node = std::make_shared<G1OdometryPublisher>(optionsWithSource("sim_ground_truth"));
     EXPECT_EQ(node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
         << "a typo must not fall back to a working source";
-    EXPECT_EQ(node->count_publishers("/tf"), 0u);
+    EXPECT_EQ(node->count_publishers("/tf"), 0U);
 }
 
 // --- fast_lio: the latch, and the odometry built on top of it -------------------------------
@@ -404,7 +416,10 @@ TEST(OdometryPublisherFastLio, LatchesTheOriginThenReportsMotionRelativeToIt)
     // A deliberately non-trivial start pose. In practice FAST-LIO's first sample is the
     // identity, since its start frame IS the body frame at init -- which would let a broken
     // composition pass by doing nothing at all.
-    const double start_x = 0.4, start_y = -0.2, start_z = 0.05, start_yaw = 0.6;
+    const double start_x   = 0.4;
+    const double start_y   = -0.2;
+    const double start_z   = 0.05;
+    const double start_yaw = 0.6;
     harness.feed(start_x, start_y, start_z, start_yaw);
     harness.spin(100ms);
 
@@ -515,7 +530,7 @@ TEST(OdometryPublisherSimTime, StopsPublishingWhenSimTimeItselfFreezes)
     auto        tf_sub          = helper->create_subscription<tf2_msgs::msg::TFMessage>(
         "/tf",
         rclcpp::QoS(100),
-        [&transform_count](tf2_msgs::msg::TFMessage::SharedPtr msg) {
+        [&transform_count](const tf2_msgs::msg::TFMessage::ConstSharedPtr& msg) {
             transform_count += msg->transforms.size();
         });
 
@@ -537,7 +552,7 @@ TEST(OdometryPublisherSimTime, StopsPublishingWhenSimTimeItselfFreezes)
         lio_pub->publish(makeLidarOdometry(sim_now, 0.01 * i, 0.0, 0.0, 0.0));
         spinFor(nodes, 20ms);
     }
-    ASSERT_GT(transform_count, 0u) << "never published while sim time was advancing";
+    ASSERT_GT(transform_count, 0U) << "never published while sim time was advancing";
 
     // Now the simulator wedges: /clock stops AND the stamp stops advancing, but samples
     // keep arriving, so the node still has fresh-looking data on a frozen clock. Wall time
@@ -578,7 +593,10 @@ TEST(OdometryPublisherConverged, PublishesTheSplitChainWithOneStamp)
 
     ConvergedHarness harness(node, "converged_split_helper");
     // A walking attitude: a few degrees of roll and pitch under a real heading.
-    const double roll = -0.05, pitch = 0.0847, yaw = 1.2, height = 0.758;
+    const double roll   = -0.05;
+    const double pitch  = 0.0847;
+    const double yaw    = 1.2;
+    const double height = 0.758;
     harness.feed(3.0, -4.0, height, roll, pitch, yaw);
 
     const auto foot = harness.latest("odom", "base_footprint");
@@ -741,6 +759,8 @@ TEST(OdometryPublisherConverged, RejectsAFrameChainThatCannotExist)
 int main(int argc, char** argv)
 {
     // Isolated domain: a running sim on the default domain must not be able to feed this.
+    // Before any node or thread exists, so the thread-safety this warns about does not apply.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     setenv("ROS_DOMAIN_ID", "77", 1);
     ::testing::InitGoogleMock(&argc, argv);
     rclcpp::init(argc, argv);

--- a/workspace/vendor/unitree_mujoco/sensor_frame.h
+++ b/workspace/vendor/unitree_mujoco/sensor_frame.h
@@ -12,6 +12,10 @@
 namespace grove_g1
 {
 
+// The enum spellings and C arrays below are the wire layout itself, fixed by the sizeof
+// assertions and shared with the simulator, so they are not ours to restyle.
+// NOLINTBEGIN(readability-identifier-naming,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+
 // Bumped whenever the layout below changes. The relay refuses a frame it does not know
 // rather than reinterpreting bytes. v2 added the depth-image fields; v3 appends colour
 // to the depth payload; v4 adds the ObjectPoses kind; v5 gives its records a size; v6 adds
@@ -111,6 +115,8 @@ struct SensorFrameHeader
 };
 
 static_assert(sizeof(SensorFrameHeader) == 104, "wire layout changed; bump kSensorFrameVersion");
+
+// NOLINTEND(readability-identifier-naming,cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 
 }  // namespace grove_g1
 


### PR DESCRIPTION
Three commits, readable in order.

**Comments.** Trims over-explained commentary across the packages. Text only, no code touched.

**C++.** Publishes through `unique_ptr` so intra-process handoff moves rather than copies, takes
read-only callback and action-server arguments by const reference, and makes narrowing
conversions explicit. The one behavioural change: `std::signal` is now checked in the two
executables that release locomotion and arm authority, and both mains catch, so a failed handler
install or an escaping exception cannot exit while still holding authority.

**Tooling.** `.clang-tidy` existed but nothing ran it. Every C++ package now has a
`clang_tidy_check_*` test beside its `clang_format_check_*`, with `WarningsAsErrors` making a
finding fail the build. The workspace is at zero findings, so anything new is a regression.
Config fixes found on the way there: one half of an alias pair was still enabled though the
other was deliberately off, and static/const members had no naming rule.

CI needs no workflow change — it already runs `colcon test`. It does add roughly 13 minutes,
since CI runs sequentially. Locally, skip it with `--ctest-args -LE 'simulator|clang_tidy'`.

Simulator suites not run here; CI cannot run them either.