### PR TITLE
Port the hardware interfaces to the Jazzy ros2_control API, and default to fast_lio odometry

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,7 +40,6 @@ Checks: '
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-avoid-magic-numbers,
   -misc-include-cleaner,
-  -clang-diagnostic-deprecated-declarations,
   -readability-redundant-member-init,
   -misc-const-correctness,
   -bugprone-unchecked-optional-access,

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -202,9 +202,7 @@ def _setup(context, *args, **kwargs):
     sim_args = {
         # Not optional on the navigation modes, whatever the operator asked for: sensors gates
         # the LiDAR sweep, the relay, the odom -> base_footprint -> pelvis chain and the waist
-        # joint states, and navigation is dead without all four. Forced here rather than by
-        # flipping sim.launch.py's default, which is still provisional on an unthrottled
-        # re-measurement of test_arm_command.
+        # joint states, and navigation is dead without all four.
         #
         # manipulation:=true forces it for a different reason: object ground truth leaves the
         # simulator over the sensor relay's own socket, so without sensors the pose source
@@ -448,10 +446,11 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             "odometry",
-            default_value="sportmodestate",
-            description="Which source publishes odom -> base_footprint. 'sportmodestate' is "
-            "exact MuJoCo state and is what the mission is tuned against. 'fast_lio' runs the "
-            "LiDAR-inertial pipeline the real robot uses, over the simulated Mid360.",
+            default_value="fast_lio",
+            description="Which source publishes odom -> base_footprint. 'fast_lio' is the "
+            "default because it is the pipeline the real robot runs, over the simulated "
+            "Mid360. 'sportmodestate' is exact MuJoCo state, for isolating a fault to 'not "
+            "the odometry'.",
         ),
         DeclareLaunchArgument(
             "world",

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -233,20 +233,13 @@ def _launch_setup(context, *args, **kwargs):
             )
 
     # Checked even when sensors are off, so a typo is caught where it was made rather than
-    # silently selecting the other source. Ground truth and an estimate are not interchangeable
-    # and the difference does not announce itself: the stack comes up either way.
+    # silently selecting the other source.
     odometry = LaunchConfiguration("odometry").perform(context)
     if odometry not in ("sportmodestate", "fast_lio"):
         raise RuntimeError(
             f"odometry:={odometry!r} is not an odometry source. Use 'sportmodestate' (exact "
             "MuJoCo state, simulation only) or 'fast_lio' (LiDAR-inertial, what the robot runs)."
         )
-    if odometry == "fast_lio" and not sensors:
-        raise RuntimeError(
-            "odometry:=fast_lio needs sensors:=true -- it is built on the Mid360, and with "
-            "sensors off nothing would publish odom -> base_footprint at all."
-        )
-
     if sensors and odometry == "fast_lio":
         # The LiDAR-inertial pipeline owns odom -> base_footprint instead, and brings up its
         # own publisher. Exactly one of these two branches runs: two writers on that transform
@@ -477,13 +470,12 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "odometry",
-                default_value="sportmodestate",
-                description="Which source publishes odom -> base_footprint. 'sportmodestate' "
-                "is exact MuJoCo state -- no drift, no noise, no latency -- and is what the "
-                "mission is tuned against. 'fast_lio' runs the real LiDAR-inertial pipeline "
-                "over the simulated Mid360 instead, which is the code path the robot uses; "
-                "expect drift, and expect it to need a few seconds to initialise. Needs "
-                "sensors:=true either way.",
+                default_value="fast_lio",
+                description="Which source publishes odom -> base_footprint. 'fast_lio' is the "
+                "default because it is the pipeline the robot runs; expect drift and a few "
+                "seconds to initialise. 'sportmodestate' is exact MuJoCo state and exists to "
+                "isolate a fault to 'not the odometry'. Either needs sensors:=true; with "
+                "sensors off neither runs.",
             ),
             DeclareLaunchArgument(
                 "pin_pelvis",

--- a/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
+++ b/workspace/src/g1_bringup/test/test_lidar_geometry.launch.py
@@ -52,6 +52,9 @@ def generate_test_description():
         ),
         launch_arguments={
             "sensors": "true",
+            # Ground truth, not the stack default: the numbers here are sensor geometry against
+            # a known room, measured with the pelvis pinned.
+            "odometry": "sportmodestate",
             "pin_pelvis": "true",
             # The small bare room this test's numbers come from, not the facility.
             "world": "perception",

--- a/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
+++ b/workspace/src/g1_hand_interface/include/g1_hand_interface/g1_dex3_system.hpp
@@ -20,8 +20,9 @@
 #include <vector>
 
 #include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_component_interface_params.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "realtime_tools/realtime_publisher.h"
+#include "realtime_tools/realtime_publisher.hpp"
 #include "unitree_hg/msg/hand_cmd.hpp"
 #include "unitree_hg/msg/hand_state.hpp"
 
@@ -58,7 +59,7 @@ class G1Dex3System : public hardware_interface::SystemInterface
 {
 public:
     hardware_interface::CallbackReturn
-    on_init(const hardware_interface::HardwareInfo& info) override;
+    on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
     hardware_interface::CallbackReturn
     on_configure(const rclcpp_lifecycle::State& previous) override;
     hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous) override;

--- a/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
+++ b/workspace/src/g1_hand_interface/src/g1_dex3_system.cpp
@@ -32,12 +32,13 @@ std::string paramOr(
 }  // namespace
 
 hardware_interface::CallbackReturn
-G1Dex3System::on_init(const hardware_interface::HardwareInfo& info)
+G1Dex3System::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
 {
-    if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    if (SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS)
     {
         return hardware_interface::CallbackReturn::ERROR;
     }
+    const auto& info = get_hardware_info();
 
     const auto side_it = info.hardware_parameters.find("side");
     if (side_it == info.hardware_parameters.end() ||

--- a/workspace/src/g1_hardware_interface/README.md
+++ b/workspace/src/g1_hardware_interface/README.md
@@ -69,9 +69,9 @@ ros2 launch g1_bringup bringup.launch.py
 ros2 launch g1_bringup activate_arm.launch.py
 ```
 
-Acquire and release order is mandatory. Humble ties command-interface availability to hardware
-component state, so activating the controller before the component can fail the switch or strand a
-controller claiming interfaces. The `activate_arm` and `deactivate_arm` scripts encode the order.
+Acquire and release order is mandatory. ros2_control ties command-interface availability to
+hardware component state, so activating the controller before the component can fail the switch or
+strand a controller claiming interfaces. The `activate_arm` and `deactivate_arm` scripts encode the order.
 
 ## Safety model
 

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_arm_sdk_system.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_arm_sdk_system.hpp
@@ -16,8 +16,8 @@
 
 #include "g1_hardware_interface/arm_ramp_engine.hpp"
 #include "hardware_interface/handle.hpp"
-#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_component_interface_params.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
@@ -114,7 +114,7 @@ public:
     ~G1ArmSdkSystem() override;
 
     hardware_interface::CallbackReturn
-    on_init(const hardware_interface::HardwareInfo& info) override;
+    on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
     hardware_interface::CallbackReturn
     on_configure(const rclcpp_lifecycle::State& previous_state) override;

--- a/workspace/src/g1_hardware_interface/src/g1_arm_sdk_system.cpp
+++ b/workspace/src/g1_hardware_interface/src/g1_arm_sdk_system.cpp
@@ -125,9 +125,9 @@ void assembleLowCmd(
 G1ArmSdkSystem::~G1ArmSdkSystem() { shutdownInternalNode(); }
 
 hardware_interface::CallbackReturn
-G1ArmSdkSystem::on_init(const hardware_interface::HardwareInfo& info)
+G1ArmSdkSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
 {
-    if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    if (SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS)
     {
         return hardware_interface::CallbackReturn::ERROR;
     }

--- a/workspace/src/g1_manipulation/test/test_pick_place.launch.py
+++ b/workspace/src/g1_manipulation/test/test_pick_place.launch.py
@@ -47,6 +47,11 @@ def generate_test_description():
         launch_arguments={
             "moveit": "true",
             "manipulation": "true",
+            # Ground truth, not the stack default. FAST-LIO cannot work in this scene: the
+            # manipulation world is a bench at arm's length with the pelvis pinned, so the
+            # Mid360 returns nothing, fast_lio logs "No point, skip this scan!" forever and
+            # never publishes odom, leaving g1_object_pose_source with no frame to place into.
+            "odometry": "sportmodestate",
             # The object is at arm's length here, so nothing has to drive anywhere and the
             # gait cannot make the test flaky. The facility mission is g1_orchestration's.
             "world": "manipulation",

--- a/workspace/src/g1_navigation/launch/nav_sim.launch.py
+++ b/workspace/src/g1_navigation/launch/nav_sim.launch.py
@@ -34,9 +34,7 @@ def _setup(context, *args, **kwargs):
 
     actions = [
         # sensors:=true is not optional: it gates the LiDAR sweep, the relay, the
-        # odom -> base_footprint -> pelvis chain and the waist joint states. Passed explicitly
-        # rather than by flipping the bringup default, which is still provisional on an
-        # unthrottled re-measurement of test_arm_command.
+        # odom -> base_footprint -> pelvis chain and the waist joint states.
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 os.path.join(
@@ -45,6 +43,7 @@ def _setup(context, *args, **kwargs):
             ),
             launch_arguments={
                 "sensors": "true",
+                "odometry": LaunchConfiguration("odometry"),
                 "world": LaunchConfiguration("world"),
                 "headless": LaunchConfiguration("headless"),
                 "sim_start_delay_s": LaunchConfiguration("sim_start_delay_s"),
@@ -89,6 +88,13 @@ def generate_launch_description():
             default_value="mapping",
             description="'mapping' builds a new map with slam_toolbox; 'localization' runs "
             "map_server + AMCL against maps/facility.",
+        ),
+        DeclareLaunchArgument(
+            "odometry",
+            default_value="fast_lio",
+            description="Forwarded to sim.launch.py. Declared here because a name this file "
+            "does not declare cannot be forwarded explicitly, and this stack needs to be able "
+            "to fall back to 'sportmodestate' to isolate a fault to 'not the odometry'.",
         ),
         DeclareLaunchArgument(
             "world",

--- a/workspace/src/g1_navigation/test/test_nav_authority.launch.py
+++ b/workspace/src/g1_navigation/test/test_nav_authority.launch.py
@@ -47,6 +47,9 @@ def generate_test_description():
         ),
         launch_arguments={
             "sensors": "true",
+            # Ground truth, not the stack default: this asserts who owns cmd_vel, and a
+            # FAST-LIO warm-up would only add latency to a test that measures arbitration.
+            "odometry": "sportmodestate",
             "world": "navigation",
             "headless": "true",
             "sim_start_delay_s": "4.0",

--- a/workspace/src/g1_navigation/test/test_scan_pipeline.launch.py
+++ b/workspace/src/g1_navigation/test/test_scan_pipeline.launch.py
@@ -51,6 +51,9 @@ def generate_test_description():
         ),
         launch_arguments={
             "sensors": "true",
+            # Ground truth, not the stack default: this asserts scan geometry through TF, so
+            # the odometry under it should contribute nothing.
+            "odometry": "sportmodestate",
             "pin_pelvis": "true",
             "world": "perception",
         }.items(),

--- a/workspace/src/g1_navigation/test/test_slam_map.launch.py
+++ b/workspace/src/g1_navigation/test/test_slam_map.launch.py
@@ -48,6 +48,9 @@ def generate_test_description():
         ),
         launch_arguments={
             "sensors": "true",
+            # Ground truth, not the stack default: this scores the map, and estimator drift
+            # would show up as map error that is not the mapper's.
+            "odometry": "sportmodestate",
             "pin_pelvis": "true",
             "world": "perception",
         }.items(),


### PR DESCRIPTION
Second PR of the Jazzy migration, stacked on #29. Ports the two `ros2_control` hardware
components to the Jazzy API, with the control path untouched — both still target `rt/arm_sdk`.
Swapping what they talk to is PR 3.

## What actually needed porting

Much less than the ros2_control migration guide implies. I measured the warnings rather than
working from the guide, and the whole port is three source edits in two files:

- `on_init(const HardwareInfo&)` → `on_init(const HardwareComponentInterfaceParams&)` in
  `G1ArmSdkSystem` and `G1Dex3System`. The arm only used the parameter for the base call. Dex3
  used it in twelve places, so it binds `get_hardware_info()` once after the base call and the
  rest of the body is unchanged.
- `realtime_tools/realtime_publisher.h` → `.hpp` in `g1_hand_interface`.
  `g1_hardware_interface` was already on the new name.

Both packages now build with **zero compiler warnings and no stderr at all**.

## What turned out to be a no-op, and why

Recording these so they don't get re-investigated in PR 3:

- **`export_state_interfaces()` / `export_command_interfaces()` need no change.** They *are*
  marked `[[deprecated]]` in hardware_interface 4.44.0, but GCC only warns at a call site, and
  overriding a deprecated virtual is silent — the framework is the only caller. Measured: zero
  warnings. NVIDIA's own G1 component keeps the old-style exports too.
- **`get_optional()` / `get_value(double&)` don't apply.** Those are controller-side handle APIs.
  These are hardware components; they own their `double` members directly.
- **`thread_priority` → `async_params` doesn't apply.** The string appears nowhere in the workspace.
- **No URDF mismatch.** Jazzy errors where Humble tolerated a `ros2_control` joint missing from the
  URDF. Checked all three blocks against the expanded 59-joint URDF: `G1ArmSdkSystem` 14,
  `G1Dex3SystemLeft` 7, `G1Dex3SystemRight` 7, zero missing.

## Dropping the deprecation suppression

PR 1 added `-clang-diagnostic-deprecated-declarations` to `.clang-tidy` with an explicit note to
remove it here, since the `on_init` port is what earns it. Removed.

The suppression was repo-wide, so I re-ran every `g1_*` clang-tidy gate rather than just the two
touched packages, and proved the gate is live by injection: restoring the deprecated call fails
`clang_tidy_check_g1_hand_interface`, reverting passes it. Exit 0 → 1 → 0.

## Verification

Module-level, per the plan — the full mission run happens once, in PR 6.

- 13 unit tests across both packages, 0 failures; both clang-format and clang-tidy gates green.
- **`on_init` proven at runtime.** Worth calling out: neither unit test calls `on_init`, they only
  load the plugin through pluginlib, so a broken `get_hardware_info()` would compile and pass
  everything. The proof is the controller_manager log from a live `sim.launch.py` — "Successful
  initialization of hardware" for `G1ArmSdkSystem`, `G1Dex3SystemLeft` and `G1Dex3SystemRight`.
  `G1Dex3System::on_init` returns ERROR when `side` is missing, so those lines are unreachable
  unless the info is really populated.
- **FAST-LIO is within noise of the Humble baseline.** `test_fastlio_odometry` passes, and
  `lio_bench` over a 20.90 m walk:

  | | Humble baseline | Jazzy |
  |---|---|---|
  | final gap | 1 cm | 0.9 cm |
  | worst case | 10 cm | 9.5 cm |
  | drift over path | 0.05 % | 0.04 % |

  119596 paired samples. GCC 13 and the rebuilt PCL/Eigen changed nothing measurable.

## Also here: fast_lio is now the default odometry source

Folded in on request. It is a parity win rather than a convenience: `sportmodestate` is exact
MuJoCo state and does not exist on the robot at all, so defaulting to it meant the sim graph
diverged from hardware at the one place we care most about.

It was not quite the one-line change it looks like:

- **With `sensors:=false` no odometry node runs at all** — both branches in `sim.launch.py` are
  gated on `sensors`, so the setting was already inert without it. The only thing that broke the
  nine sensor-less tests was the `fast_lio and not sensors` RuntimeError, which guarded a mistake
  that had just become the default. Removed. `sensors` stays defaulted to `false`; flipping that
  too would have added LiDAR simulation to nine timing-sensitive sim tests.
- **13 of 15 sim tests inherit the odometry default**, so this moves them wholesale.
  `nav_sim.launch.py` did not forward `odometry` at all, so the nav stack had no way to select
  ground truth. It now declares and forwards it.

Five tests are pinned to `sportmodestate`. Four because they assert geometry and arbitration,
where estimator drift is noise and a FAST-LIO warm-up is only latency: `test_lidar_geometry`,
`test_scan_pipeline`, `test_slam_map`, `test_nav_authority`.

The fifth is `test_pick_place`, and for a harder reason found by running it rather than assuming:
**`world:=manipulation` is not LIO-viable.** It is a bench at arm's length with the pelvis pinned,
so the Mid360 returns nothing, FAST-LIO logs `No point, skip this scan!` continuously, never
publishes, and `g1_object_pose_source` repeats `Cannot place objects in 'odom'` because the frame
never exists. Anything in that world needs ground truth until the scene grows geometry.

`test_navigate_to_pose` does ride the new default, and passes.

Three stale comments went with it: `bringup.launch.py` and `nav_sim.launch.py` both explained that
sensors were forced "rather than by flipping sim.launch.py's default, which is still provisional".

## Known-bad, not caused by this PR

**`test_pick_place` does not complete on Jazzy.** It dies with `Timed out waiting for processes to
start up` before any assertion runs, and `move_group` segfaults during teardown. I verified this is
independent of the odometry change: it fails identically pinned to `sportmodestate`, which is
exactly the pre-flip default, with no FAST-LIO in the graph.

It is the test `g1_manipulation/CMakeLists.txt:63` deliberately leaves unregistered, so it is not a
gate and nothing regressed. But that comment's stated cause is now stale — it cites
`local/lib/python3.10/dist-packages`, which does not exist on Jazzy (bindings are at
`lib/python3.12/site-packages`), and the failure is a startup timeout rather than an import error.
This belongs to PR 5, where MoveIt gets its own pass.

**Consequence worth stating plainly: pick/place is not verified end-to-end on Jazzy by this PR.**
The `forward_tolerance_m: 0.110` blocker also remains open for PR 4 — the run never got far enough
to reach the approach, so it was never exercised.
