### PR TITLE
Add the whole-body rt/lowcmd hardware component

### DIFF
--- a/workspace/src/g1_bringup/CMakeLists.txt
+++ b/workspace/src/g1_bringup/CMakeLists.txt
@@ -96,6 +96,10 @@ if(BUILD_TESTING)
   add_launch_test(test/test_walk_and_arm.launch.py TARGET test_walk_and_arm TIMEOUT 400)
   set_tests_properties(test_walk_and_arm PROPERTIES RESOURCE_LOCK mujoco_sim LABELS simulator)
 
+  # PR 3's gate: one joint commanded through the rt/lowcmd component and read back.
+  add_launch_test(test/test_lowcmd_joint.launch.py TARGET test_lowcmd_joint TIMEOUT 240)
+  set_tests_properties(test_lowcmd_joint PROPERTIES RESOURCE_LOCK mujoco_sim LABELS simulator)
+
   # DDS drain gap before the critical balance test.
   set(_SIM_SETTLE_S 5)
   add_test(NAME sim_settle_gap COMMAND ${CMAKE_COMMAND} -E sleep ${_SIM_SETTLE_S})

--- a/workspace/src/g1_bringup/launch/control.launch.py
+++ b/workspace/src/g1_bringup/launch/control.launch.py
@@ -3,16 +3,27 @@
 No sim, no motion_service_sim here -- this is the launch file that carries
 over unchanged to hardware bring-up (see README.md's domain/DDS story).
 Included by sim.launch.py for the simulation milestone.
+
+`control_stack` picks which hardware component owns the motors. The two are mutually exclusive
+by construction: `arm_sdk` blends our arm targets under the onboard balance controller, `lowcmd`
+takes the whole body and leaves no balance running. See docs/CONTROL_MODES.md.
 """
 
 import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import EmitEvent, ExecuteProcess, RegisterEventHandler
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
+    OpaqueFunction,
+    RegisterEventHandler,
+    SetEnvironmentVariable,
+)
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
-from launch.substitutions import Command, FindExecutable
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 
@@ -28,12 +39,44 @@ _SIGNAL_FORWARDING_WRAPPER = (
 )
 
 
-def generate_launch_description():
+def _launch_setup(context, *args, **kwargs):
     g1_description_share = get_package_share_directory("g1_description")
     g1_bringup_share = get_package_share_directory("g1_bringup")
 
-    xacro_path = os.path.join(g1_description_share, "urdf", "g1_arm_sdk.urdf.xacro")
-    controllers_yaml = os.path.join(g1_bringup_share, "config", "controllers.yaml")
+    control_stack = LaunchConfiguration("control_stack").perform(context)
+    if control_stack not in ("arm_sdk", "lowcmd"):
+        raise RuntimeError(
+            f"control_stack must be 'arm_sdk' or 'lowcmd', got '{control_stack}'"
+        )
+
+    rmw_for_stack = []
+    if control_stack == "lowcmd":
+        rmw_for_stack = [SetEnvironmentVariable("RMW_IMPLEMENTATION", "rmw_fastrtps_cpp")]
+
+    if control_stack == "lowcmd":
+        xacro_path = os.path.join(g1_description_share, "urdf", "g1_lowcmd.urdf.xacro")
+        controllers_yaml = os.path.join(
+            get_package_share_directory("g1_controllers"), "config", "lowcmd_controllers.yaml"
+        )
+        # The freeze holds the body from the moment the component activates; the probe joint is
+        # the one left free. Neither may load inactive: unclaimed joints are unpowered.
+        controller_spawners = [
+            ExecuteProcess(
+                cmd=["ros2", "run", "controller_manager", "spawner", name],
+                name=f"{name}_spawner",
+                output="screen",
+            )
+            for name in (
+                "joint_state_broadcaster",
+                "imu_sensor_broadcaster",
+                "body_freeze_controller",
+                "probe_position_controller",
+            )
+        ]
+    else:
+        xacro_path = os.path.join(g1_description_share, "urdf", "g1_arm_sdk.urdf.xacro")
+        controllers_yaml = os.path.join(g1_bringup_share, "config", "controllers.yaml")
+        controller_spawners = None
 
     robot_description_content = Command([FindExecutable(name="xacro"), " ", xacro_path])
     robot_description = {
@@ -110,13 +153,32 @@ def generate_launch_description():
         )
     )
 
-    return LaunchDescription(
-        [
-            robot_state_publisher_node,
-            control_node,
+    if controller_spawners is None:
+        controller_spawners = [
             joint_state_broadcaster_spawner,
             arm_trajectory_controller_spawner,
             *hand_controller_spawners,
-            shutdown_on_control_node_exit,
+        ]
+
+    return [
+        *rmw_for_stack,
+        robot_state_publisher_node,
+        control_node,
+        *controller_spawners,
+        shutdown_on_control_node_exit,
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "control_stack",
+                default_value="arm_sdk",
+                description="Which hardware component owns the motors. 'arm_sdk' blends arm "
+                "targets under the onboard balance controller; 'lowcmd' takes the whole body "
+                "and runs no balance underneath it.",
+            ),
+            OpaqueFunction(function=_launch_setup),
         ]
     )

--- a/workspace/src/g1_bringup/launch/control.launch.py
+++ b/workspace/src/g1_bringup/launch/control.launch.py
@@ -6,7 +6,7 @@ Included by sim.launch.py for the simulation milestone.
 
 `control_stack` picks which hardware component owns the motors. The two are mutually exclusive
 by construction: `arm_sdk` blends our arm targets under the onboard balance controller, `lowcmd`
-takes the whole body and leaves no balance running. See docs/CONTROL_MODES.md.
+takes the whole body and leaves no balance running.
 """
 
 import os

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -68,11 +68,8 @@ def _check_environment(context, *args, **kwargs):
     """
     problems = []
 
-    # Which RMW is correct depends on who owns the robot wire. On the arm_sdk stack our ROS
-    # nodes reach rt/* themselves, so ROS must be on CycloneDDS. On the lowcmd stack the
-    # hardware component owns the wire through unitree_sdk2's own CycloneDDS, and ROS must NOT
-    # also load one -- the two ship the same SONAME and different ABIs. See
-    # docs/notes/lowcmd-dds-config.md.
+    # Which RMW is correct depends on who owns the robot wire: arm_sdk reaches rt/* from ROS
+    # itself, lowcmd reaches it from the SDK's own CycloneDDS and ROS must not load a second.
     control_stack = LaunchConfiguration("control_stack").perform(context)
     expected_rmw = "rmw_fastrtps_cpp" if control_stack == "lowcmd" else "rmw_cyclonedds_cpp"
     rmw = os.environ.get("RMW_IMPLEMENTATION")

--- a/workspace/src/g1_bringup/launch/sim.launch.py
+++ b/workspace/src/g1_bringup/launch/sim.launch.py
@@ -68,11 +68,18 @@ def _check_environment(context, *args, **kwargs):
     """
     problems = []
 
+    # Which RMW is correct depends on who owns the robot wire. On the arm_sdk stack our ROS
+    # nodes reach rt/* themselves, so ROS must be on CycloneDDS. On the lowcmd stack the
+    # hardware component owns the wire through unitree_sdk2's own CycloneDDS, and ROS must NOT
+    # also load one -- the two ship the same SONAME and different ABIs. See
+    # docs/notes/lowcmd-dds-config.md.
+    control_stack = LaunchConfiguration("control_stack").perform(context)
+    expected_rmw = "rmw_fastrtps_cpp" if control_stack == "lowcmd" else "rmw_cyclonedds_cpp"
     rmw = os.environ.get("RMW_IMPLEMENTATION")
-    if rmw != "rmw_cyclonedds_cpp":
+    if rmw != expected_rmw:
         problems.append(
-            f"RMW_IMPLEMENTATION={rmw!r}, expected 'rmw_cyclonedds_cpp' -- "
-            "the Unitree SDK/sim only speak CycloneDDS."
+            f"RMW_IMPLEMENTATION={rmw!r}, expected {expected_rmw!r} for "
+            f"control_stack={control_stack!r}."
         )
 
     cyclone_uri = os.environ.get("CYCLONEDDS_URI")
@@ -234,6 +241,7 @@ def _launch_setup(context, *args, **kwargs):
 
     # Checked even when sensors are off, so a typo is caught where it was made rather than
     # silently selecting the other source.
+    control_stack = LaunchConfiguration("control_stack").perform(context)
     odometry = LaunchConfiguration("odometry").perform(context)
     if odometry not in ("sportmodestate", "fast_lio"):
         raise RuntimeError(
@@ -410,7 +418,8 @@ def _launch_setup(context, *args, **kwargs):
     control_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory("g1_bringup"), "launch", "control.launch.py")
-        )
+        ),
+        launch_arguments={"control_stack": control_stack}.items(),
     )
 
     # LocoClient bridge — talks to motion_service_sim's /api/sport/* responder.
@@ -428,14 +437,21 @@ def _launch_setup(context, *args, **kwargs):
         )
     )
 
-    actions.extend([motion_service_sim_node, control_launch, loco_launch, shutdown_on_sim_exit])
+    # motion_service_sim and the LocoClient bridge both stand in for the onboard controller,
+    # which rt/lowcmd replaces outright. Running them alongside it would put a second writer on
+    # the motors, the one thing CONTROL_MODES.md forbids.
+    if control_stack == "lowcmd":
+        actions.extend([control_launch, shutdown_on_sim_exit])
+    else:
+        actions.extend(
+            [motion_service_sim_node, control_launch, loco_launch, shutdown_on_sim_exit]
+        )
     return actions
 
 
 def generate_launch_description():
     return LaunchDescription(
         [
-            OpaqueFunction(function=_check_environment),
             DeclareLaunchArgument(
                 "headless",
                 default_value="true",
@@ -467,6 +483,13 @@ def generate_launch_description():
                 "result as unproven, not as a property of the sensor stack. Opt-in until it "
                 "is re-measured on an unthrottled machine. test_lidar_geometry, which is "
                 "pure geometry, turns sensors on explicitly and passes.",
+            ),
+            DeclareLaunchArgument(
+                "control_stack",
+                default_value="arm_sdk",
+                description="Forwarded to control.launch.py. 'lowcmd' also drops "
+                "motion_service_sim and the LocoClient bridge, which stand in for the onboard "
+                "controller that rt/lowcmd replaces.",
             ),
             DeclareLaunchArgument(
                 "odometry",
@@ -510,6 +533,8 @@ def generate_launch_description():
                 "sim's first physics tick. Raise this if the robot still topples on startup "
                 "(slower discovery); do not set to 0.",
             ),
+            # After the arguments, because it now depends on control_stack.
+            OpaqueFunction(function=_check_environment),
             OpaqueFunction(function=_launch_setup),
         ]
     )

--- a/workspace/src/g1_bringup/package.xml
+++ b/workspace/src/g1_bringup/package.xml
@@ -20,6 +20,9 @@
   <depend>robot_state_publisher</depend>
   <depend>controller_manager</depend>
   <depend>joint_state_broadcaster</depend>
+  <depend>imu_sensor_broadcaster</depend>
+  <depend>forward_command_controller</depend>
+  <depend>g1_controllers</depend>
   <depend>joint_trajectory_controller</depend>
   <depend>xacro</depend>
   <depend>controller_manager_msgs</depend>

--- a/workspace/src/g1_bringup/test/test_lowcmd_joint.launch.py
+++ b/workspace/src/g1_bringup/test/test_lowcmd_joint.launch.py
@@ -5,16 +5,15 @@ bridge feeds into its PD law, the freeze controller holding the other 28 joints,
 kPositionOnly branch on the probe joint. No policy is involved; that is PR 4.
 
 The pelvis is pinned because nothing is balancing: rt/lowcmd replaces the onboard controller
-outright, and a free-standing robot with no policy falls over. See docs/CONTROL_MODES.md.
+outright, and a free-standing robot with no policy falls over.
 """
 
 import os
 import time
 import unittest
 
-# Set before rclpy is imported and initialised: this test talks to a stack that runs on
-# fastrtps, because the lowcmd component owns the robot wire through unitree_sdk2's own
-# CycloneDDS. See docs/notes/lowcmd-dds-config.md.
+# Set before rclpy initialises: the lowcmd stack runs on fastrtps, because the component owns
+# the robot wire through unitree_sdk2's own CycloneDDS and ROS must not load a second one.
 os.environ["RMW_IMPLEMENTATION"] = "rmw_fastrtps_cpp"
 
 import launch_testing.actions

--- a/workspace/src/g1_bringup/test/test_lowcmd_joint.launch.py
+++ b/workspace/src/g1_bringup/test/test_lowcmd_joint.launch.py
@@ -1,0 +1,164 @@
+"""Headless sim gate for the rt/lowcmd component: command one joint, read it back.
+
+Proves the whole path end to end -- component activation, the SDK channel, the CRC the sim's
+bridge feeds into its PD law, the freeze controller holding the other 28 joints, and the
+kPositionOnly branch on the probe joint. No policy is involved; that is PR 4.
+
+The pelvis is pinned because nothing is balancing: rt/lowcmd replaces the onboard controller
+outright, and a free-standing robot with no policy falls over. See docs/CONTROL_MODES.md.
+"""
+
+import os
+import time
+import unittest
+
+# Set before rclpy is imported and initialised: this test talks to a stack that runs on
+# fastrtps, because the lowcmd component owns the robot wire through unitree_sdk2's own
+# CycloneDDS. See docs/notes/lowcmd-dds-config.md.
+os.environ["RMW_IMPLEMENTATION"] = "rmw_fastrtps_cpp"
+
+import launch_testing.actions
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from controller_manager_msgs.srv import ListControllers, ListHardwareComponents
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+# Matches the other simulator tests: kept under launch_testing's 15 s startup deadline.
+SIM_SETTLE_S = 10.0
+
+PROBE_JOINT = "left_elbow_joint"
+# Well inside the elbow's range, and far enough that noise cannot fake it.
+PROBE_TARGET_RAD = 0.6
+# position_only_kp is 10.0, so tracking is soft on purpose. Assert the joint clearly moved
+# towards the command rather than landing exactly on it.
+PROBE_MIN_TRAVEL_RAD = 0.15
+
+FROZEN_JOINT = "right_elbow_joint"
+# The freeze holds at whatever it captured; anything larger is a joint that is not being held.
+FROZEN_MAX_DRIFT_RAD = 0.15
+
+
+def generate_test_description():
+    sim_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("g1_bringup"), "launch", "sim.launch.py")
+        ),
+        launch_arguments={
+            "headless": "true",
+            "rviz": "false",
+            "control_stack": "lowcmd",
+            # Nothing balances the robot under rt/lowcmd until PR 4's policy lands.
+            "pin_pelvis": "true",
+            "sensors": "false",
+        }.items(),
+    )
+
+    return LaunchDescription([sim_launch, launch_testing.actions.ReadyToTest()])
+
+
+class TestLowCmdJoint(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_lowcmd_joint")
+        cls.executor = SingleThreadedExecutor()
+        cls.executor.add_node(cls.node)
+
+        cls.joint_states = []
+        cls.node.create_subscription(
+            JointState,
+            "/joint_states",
+            lambda msg: cls.joint_states.append(msg),
+            10,
+        )
+        cls.command_pub = cls.node.create_publisher(
+            Float64MultiArray, "/probe_position_controller/commands", 10
+        )
+
+        cls._spin_for(SIM_SETTLE_S)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.executor.remove_node(cls.node)
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def _spin_for(cls, seconds):
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            cls.executor.spin_once(timeout_sec=0.1)
+
+    def _latest_position(self, joint):
+        for msg in reversed(self.joint_states):
+            if joint in msg.name:
+                return msg.position[msg.name.index(joint)]
+        return None
+
+    def _call(self, srv_type, name):
+        client = self.node.create_client(srv_type, name)
+        self.assertTrue(client.wait_for_service(timeout_sec=20.0), f"{name} never appeared")
+        future = client.call_async(srv_type.Request())
+        deadline = time.monotonic() + 20.0
+        while not future.done() and time.monotonic() < deadline:
+            self.executor.spin_once(timeout_sec=0.1)
+        self.assertTrue(future.done(), f"{name} did not answer")
+        return future.result()
+
+    def test_component_activates(self):
+        """A broken on_init or a failed SDK channel shows up here and nowhere else.
+
+        No unit test reaches on_init -- they only load the plugin through pluginlib -- so this
+        is the only proof that HardwareInfo really populated and rt/lowstate really arrived.
+        """
+        result = self._call(ListHardwareComponents, "/controller_manager/list_hardware_components")
+        names = {component.name: component.state.label for component in result.component}
+        self.assertIn("G1LowCmdSystem", names, f"component never loaded, saw {names}")
+        self.assertEqual(names["G1LowCmdSystem"], "active")
+
+    def test_controllers_are_active(self):
+        result = self._call(ListControllers, "/controller_manager/list_controllers")
+        states = {controller.name: controller.state for controller in result.controller}
+        for name in ("body_freeze_controller", "probe_position_controller"):
+            self.assertEqual(states.get(name), "active", f"{name} is {states.get(name)}")
+
+    def test_probe_joint_follows_a_command(self):
+        start = self._latest_position(PROBE_JOINT)
+        self.assertIsNotNone(start, "no /joint_states for the probe joint")
+
+        self.command_pub.publish(Float64MultiArray(data=[PROBE_TARGET_RAD]))
+        self._spin_for(5.0)
+
+        end = self._latest_position(PROBE_JOINT)
+        travel = abs(end - start)
+        self.assertGreater(
+            travel,
+            PROBE_MIN_TRAVEL_RAD,
+            f"{PROBE_JOINT} moved {travel:.3f} rad from {start:.3f}; the command never reached "
+            "the motors",
+        )
+        # Direction matters as much as magnitude: a wrong sign or a wrong motor index would
+        # still register as travel.
+        self.assertLess(
+            abs(end - PROBE_TARGET_RAD),
+            abs(start - PROBE_TARGET_RAD),
+            f"{PROBE_JOINT} moved away from the target ({start:.3f} -> {end:.3f})",
+        )
+
+    def test_frozen_joint_holds(self):
+        """The freeze controller is what keeps the body up; if it were a no-op this drifts."""
+        first = self._latest_position(FROZEN_JOINT)
+        self.assertIsNotNone(first, "no /joint_states for the frozen joint")
+        self._spin_for(3.0)
+        second = self._latest_position(FROZEN_JOINT)
+        self.assertLess(
+            abs(second - first),
+            FROZEN_MAX_DRIFT_RAD,
+            f"{FROZEN_JOINT} drifted {abs(second - first):.3f} rad while frozen",
+        )

--- a/workspace/src/g1_controllers/CMakeLists.txt
+++ b/workspace/src/g1_controllers/CMakeLists.txt
@@ -1,0 +1,102 @@
+cmake_minimum_required(VERSION 3.8)
+project(g1_controllers)
+
+find_package(ament_cmake REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+add_library(g1_freeze_controller SHARED src/g1_freeze_controller.cpp)
+target_include_directories(g1_freeze_controller PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(g1_freeze_controller PUBLIC cxx_std_20)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(g1_freeze_controller PRIVATE -Wall -Wextra)
+endif()
+ament_target_dependencies(g1_freeze_controller PUBLIC
+  controller_interface
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+
+pluginlib_export_plugin_description_file(controller_interface g1_controllers.xml)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+install(
+  TARGETS g1_freeze_controller
+  EXPORT export_g1_controllers
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gmock REQUIRED)
+
+  # Discovery through pluginlib's own loader is the proof controller_manager can spawn it;
+  # a clean compile does not check the plugin XML or its export.
+  ament_add_gmock(test_freeze_pluginlib test/test_freeze_pluginlib.cpp)
+  target_link_libraries(test_freeze_pluginlib g1_freeze_controller)
+  ament_target_dependencies(test_freeze_pluginlib pluginlib controller_interface)
+
+  # See g1_description/CMakeLists.txt for why this is a plain CTest rather than uncrustify.
+  find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+  set(_clang_format_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+  if(CLANG_FORMAT_EXECUTABLE AND EXISTS "${_clang_format_config}")
+    file(GLOB_RECURSE _format_sources
+      "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp"
+    )
+    add_test(
+      NAME clang_format_check_g1_controllers
+      COMMAND ${CLANG_FORMAT_EXECUTABLE} --style=file:${_clang_format_config} --dry-run --Werror
+        ${_format_sources}
+    )
+  else()
+    message(WARNING
+      "clang-format and/or workspace .clang-format not found; skipping clang_format_check_g1_controllers test")
+  endif()
+
+  # Minutes rather than milliseconds, so it carries a label: `--ctest-args -LE clang_tidy` skips
+  # it for a fast local loop. CI runs it.
+  find_program(RUN_CLANG_TIDY_EXECUTABLE NAMES run-clang-tidy run-clang-tidy-18 run-clang-tidy-14)
+  set(_clang_tidy_config "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  if(RUN_CLANG_TIDY_EXECUTABLE AND EXISTS "${_clang_tidy_config}"
+      AND CMAKE_EXPORT_COMPILE_COMMANDS)
+    add_test(
+      NAME clang_tidy_check_g1_controllers
+      COMMAND ${RUN_CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} -quiet -j 4
+    )
+    set_tests_properties(clang_tidy_check_g1_controllers PROPERTIES LABELS clang_tidy TIMEOUT 900)
+  else()
+    message(WARNING
+      "run-clang-tidy or .clang-tidy not found, or compile commands are off; skipping clang_tidy_check_g1_controllers test")
+  endif()
+endif()
+
+ament_export_include_directories(include)
+ament_export_libraries(g1_freeze_controller)
+ament_export_targets(export_g1_controllers)
+ament_export_dependencies(
+  controller_interface
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+
+ament_package()

--- a/workspace/src/g1_controllers/README.md
+++ b/workspace/src/g1_controllers/README.md
@@ -1,0 +1,52 @@
+# g1_controllers
+
+`ros2_control` controllers for the whole-body `rt/lowcmd` stack. `ament_cmake`, C++20.
+
+| Controller | Does |
+|---|---|
+| `g1_controllers/G1FreezeController` | Captures each claimed joint's position on activation and holds it there under impedance control. |
+
+The AGILE policy controller and its safety wrapper land here too.
+
+## Why a freeze controller exists
+
+`rt/lowcmd` is one message covering all 29 motors, so the hardware component sends something for
+every joint on every tick, claimed or not. Its answer for unclaimed joints is "unpowered", which
+is correct but means nothing holds the robot up when no policy is running.
+
+Holding is therefore a controller, not component behaviour: it can be switched in and out at
+runtime, and the component stays free of policy. This mirrors NVIDIA's
+`isaac_ros_deploy_ros2_control` split, where `FreezeController` holds and `DisableController`
+lets go. Ours drops their regex gain patterns, because their own G1 config sets one value for
+every joint anyway.
+
+## Parameters
+
+| Parameter | Meaning |
+|---|---|
+| `joints` | Which joints to hold. Must be non-empty. |
+| `kp` | Position gain applied to all of them. Must be > 0. |
+| `kd` | Damping applied to all of them. Must be > 0. |
+
+Both gains must be positive: a freeze with no stiffness is a disable with extra steps, and
+`on_configure` rejects it rather than silently letting the robot down.
+
+`config/lowcmd_controllers.yaml` ships the bring-up set — this controller over 28 joints, plus a
+`forward_command_controller` on one probe joint so a single command can be pushed through the
+whole path and read back.
+
+## Running
+
+Comes up with the lowcmd stack:
+
+```bash
+ros2 launch g1_bringup sim.launch.py control_stack:=lowcmd pin_pelvis:=true
+```
+
+`pin_pelvis` matters until the policy controller lands: this holds joints, it does not balance.
+
+## Tests
+
+`test_freeze_pluginlib` proves the plugin resolves through pluginlib, which is the path
+`controller_manager` uses to spawn it. Behaviour is covered by `g1_bringup`'s
+`test_lowcmd_joint`, which asserts a held joint does not drift while a commanded one moves.

--- a/workspace/src/g1_controllers/config/lowcmd_controllers.yaml
+++ b/workspace/src/g1_controllers/config/lowcmd_controllers.yaml
@@ -1,0 +1,80 @@
+# controller_manager config for the whole-body rt/lowcmd stack.
+#
+# Bring-up shape only: a freeze that holds the body and one probe joint to prove the path end to
+# end. PR 4 replaces this wholesale when the AGILE policy controller lands and claims the 12 leg
+# joints plus waist_roll/waist_pitch.
+
+controller_manager:
+  ros__parameters:
+    # 200 Hz, matching NVIDIA's. Their policy runs at 50 Hz under it via decimation: 4, so this
+    # rate is part of the policy contract rather than a free choice.
+    update_rate: 200
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    imu_sensor_broadcaster:
+      type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+    body_freeze_controller:
+      type: g1_controllers/G1FreezeController
+
+    probe_position_controller:
+      type: forward_command_controller/ForwardCommandController
+
+joint_state_broadcaster:
+  ros__parameters:
+    interfaces:
+      - position
+      - velocity
+      - effort
+
+imu_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: imu
+    frame_id: pelvis
+
+# Holds everything except the probe joint. Claiming kp/kd puts these joints in the component's
+# impedance branch, which is the mode a policy controller will also use.
+body_freeze_controller:
+  ros__parameters:
+    kp: 10.0
+    kd: 1.0
+    joints:
+      - left_hip_pitch_joint
+      - left_hip_roll_joint
+      - left_hip_yaw_joint
+      - left_knee_joint
+      - left_ankle_pitch_joint
+      - left_ankle_roll_joint
+      - right_hip_pitch_joint
+      - right_hip_roll_joint
+      - right_hip_yaw_joint
+      - right_knee_joint
+      - right_ankle_pitch_joint
+      - right_ankle_roll_joint
+      - waist_yaw_joint
+      - waist_roll_joint
+      - waist_pitch_joint
+      - left_shoulder_pitch_joint
+      - left_shoulder_roll_joint
+      - left_shoulder_yaw_joint
+      - left_wrist_roll_joint
+      - left_wrist_pitch_joint
+      - left_wrist_yaw_joint
+      - right_shoulder_pitch_joint
+      - right_shoulder_roll_joint
+      - right_shoulder_yaw_joint
+      - right_elbow_joint
+      - right_wrist_roll_joint
+      - right_wrist_pitch_joint
+      - right_wrist_yaw_joint
+
+# The one joint left free, so a single command can be pushed through the whole path and read back.
+# Position only and no gains, so it exercises the component's kPositionOnly branch and the
+# position_only_kp/kd params from the URDF.
+probe_position_controller:
+  ros__parameters:
+    joints:
+      - left_elbow_joint
+    interface_name: position

--- a/workspace/src/g1_controllers/g1_controllers.xml
+++ b/workspace/src/g1_controllers/g1_controllers.xml
@@ -1,0 +1,15 @@
+<class_libraries>
+
+  <library path="g1_freeze_controller">
+    <class name="g1_controllers/G1FreezeController"
+           type="g1_controllers::G1FreezeController"
+           base_class_type="controller_interface::ControllerInterface">
+      <description>
+        Captures each claimed joint's position on activation and holds it there under
+        impedance control. The safe resting state for a robot whose balance policy is not
+        running. Adapted from NVIDIA's isaac_ros_deploy_ros2_control FreezeController.
+      </description>
+    </class>
+  </library>
+
+</class_libraries>

--- a/workspace/src/g1_controllers/include/g1_controllers/g1_freeze_controller.hpp
+++ b/workspace/src/g1_controllers/include/g1_controllers/g1_freeze_controller.hpp
@@ -1,0 +1,71 @@
+#ifndef G1_CONTROLLERS__G1_FREEZE_CONTROLLER_HPP_
+#define G1_CONTROLLERS__G1_FREEZE_CONTROLLER_HPP_
+
+/**
+ * @file g1_freeze_controller.hpp
+ * @brief Capture-and-hold controller for joints on the rt/lowcmd component.
+ *
+ * Adapted from NVIDIA's isaac_ros_deploy_ros2_control FreezeController (Apache-2.0), minus its
+ * regex gain patterns: their own G1 config sets one value for every joint.
+ */
+
+#include <string>
+#include <vector>
+
+#include "controller_interface/controller_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace g1_controllers
+{
+
+/**
+ * @brief Holds every claimed joint at the position it had when this controller activated.
+ *
+ * The lowcmd component leaves unclaimed joints unpowered, so something has to hold the body
+ * when no policy is running. That is deliberately a controller rather than component behaviour:
+ * it can be switched in and out at runtime, and it keeps the component free of policy.
+ */
+class G1FreezeController : public controller_interface::ControllerInterface
+{
+public:
+    controller_interface::CallbackReturn on_init() override;
+
+    controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+    controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+    controller_interface::CallbackReturn
+    on_configure(const rclcpp_lifecycle::State& previous_state) override;
+    controller_interface::CallbackReturn
+    on_activate(const rclcpp_lifecycle::State& previous_state) override;
+    controller_interface::CallbackReturn
+    on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+    controller_interface::return_type
+    update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+private:
+    /// Locates `names` within `interfaces`, preserving the order of `names`.
+    /// @return false, having logged, if any name is absent.
+    template <typename InterfaceT>
+    bool indexInterfaces(
+        const std::vector<std::string>& names, const std::vector<InterfaceT>& interfaces,
+        std::vector<std::size_t>& out) const;
+
+    std::vector<std::string> joint_names_;
+    double                   kp_ = 0.0;
+    double                   kd_ = 0.0;
+
+    /// Captured in on_activate, then commanded unchanged every tick.
+    std::vector<double> frozen_positions_;
+
+    std::vector<std::size_t> position_state_indices_;
+    std::vector<std::size_t> position_command_indices_;
+    std::vector<std::size_t> velocity_command_indices_;
+    std::vector<std::size_t> effort_command_indices_;
+    std::vector<std::size_t> kp_command_indices_;
+    std::vector<std::size_t> kd_command_indices_;
+};
+
+}  // namespace g1_controllers
+
+#endif  // G1_CONTROLLERS__G1_FREEZE_CONTROLLER_HPP_

--- a/workspace/src/g1_controllers/package.xml
+++ b/workspace/src/g1_controllers/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_controllers</name>
+  <version>0.1.0</version>
+  <description>
+    ros2_control controllers for the G1's whole-body rt/lowcmd component. Holds
+    G1FreezeController, the capture-and-hold fallback the lowcmd component deliberately
+    does not implement itself. The policy and safety controllers land here too.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <!-- Lint checks run via workspace-root CTests (see CMakeLists.txt). -->
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_controllers/src/g1_freeze_controller.cpp
+++ b/workspace/src/g1_controllers/src/g1_freeze_controller.cpp
@@ -1,0 +1,186 @@
+/**
+ * @file g1_freeze_controller.cpp
+ * @brief Capture-and-hold controller for joints on the rt/lowcmd component.
+ */
+
+#include "g1_controllers/g1_freeze_controller.hpp"
+
+#include <algorithm>
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+namespace g1_controllers
+{
+
+namespace
+{
+/// Must match g1_hardware_interface's kHwIfKp/kHwIfKd, which follow NVIDIA's spelling.
+constexpr char kHwIfKp[] = "kp";
+constexpr char kHwIfKd[] = "kd";
+
+std::vector<std::string> suffixed(const std::vector<std::string>& joints, const std::string& type)
+{
+    std::vector<std::string> names;
+    names.reserve(joints.size());
+    for (const auto& joint : joints)
+    {
+        names.push_back(joint + "/" + type);
+    }
+    return names;
+}
+}  // namespace
+
+template <typename InterfaceT>
+bool G1FreezeController::indexInterfaces(
+    const std::vector<std::string>& names, const std::vector<InterfaceT>& interfaces,
+    std::vector<std::size_t>& out) const
+{
+    out.clear();
+    out.reserve(names.size());
+    for (const auto& name : names)
+    {
+        const auto it = std::find_if(
+            interfaces.begin(),
+            interfaces.end(),
+            [&name](const auto& iface) { return iface.get_name() == name; });
+        if (it == interfaces.end())
+        {
+            RCLCPP_ERROR(get_node()->get_logger(), "interface '%s' was not claimed", name.c_str());
+            return false;
+        }
+        out.push_back(static_cast<std::size_t>(std::distance(interfaces.begin(), it)));
+    }
+    return true;
+}
+
+controller_interface::CallbackReturn G1FreezeController::on_init()
+{
+    auto_declare<std::vector<std::string>>("joints", {});
+    auto_declare<double>("kp", 0.0);
+    auto_declare<double>("kd", 0.0);
+    return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+G1FreezeController::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    joint_names_ = get_node()->get_parameter("joints").as_string_array();
+    kp_          = get_node()->get_parameter("kp").as_double();
+    kd_          = get_node()->get_parameter("kd").as_double();
+
+    if (joint_names_.empty())
+    {
+        RCLCPP_ERROR(get_node()->get_logger(), "no joints given, nothing to hold");
+        return controller_interface::CallbackReturn::ERROR;
+    }
+    if (kp_ <= 0.0 || kd_ <= 0.0)
+    {
+        // A freeze with no stiffness is not a freeze, it is a disable with extra steps.
+        RCLCPP_ERROR(get_node()->get_logger(), "kp and kd must both be > 0");
+        return controller_interface::CallbackReturn::ERROR;
+    }
+
+    frozen_positions_.assign(joint_names_.size(), 0.0);
+    return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::InterfaceConfiguration
+G1FreezeController::command_interface_configuration() const
+{
+    controller_interface::InterfaceConfiguration config;
+    config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+    for (const auto& joint : joint_names_)
+    {
+        config.names.push_back(joint + "/" + hardware_interface::HW_IF_POSITION);
+        config.names.push_back(joint + "/" + hardware_interface::HW_IF_VELOCITY);
+        config.names.push_back(joint + "/" + hardware_interface::HW_IF_EFFORT);
+        config.names.push_back(joint + "/" + kHwIfKp);
+        config.names.push_back(joint + "/" + kHwIfKd);
+    }
+    return config;
+}
+
+controller_interface::InterfaceConfiguration
+G1FreezeController::state_interface_configuration() const
+{
+    controller_interface::InterfaceConfiguration config;
+    config.type  = controller_interface::interface_configuration_type::INDIVIDUAL;
+    config.names = suffixed(joint_names_, hardware_interface::HW_IF_POSITION);
+    return config;
+}
+
+controller_interface::CallbackReturn
+G1FreezeController::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    if (!indexInterfaces(
+            suffixed(joint_names_, hardware_interface::HW_IF_POSITION),
+            state_interfaces_,
+            position_state_indices_) ||
+        !indexInterfaces(
+            suffixed(joint_names_, hardware_interface::HW_IF_POSITION),
+            command_interfaces_,
+            position_command_indices_) ||
+        !indexInterfaces(
+            suffixed(joint_names_, hardware_interface::HW_IF_VELOCITY),
+            command_interfaces_,
+            velocity_command_indices_) ||
+        !indexInterfaces(
+            suffixed(joint_names_, hardware_interface::HW_IF_EFFORT),
+            command_interfaces_,
+            effort_command_indices_) ||
+        !indexInterfaces(suffixed(joint_names_, kHwIfKp), command_interfaces_, kp_command_indices_) ||
+        !indexInterfaces(suffixed(joint_names_, kHwIfKd), command_interfaces_, kd_command_indices_))
+    {
+        return controller_interface::CallbackReturn::ERROR;
+    }
+
+    for (std::size_t i = 0; i < joint_names_.size(); ++i)
+    {
+        const auto position = state_interfaces_[position_state_indices_[i]].get_optional();
+        if (!position.has_value())
+        {
+            RCLCPP_ERROR(
+                get_node()->get_logger(),
+                "joint '%s' has no position to freeze at",
+                joint_names_[i].c_str());
+            return controller_interface::CallbackReturn::ERROR;
+        }
+        frozen_positions_[i] = position.value();
+    }
+
+    RCLCPP_INFO(get_node()->get_logger(), "holding %zu joints", joint_names_.size());
+    return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+G1FreezeController::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    position_state_indices_.clear();
+    position_command_indices_.clear();
+    velocity_command_indices_.clear();
+    effort_command_indices_.clear();
+    kp_command_indices_.clear();
+    kd_command_indices_.clear();
+    return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type
+G1FreezeController::update(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+    for (std::size_t i = 0; i < joint_names_.size(); ++i)
+    {
+        (void)command_interfaces_[position_command_indices_[i]].set_value(frozen_positions_[i]);
+        (void)command_interfaces_[velocity_command_indices_[i]].set_value(0.0);
+        (void)command_interfaces_[effort_command_indices_[i]].set_value(0.0);
+        (void)command_interfaces_[kp_command_indices_[i]].set_value(kp_);
+        (void)command_interfaces_[kd_command_indices_[i]].set_value(kd_);
+    }
+    return controller_interface::return_type::OK;
+}
+
+}  // namespace g1_controllers
+
+PLUGINLIB_EXPORT_CLASS(
+    g1_controllers::G1FreezeController, controller_interface::ControllerInterface)

--- a/workspace/src/g1_controllers/src/g1_freeze_controller.cpp
+++ b/workspace/src/g1_controllers/src/g1_freeze_controller.cpp
@@ -6,8 +6,9 @@
 #include "g1_controllers/g1_freeze_controller.hpp"
 
 #include <algorithm>
-
 #include <pluginlib/class_list_macros.hpp>
+#include <string_view>
+#include <utility>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
@@ -17,16 +18,19 @@ namespace g1_controllers
 namespace
 {
 /// Must match g1_hardware_interface's kHwIfKp/kHwIfKd, which follow NVIDIA's spelling.
-constexpr char kHwIfKp[] = "kp";
-constexpr char kHwIfKd[] = "kd";
+constexpr std::string_view kHwIfKp{ "kp" };
+constexpr std::string_view kHwIfKd{ "kd" };
 
-std::vector<std::string> suffixed(const std::vector<std::string>& joints, const std::string& type)
+std::vector<std::string> suffixed(const std::vector<std::string>& joints, std::string_view type)
 {
     std::vector<std::string> names;
     names.reserve(joints.size());
     for (const auto& joint : joints)
     {
-        names.push_back(joint + "/" + type);
+        std::string name = joint;
+        name += '/';
+        name += type;
+        names.push_back(std::move(name));
     }
     return names;
 }
@@ -41,10 +45,10 @@ bool G1FreezeController::indexInterfaces(
     out.reserve(names.size());
     for (const auto& name : names)
     {
-        const auto it = std::find_if(
-            interfaces.begin(),
-            interfaces.end(),
-            [&name](const auto& iface) { return iface.get_name() == name; });
+        const auto it =
+            std::find_if(interfaces.begin(), interfaces.end(), [&name](const auto& iface) {
+                return iface.get_name() == name;
+            });
         if (it == interfaces.end())
         {
             RCLCPP_ERROR(get_node()->get_logger(), "interface '%s' was not claimed", name.c_str());
@@ -91,13 +95,15 @@ G1FreezeController::command_interface_configuration() const
 {
     controller_interface::InterfaceConfiguration config;
     config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-    for (const auto& joint : joint_names_)
+    config.names.reserve(joint_names_.size() * 5);
+    for (const std::string_view type : { std::string_view{ hardware_interface::HW_IF_POSITION },
+                                         std::string_view{ hardware_interface::HW_IF_VELOCITY },
+                                         std::string_view{ hardware_interface::HW_IF_EFFORT },
+                                         kHwIfKp,
+                                         kHwIfKd })
     {
-        config.names.push_back(joint + "/" + hardware_interface::HW_IF_POSITION);
-        config.names.push_back(joint + "/" + hardware_interface::HW_IF_VELOCITY);
-        config.names.push_back(joint + "/" + hardware_interface::HW_IF_EFFORT);
-        config.names.push_back(joint + "/" + kHwIfKp);
-        config.names.push_back(joint + "/" + kHwIfKd);
+        const auto names = suffixed(joint_names_, type);
+        config.names.insert(config.names.end(), names.begin(), names.end());
     }
     return config;
 }
@@ -182,5 +188,4 @@ G1FreezeController::update(const rclcpp::Time& /*time*/, const rclcpp::Duration&
 
 }  // namespace g1_controllers
 
-PLUGINLIB_EXPORT_CLASS(
-    g1_controllers::G1FreezeController, controller_interface::ControllerInterface)
+PLUGINLIB_EXPORT_CLASS(g1_controllers::G1FreezeController, controller_interface::ControllerInterface)

--- a/workspace/src/g1_controllers/test/test_freeze_pluginlib.cpp
+++ b/workspace/src/g1_controllers/test/test_freeze_pluginlib.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file test_freeze_pluginlib.cpp
+ * @brief Verifies G1FreezeController is discoverable via pluginlib.
+ */
+
+#include <gmock/gmock.h>
+
+#include <controller_interface/controller_interface.hpp>
+#include <pluginlib/class_loader.hpp>
+
+/**
+ * @brief Confirms g1_controllers/G1FreezeController resolves through pluginlib's ament-index
+ * lookup, which is the path controller_manager uses to spawn it.
+ */
+TEST(G1FreezeControllerPluginlib, DiscoversAndInstantiates)
+{
+    pluginlib::ClassLoader<controller_interface::ControllerInterface> loader(
+        "controller_interface",
+        "controller_interface::ControllerInterface");
+
+    ASSERT_TRUE(loader.isClassAvailable("g1_controllers/G1FreezeController"));
+
+    auto instance = loader.createUniqueInstance("g1_controllers/G1FreezeController");
+    ASSERT_NE(instance, nullptr);
+}

--- a/workspace/src/g1_description/config/lowcmd_params.yaml
+++ b/workspace/src/g1_description/config/lowcmd_params.yaml
@@ -1,0 +1,60 @@
+# Hardware parameters for g1_hardware_interface/G1LowCmdSystem.
+#
+# Consumed by urdf/g1_lowcmd.urdf.xacro at xacro-expansion time, for the same reason
+# arm_sdk_params.yaml is: ros2_control plugins only ever see <ros2_control><param> tags, never
+# controller_manager's own YAML.
+
+system:
+  # unitree_sdk2's ChannelFactory takes its own domain, which must match the simulator's
+  # (simulate/config.yaml) and ROS_DOMAIN_ID. Both are 1 in this image.
+  domain_id: 1
+
+  # MUST stay empty. A non-empty interface makes the SDK build an inline CycloneDDS config that
+  # replaces CYCLONEDDS_URI wholesale, losing MaxAutoParticipantIndex and crashing DDS init. That
+  # is the same fault patches/unitree_mujoco/002-sdk-honour-cyclonedds-uri.patch fixed for the
+  # simulator. The interface is pinned by CYCLONEDDS_URI instead.
+  network_interface: ""
+
+  lowstate_timeout_ms: 100     # ms; rt/lowstate older than this errors the component while active
+  release_ramp_s: 0.5          # s; stiffness fades to zero over this on deactivate
+  release_kd: 2.0              # damping held flat across the release, so it outlives the stiffness
+  motor_temp_warn_threshold: 120   # deg C; NVIDIA's value, warns on /diagnostics
+
+  # Whether to ask the onboard motion service to hand over the motors. There is no such service
+  # in unitree_mujoco, so sim leaves it false; hardware must set it true or rt/lowcmd is ignored.
+  release_motion_mode: false
+
+# Gains used only when a controller claims position without kp/kd, i.e. the kPositionOnly branch.
+# 10/1 across the board is NVIDIA's shipped value (their fill_motor_cmd hardcodes it, and their
+# FreezeController config uses the same pair for every joint). Kept per joint so it is tunable
+# without touching code; NOT yet validated against our robot under load.
+joints:
+  left_hip_pitch_joint:        { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_hip_roll_joint:         { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_hip_yaw_joint:          { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_knee_joint:             { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_ankle_pitch_joint:      { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_ankle_roll_joint:       { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_hip_pitch_joint:       { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_hip_roll_joint:        { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_hip_yaw_joint:         { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_knee_joint:            { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_ankle_pitch_joint:     { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_ankle_roll_joint:      { position_only_kp: 10.0, position_only_kd: 1.0 }
+  waist_yaw_joint:             { position_only_kp: 10.0, position_only_kd: 1.0 }
+  waist_roll_joint:            { position_only_kp: 10.0, position_only_kd: 1.0 }
+  waist_pitch_joint:           { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_shoulder_pitch_joint:   { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_shoulder_roll_joint:    { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_shoulder_yaw_joint:     { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_elbow_joint:            { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_wrist_roll_joint:       { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_wrist_pitch_joint:      { position_only_kp: 10.0, position_only_kd: 1.0 }
+  left_wrist_yaw_joint:        { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_shoulder_pitch_joint:  { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_shoulder_roll_joint:   { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_shoulder_yaw_joint:    { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_elbow_joint:           { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_wrist_roll_joint:      { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_wrist_pitch_joint:     { position_only_kp: 10.0, position_only_kd: 1.0 }
+  right_wrist_yaw_joint:       { position_only_kp: 10.0, position_only_kd: 1.0 }

--- a/workspace/src/g1_description/urdf/g1_lowcmd.urdf.xacro
+++ b/workspace/src/g1_description/urdf/g1_lowcmd.urdf.xacro
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="g1_29dof_with_hand_rev_1_0">
+
+  <!-- Whole-body variant: the 29 body motors are owned by G1LowCmdSystem over rt/lowcmd, with no
+       onboard balance running underneath. g1_arm_sdk.urdf.xacro is the blended-arm variant and
+       stays until PR 6 retires it. Only one of the two may be loaded at a time. -->
+  <xacro:include filename="g1_29dof_with_hand_rev_1_0.urdf"/>
+
+  <xacro:property name="lowcmd" value="${xacro.load_yaml('../config/lowcmd_params.yaml')}"/>
+
+  <xacro:macro name="g1_lowcmd_joint" params="name">
+    <joint name="${name}">
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
+      <command_interface name="effort"/>
+      <!-- kp and kd as command interfaces is what lets a controller pick the joint's control
+           mode per tick, and what a policy controller needs. Names match NVIDIA's exactly. -->
+      <command_interface name="kp"/>
+      <command_interface name="kd"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+      <param name="position_only_kp">${lowcmd.joints[name].position_only_kp}</param>
+      <param name="position_only_kd">${lowcmd.joints[name].position_only_kd}</param>
+    </joint>
+  </xacro:macro>
+
+  <ros2_control name="G1LowCmdSystem" type="system">
+    <hardware>
+      <plugin>g1_hardware_interface/G1LowCmdSystem</plugin>
+      <param name="domain_id">${lowcmd.system.domain_id}</param>
+      <param name="network_interface">${lowcmd.system.network_interface}</param>
+      <param name="lowstate_timeout_ms">${lowcmd.system.lowstate_timeout_ms}</param>
+      <param name="release_ramp_s">${lowcmd.system.release_ramp_s}</param>
+      <param name="release_kd">${lowcmd.system.release_kd}</param>
+      <param name="release_motion_mode">${lowcmd.system.release_motion_mode}</param>
+      <param name="motor_temp_warn_threshold">${lowcmd.system.motor_temp_warn_threshold}</param>
+    </hardware>
+
+    <xacro:g1_lowcmd_joint name="left_hip_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="left_hip_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="left_hip_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="left_knee_joint"/>
+    <xacro:g1_lowcmd_joint name="left_ankle_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="left_ankle_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="right_hip_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="right_hip_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="right_hip_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="right_knee_joint"/>
+    <xacro:g1_lowcmd_joint name="right_ankle_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="right_ankle_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="waist_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="waist_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="waist_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="left_shoulder_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="left_shoulder_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="left_shoulder_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="left_elbow_joint"/>
+    <xacro:g1_lowcmd_joint name="left_wrist_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="left_wrist_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="left_wrist_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="right_shoulder_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="right_shoulder_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="right_shoulder_yaw_joint"/>
+    <xacro:g1_lowcmd_joint name="right_elbow_joint"/>
+    <xacro:g1_lowcmd_joint name="right_wrist_roll_joint"/>
+    <xacro:g1_lowcmd_joint name="right_wrist_pitch_joint"/>
+    <xacro:g1_lowcmd_joint name="right_wrist_yaw_joint"/>
+
+    <!-- The pelvis IMU, exported under the names imu_sensor_broadcaster expects. AGILE reads
+         root orientation and angular velocity from here in PR 4. -->
+    <sensor name="imu">
+      <state_interface name="orientation.x"/>
+      <state_interface name="orientation.y"/>
+      <state_interface name="orientation.z"/>
+      <state_interface name="orientation.w"/>
+      <state_interface name="angular_velocity.x"/>
+      <state_interface name="angular_velocity.y"/>
+      <state_interface name="angular_velocity.z"/>
+      <state_interface name="linear_acceleration.x"/>
+      <state_interface name="linear_acceleration.y"/>
+      <state_interface name="linear_acceleration.z"/>
+    </sensor>
+  </ros2_control>
+
+</robot>

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -10,11 +10,22 @@ find_package(realtime_tools REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(unitree_hg REQUIRED)
 
+# Shared by both hardware plugins, so it is its own library rather than a source compiled into
+# each: pluginlib dlopens both .so files into one controller_manager, and two copies of the same
+# externally-visible symbols is a resolution order nobody should have to reason about.
+add_library(motor_crc_hg src/motor_crc_hg.cpp)
+target_include_directories(motor_crc_hg PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(motor_crc_hg PUBLIC cxx_std_20)
+ament_target_dependencies(motor_crc_hg PUBLIC unitree_hg)
+
 add_library(g1_arm_sdk_system SHARED
   src/arm_ramp_engine.cpp
-  src/motor_crc_hg.cpp
   src/g1_arm_sdk_system.cpp
 )
+target_link_libraries(g1_arm_sdk_system PUBLIC motor_crc_hg)
 target_include_directories(g1_arm_sdk_system PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
@@ -60,7 +71,7 @@ install(
   DESTINATION include
 )
 install(
-  TARGETS g1_arm_sdk_system lowstate_joint_states
+  TARGETS g1_arm_sdk_system lowstate_joint_states motor_crc_hg
   EXPORT export_g1_arm_sdk_system
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -91,6 +102,12 @@ if(BUILD_TESTING)
   ament_add_gmock(test_assemble_low_cmd test/test_assemble_low_cmd.cpp)
   target_link_libraries(test_assemble_low_cmd g1_arm_sdk_system)
   ament_target_dependencies(test_assemble_low_cmd unitree_hg)
+
+  # Not the bit loop, which is vendored: which bytes it covers, and that the mirror struct's
+  # padding is deterministic. A checksum the firmware rejects means every command is ignored.
+  ament_add_gmock(test_motor_crc_hg test/test_motor_crc_hg.cpp)
+  target_link_libraries(test_motor_crc_hg motor_crc_hg)
+  ament_target_dependencies(test_motor_crc_hg unitree_hg)
 
   ament_add_gmock(test_lowstate_joint_states test/test_lowstate_joint_states.cpp)
   target_link_libraries(test_lowstate_joint_states lowstate_joint_states)

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(unitree_hg REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
 # Shared by both hardware plugins, so it is its own library rather than a source compiled into
 # each: pluginlib dlopens both .so files into one controller_manager, and two copies of the same
@@ -21,6 +22,16 @@ target_include_directories(motor_crc_hg PUBLIC
 target_compile_features(motor_crc_hg PUBLIC cxx_std_20)
 ament_target_dependencies(motor_crc_hg PUBLIC unitree_hg)
 
+# Plain CMake package baked into the dev image, not an ament one, so it needs the prefix.
+set(UNITREE_SDK2_PREFIX /opt/unitree_robotics)
+find_package(unitree_sdk2 REQUIRED PATHS ${UNITREE_SDK2_PREFIX}/lib/cmake NO_DEFAULT_PATH)
+
+# The SDK ships its own libddsc/libddscxx there and nothing else puts that directory on the
+# loader path. Scoped to this package rather than /etc/ld.so.conf.d so the SDK's older CycloneDDS
+# cannot shadow ROS's for every other process -- see docs/notes/lowcmd-dds-config.md.
+list(APPEND CMAKE_BUILD_RPATH ${UNITREE_SDK2_PREFIX}/lib)
+list(APPEND CMAKE_INSTALL_RPATH ${UNITREE_SDK2_PREFIX}/lib)
+
 # The rt/lowcmd mode table and per-motor packing, split out for the same reason
 # arm_ramp_engine is: it is the part worth asserting without a live component.
 add_library(lowcmd_assembly src/lowcmd_assembly.cpp)
@@ -29,7 +40,26 @@ target_include_directories(lowcmd_assembly PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_compile_features(lowcmd_assembly PUBLIC cxx_std_20)
-ament_target_dependencies(lowcmd_assembly PUBLIC unitree_hg)
+target_link_libraries(lowcmd_assembly PUBLIC unitree_sdk2 motor_crc_hg)
+
+add_library(g1_lowcmd_system SHARED src/g1_lowcmd_system.cpp)
+target_include_directories(g1_lowcmd_system PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(g1_lowcmd_system PUBLIC cxx_std_20)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(g1_lowcmd_system PRIVATE -Wall -Wextra)
+endif()
+target_link_libraries(g1_lowcmd_system PUBLIC lowcmd_assembly)
+ament_target_dependencies(g1_lowcmd_system PUBLIC
+  diagnostic_msgs
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  realtime_tools
+)
 
 add_library(g1_arm_sdk_system SHARED
   src/arm_ramp_engine.cpp
@@ -81,7 +111,7 @@ install(
   DESTINATION include
 )
 install(
-  TARGETS g1_arm_sdk_system lowstate_joint_states motor_crc_hg lowcmd_assembly
+  TARGETS g1_arm_sdk_system g1_lowcmd_system lowstate_joint_states motor_crc_hg lowcmd_assembly
   EXPORT export_g1_arm_sdk_system
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -99,7 +129,7 @@ if(BUILD_TESTING)
   # ClassLoader is the actual proof controller_manager will find it -- a
   # clean compile doesn't guarantee the plugin XML/export is wired correctly.
   ament_add_gmock(test_pluginlib_loading test/test_pluginlib_loading.cpp)
-  target_link_libraries(test_pluginlib_loading g1_arm_sdk_system)
+  target_link_libraries(test_pluginlib_loading g1_arm_sdk_system g1_lowcmd_system)
   ament_target_dependencies(test_pluginlib_loading pluginlib hardware_interface)
 
   # The safety-critical surface: pure, ROS-free ramp/slew/staleness logic --
@@ -116,7 +146,6 @@ if(BUILD_TESTING)
   # The mode table rt/lowcmd resolves interface claims through, plus the release ramp's packing.
   ament_add_gmock(test_lowcmd_assembly test/test_lowcmd_assembly.cpp)
   target_link_libraries(test_lowcmd_assembly lowcmd_assembly)
-  ament_target_dependencies(test_lowcmd_assembly unitree_hg)
 
   # Not the bit loop, which is vendored: which bytes it covers, and that the mirror struct's
   # padding is deterministic. A checksum the firmware rejects means every command is ignored.

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -21,6 +21,16 @@ target_include_directories(motor_crc_hg PUBLIC
 target_compile_features(motor_crc_hg PUBLIC cxx_std_20)
 ament_target_dependencies(motor_crc_hg PUBLIC unitree_hg)
 
+# The rt/lowcmd mode table and per-motor packing, split out for the same reason
+# arm_ramp_engine is: it is the part worth asserting without a live component.
+add_library(lowcmd_assembly src/lowcmd_assembly.cpp)
+target_include_directories(lowcmd_assembly PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_compile_features(lowcmd_assembly PUBLIC cxx_std_20)
+ament_target_dependencies(lowcmd_assembly PUBLIC unitree_hg)
+
 add_library(g1_arm_sdk_system SHARED
   src/arm_ramp_engine.cpp
   src/g1_arm_sdk_system.cpp
@@ -71,7 +81,7 @@ install(
   DESTINATION include
 )
 install(
-  TARGETS g1_arm_sdk_system lowstate_joint_states motor_crc_hg
+  TARGETS g1_arm_sdk_system lowstate_joint_states motor_crc_hg lowcmd_assembly
   EXPORT export_g1_arm_sdk_system
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -102,6 +112,11 @@ if(BUILD_TESTING)
   ament_add_gmock(test_assemble_low_cmd test/test_assemble_low_cmd.cpp)
   target_link_libraries(test_assemble_low_cmd g1_arm_sdk_system)
   ament_target_dependencies(test_assemble_low_cmd unitree_hg)
+
+  # The mode table rt/lowcmd resolves interface claims through, plus the release ramp's packing.
+  ament_add_gmock(test_lowcmd_assembly test/test_lowcmd_assembly.cpp)
+  target_link_libraries(test_lowcmd_assembly lowcmd_assembly)
+  ament_target_dependencies(test_lowcmd_assembly unitree_hg)
 
   # Not the bit loop, which is vendored: which bytes it covers, and that the mirror struct's
   # padding is deterministic. A checksum the firmware rejects means every command is ignored.

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -41,6 +41,12 @@ target_include_directories(lowcmd_assembly PUBLIC
 )
 target_compile_features(lowcmd_assembly PUBLIC cxx_std_20)
 target_link_libraries(lowcmd_assembly PUBLIC unitree_sdk2 motor_crc_hg)
+# SYSTEM so clang-tidy's WarningsAsErrors does not fail us on the SDK's own headers, which still
+# use std::result_of.
+target_include_directories(lowcmd_assembly SYSTEM PUBLIC
+  ${UNITREE_SDK2_PREFIX}/include
+  ${UNITREE_SDK2_PREFIX}/include/ddscxx
+)
 
 add_library(g1_lowcmd_system SHARED src/g1_lowcmd_system.cpp)
 target_include_directories(g1_lowcmd_system PUBLIC
@@ -49,7 +55,10 @@ target_include_directories(g1_lowcmd_system PUBLIC
 )
 target_compile_features(g1_lowcmd_system PUBLIC cxx_std_20)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(g1_lowcmd_system PRIVATE -Wall -Wextra)
+  # unitree_sdk2's dds_entity.hpp still builds its queue thread through std::result_of, which
+  # InitChannel instantiates unconditionally. Scoped to this one target so the rest of the package
+  # keeps the strict gate PR 2 earned back; drop it when the SDK is bumped past the deprecation.
+  target_compile_options(g1_lowcmd_system PRIVATE -Wall -Wextra -Wno-deprecated-declarations)
 endif()
 target_link_libraries(g1_lowcmd_system PUBLIC lowcmd_assembly)
 ament_target_dependencies(g1_lowcmd_system PUBLIC

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -26,14 +26,12 @@ ament_target_dependencies(motor_crc_hg PUBLIC unitree_hg)
 set(UNITREE_SDK2_PREFIX /opt/unitree_robotics)
 find_package(unitree_sdk2 REQUIRED PATHS ${UNITREE_SDK2_PREFIX}/lib/cmake NO_DEFAULT_PATH)
 
-# The SDK ships its own libddsc/libddscxx there and must bind to those, not to ROS's newer
-# CycloneDDS: same SONAME, different ABI, and mixing them corrupts the heap. Scoped to this
-# package, not /etc/ld.so.conf.d. See docs/notes/lowcmd-dds-config.md.
+# The SDK must bind the libddsc/libddscxx it ships, not ROS's newer CycloneDDS: same SONAME,
+# different ABI, and mixing them corrupts the heap. Scoped here, not /etc/ld.so.conf.d.
 list(APPEND CMAKE_BUILD_RPATH ${UNITREE_SDK2_PREFIX}/lib)
 list(APPEND CMAKE_INSTALL_RPATH ${UNITREE_SDK2_PREFIX}/lib)
 
-# DT_RPATH, not the modern DT_RUNPATH: RUNPATH is searched *after* LD_LIBRARY_PATH, which
-# carries /opt/ros/jazzy/lib/x86_64-linux-gnu, so the SDK would still get ROS's libddsc.
+# DT_RPATH, not the default DT_RUNPATH, which loses to LD_LIBRARY_PATH and its ROS lib dir.
 string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--disable-new-dtags")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags")
 

--- a/workspace/src/g1_hardware_interface/CMakeLists.txt
+++ b/workspace/src/g1_hardware_interface/CMakeLists.txt
@@ -26,11 +26,16 @@ ament_target_dependencies(motor_crc_hg PUBLIC unitree_hg)
 set(UNITREE_SDK2_PREFIX /opt/unitree_robotics)
 find_package(unitree_sdk2 REQUIRED PATHS ${UNITREE_SDK2_PREFIX}/lib/cmake NO_DEFAULT_PATH)
 
-# The SDK ships its own libddsc/libddscxx there and nothing else puts that directory on the
-# loader path. Scoped to this package rather than /etc/ld.so.conf.d so the SDK's older CycloneDDS
-# cannot shadow ROS's for every other process -- see docs/notes/lowcmd-dds-config.md.
+# The SDK ships its own libddsc/libddscxx there and must bind to those, not to ROS's newer
+# CycloneDDS: same SONAME, different ABI, and mixing them corrupts the heap. Scoped to this
+# package, not /etc/ld.so.conf.d. See docs/notes/lowcmd-dds-config.md.
 list(APPEND CMAKE_BUILD_RPATH ${UNITREE_SDK2_PREFIX}/lib)
 list(APPEND CMAKE_INSTALL_RPATH ${UNITREE_SDK2_PREFIX}/lib)
+
+# DT_RPATH, not the modern DT_RUNPATH: RUNPATH is searched *after* LD_LIBRARY_PATH, which
+# carries /opt/ros/jazzy/lib/x86_64-linux-gnu, so the SDK would still get ROS's libddsc.
+string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--disable-new-dtags")
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--disable-new-dtags")
 
 # The rt/lowcmd mode table and per-motor packing, split out for the same reason
 # arm_ramp_engine is: it is the part worth asserting without a live component.

--- a/workspace/src/g1_hardware_interface/README.md
+++ b/workspace/src/g1_hardware_interface/README.md
@@ -1,9 +1,16 @@
 # g1_hardware_interface
 
-A `ros2_control` `SystemInterface` plugin that bridges standard joint command and state interfaces
-onto Unitree's weight-blended `rt/arm_sdk` DDS topic. Covers the 14 arm joints, and holds the 3
-waist motors that topic hands over with them. Also ships `g1_lowstate_joint_states`, which puts
-the legs and waist on `/joint_states` because no controller owns them.
+Two `ros2_control` `SystemInterface` plugins, one per control mode. Exactly one may be loaded at
+a time; `control_stack` in `g1_bringup` picks.
+
+| Plugin | Channel | Owns |
+|---|---|---|
+| `G1LowCmdSystem` | `rt/lowcmd` | all 29 body motors, no onboard balance underneath |
+| `G1ArmSdkSystem` | `rt/arm_sdk` | 14 arm joints + 3 waist, balance stays onboard |
+
+`G1LowCmdSystem` is where the stack is heading; `G1ArmSdkSystem` is the path being replaced.
+Also ships `g1_lowstate_joint_states`, which puts the legs and waist on `/joint_states` on the
+arm_sdk path, because no controller owns them there.
 
 `ament_cmake`, C++20. This is real hardware code and runs unchanged against the physical G1.
 
@@ -29,7 +36,9 @@ the legs. The weight in motor slot 29 tells it how much of the arm command to ho
 | `lowstate_joint_states.{hpp,cpp}` | `LowState` motors 0-14 to `JointState`. Pure, so it tests without a graph. |
 | `g1_lowstate_joint_states_node.cpp` | The node around it. See below. |
 | `motor_crc_hg.{hpp,cpp}` | Vendored CRC, byte-exact against Unitree's. |
-| `g1_hardware_interface.xml` | pluginlib export. |
+| `g1_lowcmd_system.{hpp,cpp}` | The whole-body plugin: SDK channels, mode switching, release ramp, diagnostics. |
+| `lowcmd_assembly.{hpp,cpp}` | The `rt/lowcmd` mode table and per-motor packing. Pure, so the branches unit-test. |
+| `g1_hardware_interface.xml` | pluginlib export for both plugins. |
 
 ## Interfaces
 
@@ -176,3 +185,47 @@ colcon test --packages-select g1_hardware_interface
 
 End-to-end validation against a live simulator lives in `g1_bringup`'s `test_sim_bringup` and
 `test_arm_command`.
+
+
+## G1LowCmdSystem
+
+Adapted from NVIDIA's `unitree_g1_ros2_control`, and deliberately close to it so their controllers
+bind unchanged: same SDK joint order, same `kp`/`kd` command-interface names, same mode branches,
+same IMU sensor interface names.
+
+### Interfaces
+
+Per joint: `position`, `velocity`, `effort`, `kp`, `kd` as commands; `position`, `velocity`,
+`effort` as state. Plus an `imu` sensor with the ten fields `imu_sensor_broadcaster` expects.
+
+**`kp` and `kd` being command interfaces is the point.** Which ones a controller claims decides
+the joint's mode for that tick:
+
+| Claimed | Mode | What goes out |
+|---|---|---|
+| `kp` + `kd` | impedance | q, dq, tau, kp, kd all from the controller |
+| `position` only | position | q from the controller, gains from `position_only_*` in the URDF |
+| `effort` | effort | q pinned to the measurement, kp forced to 0 |
+| nothing | disabled | motor unpowered |
+
+An unclaimed joint is unpowered, never held. Holding is `g1_controllers/G1FreezeController`, so
+the choice is a runtime controller switch rather than behaviour baked into the component.
+
+### Where we differ from NVIDIA
+
+- **Lock-free state path.** They take a `shared_mutex` in `write()`; we copy through a
+  `realtime_tools::RealtimeBuffer`, and error out when `rt/lowstate` goes stale, which they do
+  not check at all.
+- **One preallocated `LowCmd_`, zeroed once.** The checksum covers the struct's padding, so their
+  per-tick stack object checksums whatever the stack held.
+- **`domain_id` 1 and an empty `network_interface`.** A non-empty interface makes the SDK discard
+  `CYCLONEDDS_URI`, which is what pins the sim to loopback.
+- **A damped release ramp on deactivate** rather than dropping the channel.
+- **The Dex3 stays on `G1Dex3System`**, one component per hand, so a hand fault cannot take the
+  body down with it. NVIDIA fold the hands into this component.
+
+### What sim does not validate
+
+The `MotionSwitcherClient` handover (`release_motion_mode` is false in sim, since MuJoCo has no
+motion service), real motor temperatures, and whether control can be handed *back* to the onboard
+service afterwards. Assume it cannot without a reboot.

--- a/workspace/src/g1_hardware_interface/g1_hardware_interface.xml
+++ b/workspace/src/g1_hardware_interface/g1_hardware_interface.xml
@@ -19,7 +19,7 @@
       <description>
         ros2_control System owning all 29 G1 body motors over Unitree's rt/lowcmd, with no
         onboard balance running underneath. Adapted from NVIDIA's unitree_g1_ros2_control.
-        See the package README and docs/CONTROL_MODES.md.
+        See the package README for the authority model.
       </description>
     </class>
   </library>

--- a/workspace/src/g1_hardware_interface/g1_hardware_interface.xml
+++ b/workspace/src/g1_hardware_interface/g1_hardware_interface.xml
@@ -1,11 +1,27 @@
-<library path="g1_arm_sdk_system">
-  <class name="g1_hardware_interface/G1ArmSdkSystem"
-         type="g1_hardware_interface::G1ArmSdkSystem"
-         base_class_type="hardware_interface::SystemInterface">
-    <description>
-      ros2_control System bridging the G1's 14 arm joints onto Unitree's
-      weight-blended rt/arm_sdk DDS channel; legs/waist/hands stay with the
-      onboard controller. See the package README for the safety/ramp model.
-    </description>
-  </class>
-</library>
+<class_libraries>
+
+  <library path="g1_arm_sdk_system">
+    <class name="g1_hardware_interface/G1ArmSdkSystem"
+           type="g1_hardware_interface::G1ArmSdkSystem"
+           base_class_type="hardware_interface::SystemInterface">
+      <description>
+        ros2_control System bridging the G1's 14 arm joints onto Unitree's
+        weight-blended rt/arm_sdk DDS channel; legs/waist/hands stay with the
+        onboard controller. See the package README for the safety/ramp model.
+      </description>
+    </class>
+  </library>
+
+  <library path="g1_lowcmd_system">
+    <class name="g1_hardware_interface/G1LowCmdSystem"
+           type="g1_hardware_interface::G1LowCmdSystem"
+           base_class_type="hardware_interface::SystemInterface">
+      <description>
+        ros2_control System owning all 29 G1 body motors over Unitree's rt/lowcmd, with no
+        onboard balance running underneath. Adapted from NVIDIA's unitree_g1_ros2_control.
+        See the package README and docs/CONTROL_MODES.md.
+      </description>
+    </class>
+  </library>
+
+</class_libraries>

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
@@ -1,0 +1,189 @@
+#ifndef G1_HARDWARE_INTERFACE__G1_LOWCMD_SYSTEM_HPP_
+#define G1_HARDWARE_INTERFACE__G1_LOWCMD_SYSTEM_HPP_
+
+/**
+ * @file g1_lowcmd_system.hpp
+ * @brief ros2_control SystemInterface owning all 29 G1 body motors over rt/lowcmd.
+ *
+ * Adapted from NVIDIA's unitree_g1_ros2_control (Apache-2.0): same joint mapping, same kp/kd
+ * command interfaces, same mode branches, so their controllers bind unchanged. The deviations
+ * are listed in the package README.
+ */
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unitree/idl/hg/LowCmd_.hpp>
+#include <unitree/idl/hg/LowState_.hpp>
+#include <unitree/robot/channel/channel_publisher.hpp>
+#include <unitree/robot/channel/channel_subscriber.hpp>
+#include <unordered_map>
+#include <vector>
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "g1_hardware_interface/lowcmd_assembly.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_component_interface_params.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+#include "realtime_tools/realtime_buffer.hpp"
+
+namespace g1_hardware_interface
+{
+
+/// Interface names NVIDIA's controllers claim for per-joint gains. Must match theirs exactly.
+inline constexpr char kHwIfKp[] = "kp";
+inline constexpr char kHwIfKd[] = "kd";
+
+/// Joint names in SDK motor index order, from NVIDIA's kG1JointNames. This is the mapping, so
+/// the URDF needs no per-joint motor_index param.
+extern const std::array<std::string, kNumBodyMotors> kG1JointNames;
+
+/// Everything the component tracks for one joint. Layout follows NVIDIA's JointData.
+struct JointData
+{
+    std::string name;
+
+    double position_state = 0.0;
+    double velocity_state = 0.0;
+    double effort_state   = 0.0;
+
+    JointCommand    command;
+    InterfaceClaims claims;
+
+    /// Applied in kPositionOnly, where no controller supplies gains. Per joint because a knee
+    /// and a wrist do not share a sensible default; NVIDIA hardcodes 10/1 for every motor.
+    PositionOnlyGains position_only_gains;
+
+    std::int16_t surface_temperature = 0;
+    std::int16_t winding_temperature = 0;
+
+    /// No atomic needed: controller_manager runs perform_command_mode_switch, read and write
+    /// on one thread, so the switch can never land mid-tick.
+    JointControlMode mode = JointControlMode::kDisabled;
+
+    /// Latched when a release ramp starts, so the ramp holds a pose instead of chasing the fall.
+    double release_hold_position = 0.0;
+    double release_kp            = 0.0;
+
+    /// -1 when the URDF names a joint absent from kG1JointNames.
+    int sdk_index = -1;
+};
+
+/// Backing storage for the IMU sensor interfaces, named as imu_sensor_broadcaster expects.
+struct ImuData
+{
+    std::string name;
+
+    double orientation_w = 1.0;
+    double orientation_x = 0.0;
+    double orientation_y = 0.0;
+    double orientation_z = 0.0;
+
+    double angular_velocity_x = 0.0;
+    double angular_velocity_y = 0.0;
+    double angular_velocity_z = 0.0;
+
+    double linear_acceleration_x = 0.0;
+    double linear_acceleration_y = 0.0;
+    double linear_acceleration_z = 0.0;
+};
+
+/**
+ * @brief ros2_control System publishing rt/lowcmd and subscribing rt/lowstate over unitree_sdk2.
+ *
+ * Owns the whole body: nothing else may publish rt/lowcmd while this is active, and no onboard
+ * balance runs underneath it. See docs/CONTROL_MODES.md before changing anything here.
+ */
+class G1LowCmdSystem : public hardware_interface::SystemInterface
+{
+public:
+    ~G1LowCmdSystem() override;
+
+    hardware_interface::CallbackReturn
+    on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
+
+    std::vector<hardware_interface::StateInterface>   export_state_interfaces() override;
+    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+    hardware_interface::CallbackReturn
+    on_activate(const rclcpp_lifecycle::State& previous_state) override;
+    hardware_interface::CallbackReturn
+    on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+    hardware_interface::CallbackReturn
+    on_error(const rclcpp_lifecycle::State& previous_state) override;
+
+    hardware_interface::return_type perform_command_mode_switch(
+        const std::vector<std::string>& start_interfaces,
+        const std::vector<std::string>& stop_interfaces) override;
+
+    hardware_interface::return_type
+    read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+    hardware_interface::return_type
+    write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+private:
+    /// LowState_ carries no timestamp, so freshness is judged from arrival.
+    struct StampedLowState
+    {
+        unitree_hg::msg::dds_::LowState_      state{};
+        std::chrono::steady_clock::time_point arrival{};
+    };
+
+    bool initializeSdk();
+    void shutdownSdk();
+    /// Releases whatever onboard mode holds the motors. Blocking, and only ever off the RT path.
+    bool releaseOnboardMotionMode();
+    void registerJoints(const hardware_interface::HardwareInfo& info);
+    void registerImuSensor(const hardware_interface::HardwareInfo& info);
+    void buildJointSdkMapping();
+    void lowStateCallback(const void* message);
+    void publishLowCmd();
+    /// Ramps stiffness to zero over release_ramp_s, then stops publishing.
+    void               releaseSynchronously();
+    [[nodiscard]] bool lowStateIsStale() const;
+
+    rclcpp::Logger logger_{ rclcpp::get_logger("g1_lowcmd_system") };
+
+    std::vector<JointData>                       joint_data_;
+    std::unordered_map<std::string, std::size_t> joint_name_to_index_;
+    ImuData                                      imu_data_;
+    bool                                         has_imu_ = false;
+
+    std::string  network_interface_;
+    int          domain_id_                 = 0;
+    int          motor_temp_warn_threshold_ = 120;
+    double       lowstate_timeout_s_        = 0.0;
+    double       release_ramp_s_            = 0.0;
+    double       release_kd_                = 0.0;
+    bool         release_motion_mode_       = false;
+    std::uint8_t mode_machine_              = 0;
+
+    /// Preallocated and zeroed once: the checksum covers this struct's padding, so a per-tick
+    /// stack object (what NVIDIA does) would checksum whatever the stack held.
+    unitree_hg::msg::dds_::LowCmd_ low_cmd_{};
+
+    realtime_tools::RealtimeBuffer<StampedLowState> lowstate_buffer_;
+    std::atomic<bool>                               sdk_initialized_{ false };
+    std::atomic<bool>                               first_state_received_{ false };
+    std::atomic<bool>                               active_{ false };
+
+    unitree::robot::ChannelSubscriberPtr<unitree_hg::msg::dds_::LowState_> lowstate_subscriber_;
+    unitree::robot::ChannelPublisherPtr<unitree_hg::msg::dds_::LowCmd_>    lowcmd_publisher_;
+
+    /// Added to the controller_manager's own executor, which Jazzy hands us in on_init. Humble
+    /// had no such hook, which is why NVIDIA's version reaches for get_node() instead.
+    rclcpp::Node::SharedPtr                                             node_;
+    rclcpp::Executor::WeakPtr                                           executor_;
+    rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
+    rclcpp::TimerBase::SharedPtr                                        diagnostics_timer_;
+};
+
+}  // namespace g1_hardware_interface
+
+#endif  // G1_HARDWARE_INTERFACE__G1_LOWCMD_SYSTEM_HPP_

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
@@ -118,6 +118,10 @@ public:
     on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
     hardware_interface::CallbackReturn
     on_error(const rclcpp_lifecycle::State& previous_state) override;
+    /// Belt and braces: controller_manager does not guarantee on_deactivate runs before the
+    /// process goes away, and this is the only channel holding the robot up.
+    hardware_interface::CallbackReturn
+    on_shutdown(const rclcpp_lifecycle::State& previous_state) override;
 
     hardware_interface::return_type perform_command_mode_switch(
         const std::vector<std::string>& start_interfaces,
@@ -144,7 +148,8 @@ private:
     void registerImuSensor(const hardware_interface::HardwareInfo& info);
     void buildJointSdkMapping();
     void lowStateCallback(const void* message);
-    void publishLowCmd();
+    /// @return false if the DDS write was refused, which write() escalates to a component error.
+    bool publishLowCmd();
     /// Ramps stiffness to zero over release_ramp_s, then stops publishing.
     void               releaseSynchronously();
     [[nodiscard]] bool lowStateIsStale() const;

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unitree/idl/hg/LowCmd_.hpp>
 #include <unitree/idl/hg/LowState_.hpp>
 #include <unitree/robot/channel/channel_publisher.hpp>
@@ -37,8 +38,8 @@ namespace g1_hardware_interface
 {
 
 /// Interface names NVIDIA's controllers claim for per-joint gains. Must match theirs exactly.
-inline constexpr char kHwIfKp[] = "kp";
-inline constexpr char kHwIfKd[] = "kd";
+inline constexpr std::string_view kHwIfKp{ "kp" };
+inline constexpr std::string_view kHwIfKd{ "kd" };
 
 /// Joint names in SDK motor index order, from NVIDIA's kG1JointNames. This is the mapping, so
 /// the URDF needs no per-joint motor_index param.

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/g1_lowcmd_system.hpp
@@ -99,7 +99,7 @@ struct ImuData
  * @brief ros2_control System publishing rt/lowcmd and subscribing rt/lowstate over unitree_sdk2.
  *
  * Owns the whole body: nothing else may publish rt/lowcmd while this is active, and no onboard
- * balance runs underneath it. See docs/CONTROL_MODES.md before changing anything here.
+ * balance runs underneath it. See the package README for the authority model.
  */
 class G1LowCmdSystem : public hardware_interface::SystemInterface
 {

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
@@ -1,0 +1,99 @@
+#ifndef G1_HARDWARE_INTERFACE__LOWCMD_ASSEMBLY_HPP_
+#define G1_HARDWARE_INTERFACE__LOWCMD_ASSEMBLY_HPP_
+
+/**
+ * @file lowcmd_assembly.hpp
+ * @brief Per-motor LowCmd packing for the full-body rt/lowcmd path, kept free of rclcpp so the
+ *        mode table can be asserted without a live hardware component.
+ */
+
+#include <cstddef>
+#include <cstdint>
+
+#include "unitree_hg/msg/low_cmd.hpp"
+
+namespace g1_hardware_interface
+{
+
+/// The body motors rt/lowcmd owns: legs 0-11, waist 12-14, arms 15-28.
+inline constexpr std::size_t kNumBodyMotors = 29;
+
+/**
+ * @brief What a joint's claimed interfaces mean for the firmware's control law,
+ * `tau = tau_ff + kp * (q - q_meas) + kd * (dq - dq_meas)`.
+ */
+enum class JointControlMode : std::uint8_t
+{
+    /// Unclaimed: motor disabled, every field zero. Also where a finished release ramp lands.
+    kDisabled,
+    /// Position tracked at the joint's configured fallback gains, no feedforward torque.
+    kPositionOnly,
+    /// Torque with damping: kp is forced to zero so the position term cannot fight the effort.
+    kEffort,
+    /// The policy mode -- the controller owns q, dq, tau, kp and kd on every tick.
+    kImpedance,
+};
+
+/// Which command interfaces a controller currently holds on one joint.
+struct InterfaceClaims
+{
+    bool position = false;
+    bool velocity = false;
+    bool effort   = false;
+    /// kp and kd together; either one alone does not define an impedance.
+    bool impedance = false;
+};
+
+/**
+ * @brief Maps claimed interfaces onto the mode write() acts on.
+ *
+ * Impedance wins because it is the only claim carrying its own gains. A velocity-only claim
+ * resolves to kDisabled: with kp and kd both zero the firmware law has no term left to act on,
+ * so there is no such mode on this hardware.
+ */
+[[nodiscard]] JointControlMode resolveJointMode(const InterfaceClaims& claims) noexcept;
+
+/// One joint's commanded values, as written by whichever controller holds its interfaces.
+struct JointCommand
+{
+    double position = 0.0;
+    double velocity = 0.0;
+    double effort   = 0.0;
+    double kp       = 0.0;
+    double kd       = 0.0;
+};
+
+/// Gains used in kPositionOnly, where the controller supplies no kp/kd of its own.
+struct PositionOnlyGains
+{
+    double kp = 0.0;
+    double kd = 0.0;
+};
+
+/**
+ * @brief Fills one motor_cmd slot for `mode`.
+ *
+ * @param measured_position Read only in kEffort, where q must sit on the measurement so the
+ *                          position term contributes nothing while tau does the work.
+ */
+void fillMotorCmd(
+    unitree_hg::msg::MotorCmd& motor, JointControlMode mode, const JointCommand& command,
+    const PositionOnlyGains& fallback, double measured_position);
+
+/**
+ * @brief Fills one motor_cmd slot for the release ramp: hold position at fading stiffness with
+ *        fixed damping, so authority hands back as a controlled sag rather than a drop.
+ *
+ * @param hold_position   Where the joint was when the release began, not the live measurement --
+ *                        tracking the fall would drive the joint down with it.
+ * @param kp_at_release   The joint's stiffness on the last commanded tick.
+ * @param stiffness_scale 1.0 at the start of the ramp, 0.0 at its end.
+ * @param release_kd      Damping held flat across the whole ramp, so it survives kp reaching zero.
+ */
+void fillReleaseCmd(
+    unitree_hg::msg::MotorCmd& motor, double hold_position, double kp_at_release,
+    double stiffness_scale, double release_kd);
+
+}  // namespace g1_hardware_interface
+
+#endif  // G1_HARDWARE_INTERFACE__LOWCMD_ASSEMBLY_HPP_

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
@@ -3,14 +3,14 @@
 
 /**
  * @file lowcmd_assembly.hpp
- * @brief Per-motor LowCmd packing for the full-body rt/lowcmd path, kept free of rclcpp so the
- *        mode table can be asserted without a live hardware component.
+ * @brief Per-motor LowCmd packing for rt/lowcmd, on unitree_sdk2's DDS structs rather than the
+ *        unitree_hg ROS messages G1ArmSdkSystem uses. Same 1004-byte wire, different API.
  */
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
-
-#include "unitree_hg/msg/low_cmd.hpp"
+#include <unitree/idl/hg/LowCmd_.hpp>
 
 namespace g1_hardware_interface
 {
@@ -19,18 +19,18 @@ namespace g1_hardware_interface
 inline constexpr std::size_t kNumBodyMotors = 29;
 
 /**
- * @brief What a joint's claimed interfaces mean for the firmware's control law,
- * `tau = tau_ff + kp * (q - q_meas) + kd * (dq - dq_meas)`.
+ * @brief Per-joint branch of the firmware law `tau = tau_ff + kp*(q - q_meas) + kd*(dq - dq_meas)`.
+ *
+ * Mirrors NVIDIA's fill_motor_cmd so their controllers behave identically against this component.
  */
 enum class JointControlMode : std::uint8_t
 {
-    /// Unclaimed: motor disabled, every field zero. Also where a finished release ramp lands.
+    /// Unclaimed: motor off. Holding is a controller's job, see G1FreezeController.
     kDisabled,
-    /// Position tracked at the joint's configured fallback gains, no feedforward torque.
     kPositionOnly,
-    /// Torque with damping: kp is forced to zero so the position term cannot fight the effort.
+    /// kp forced to 0 so the position term cannot fight the commanded torque.
     kEffort,
-    /// The policy mode -- the controller owns q, dq, tau, kp and kd on every tick.
+    /// The policy mode: controller owns q, dq, tau, kp and kd every tick.
     kImpedance,
 };
 
@@ -40,20 +40,22 @@ struct InterfaceClaims
     bool position = false;
     bool velocity = false;
     bool effort   = false;
-    /// kp and kd together; either one alone does not define an impedance.
+    /// kp and kd together; either alone does not define an impedance.
     bool impedance = false;
 };
 
 /**
- * @brief Maps claimed interfaces onto the mode write() acts on.
+ * @brief Maps claimed command interfaces onto the mode write() acts on.
  *
- * Impedance wins because it is the only claim carrying its own gains. A velocity-only claim
- * resolves to kDisabled: with kp and kd both zero the firmware law has no term left to act on,
- * so there is no such mode on this hardware.
+ * Impedance outranks the rest, being the only claim carrying its own gains. Velocity alone
+ * resolves to kDisabled: with kp and kd zero the firmware law has no term left to act on.
+ *
+ * @param claims Interfaces a controller currently holds on one joint.
+ * @return The branch fillMotorCmd should take for that joint.
  */
 [[nodiscard]] JointControlMode resolveJointMode(const InterfaceClaims& claims) noexcept;
 
-/// One joint's commanded values, as written by whichever controller holds its interfaces.
+/// One joint's commanded values, from whichever controller holds its interfaces.
 struct JointCommand
 {
     double position = 0.0;
@@ -63,7 +65,7 @@ struct JointCommand
     double kd       = 0.0;
 };
 
-/// Gains used in kPositionOnly, where the controller supplies no kp/kd of its own.
+/// Gains used in kPositionOnly, where the controller supplies none of its own.
 struct PositionOnlyGains
 {
     double kp = 0.0;
@@ -73,26 +75,39 @@ struct PositionOnlyGains
 /**
  * @brief Fills one motor_cmd slot for `mode`.
  *
- * @param measured_position Read only in kEffort, where q must sit on the measurement so the
- *                          position term contributes nothing while tau does the work.
+ * @param motor             Slot filled in place.
+ * @param mode              Which branch of the firmware law to command.
+ * @param command           Values written by the claiming controller.
+ * @param fallback          Gains applied in kPositionOnly.
+ * @param measured_position Read only in kEffort, where q sits on the measurement so the position
+ *                          term contributes nothing.
  */
 void fillMotorCmd(
-    unitree_hg::msg::MotorCmd& motor, JointControlMode mode, const JointCommand& command,
+    unitree_hg::msg::dds_::MotorCmd_& motor, JointControlMode mode, const JointCommand& command,
     const PositionOnlyGains& fallback, double measured_position);
 
 /**
- * @brief Fills one motor_cmd slot for the release ramp: hold position at fading stiffness with
- *        fixed damping, so authority hands back as a controlled sag rather than a drop.
+ * @brief Fills one motor_cmd slot for the release ramp: fading stiffness, fixed damping.
  *
- * @param hold_position   Where the joint was when the release began, not the live measurement --
- *                        tracking the fall would drive the joint down with it.
- * @param kp_at_release   The joint's stiffness on the last commanded tick.
+ * @param motor           Slot filled in place.
+ * @param hold_position   Where the joint was when the release began; tracking the live
+ *                        measurement would drive the joint down with the fall.
+ * @param kp_at_release   The joint's stiffness on its last commanded tick.
  * @param stiffness_scale 1.0 at the start of the ramp, 0.0 at its end.
- * @param release_kd      Damping held flat across the whole ramp, so it survives kp reaching zero.
+ * @param release_kd      Damping held flat across the ramp, so it survives kp reaching zero.
  */
 void fillReleaseCmd(
-    unitree_hg::msg::MotorCmd& motor, double hold_position, double kp_at_release,
+    unitree_hg::msg::dds_::MotorCmd_& motor, double hold_position, double kp_at_release,
     double stiffness_scale, double release_kd);
+
+/**
+ * @brief Checksums `cmd` in place over every byte but its own crc field, which the firmware
+ *        requires on every frame.
+ *
+ * @param cmd LowCmd whose crc field is overwritten.
+ * @note bit_cast rather than a uint32_t* cast; see docs/notes/lowcmd-crc-aliasing.md.
+ */
+void computeLowCmdCrc(unitree_hg::msg::dds_::LowCmd_& cmd);
 
 }  // namespace g1_hardware_interface
 

--- a/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
+++ b/workspace/src/g1_hardware_interface/include/g1_hardware_interface/lowcmd_assembly.hpp
@@ -105,7 +105,7 @@ void fillReleaseCmd(
  *        requires on every frame.
  *
  * @param cmd LowCmd whose crc field is overwritten.
- * @note bit_cast rather than a uint32_t* cast; see docs/notes/lowcmd-crc-aliasing.md.
+ * @note bit_cast rather than a uint32_t* cast, which GCC 13 optimises fields out of at -O2.
  */
 void computeLowCmdCrc(unitree_hg::msg::dds_::LowCmd_& cmd);
 

--- a/workspace/src/g1_hardware_interface/package.xml
+++ b/workspace/src/g1_hardware_interface/package.xml
@@ -21,6 +21,7 @@
   <depend>realtime_tools</depend>
   <depend>sensor_msgs</depend>
   <depend>unitree_hg</depend>
+  <depend>diagnostic_msgs</depend>
 
   <!-- Lint checks run via workspace-root CTests (see CMakeLists.txt). -->
   <test_depend>ament_lint_auto</test_depend>

--- a/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
+++ b/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
@@ -1,0 +1,639 @@
+/**
+ * @file g1_lowcmd_system.cpp
+ * @brief ros2_control SystemInterface owning the G1's 29 body motors over rt/lowcmd.
+ */
+
+#include "g1_hardware_interface/g1_lowcmd_system.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <functional>
+#include <pluginlib/class_list_macros.hpp>
+#include <thread>
+#include <unitree/robot/b2/motion_switcher/motion_switcher_client.hpp>
+#include <utility>
+
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "diagnostic_msgs/msg/key_value.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+
+namespace g1_hardware_interface
+{
+
+const std::array<std::string, kNumBodyMotors> kG1JointNames = {
+    "left_hip_pitch_joint",      "left_hip_roll_joint",        "left_hip_yaw_joint",
+    "left_knee_joint",           "left_ankle_pitch_joint",     "left_ankle_roll_joint",
+    "right_hip_pitch_joint",     "right_hip_roll_joint",       "right_hip_yaw_joint",
+    "right_knee_joint",          "right_ankle_pitch_joint",    "right_ankle_roll_joint",
+    "waist_yaw_joint",           "waist_roll_joint",           "waist_pitch_joint",
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint",   "left_shoulder_yaw_joint",
+    "left_elbow_joint",          "left_wrist_roll_joint",      "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",      "right_shoulder_pitch_joint", "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",  "right_elbow_joint",          "right_wrist_roll_joint",
+    "right_wrist_pitch_joint",   "right_wrist_yaw_joint"
+};
+
+namespace
+{
+/// mode_pr selects the ankle parameterisation; 0 is pitch/roll, which is what our URDF models.
+constexpr std::uint8_t kModePr = 0;
+
+/// Retry budget for handing control over from the onboard service. NVIDIA's numbers.
+constexpr int                       kMotionSwitchAttempts = 5;
+constexpr float                     kMotionSwitchTimeoutS = 5.0F;
+constexpr std::chrono::seconds      kMotionSwitchBackoff{ 2 };
+constexpr std::chrono::milliseconds kReleaseTickPeriod{ 5 };
+constexpr std::chrono::seconds      kFirstStateTimeout{ 10 };
+
+bool parseDouble(
+    const std::unordered_map<std::string, std::string>& params, const std::string& key, double& out)
+{
+    const auto it = params.find(key);
+    if (it == params.end())
+    {
+        return false;
+    }
+    try
+    {
+        out = std::stod(it->second);
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool parseInt(
+    const std::unordered_map<std::string, std::string>& params, const std::string& key, int& out)
+{
+    const auto it = params.find(key);
+    if (it == params.end())
+    {
+        return false;
+    }
+    try
+    {
+        out = std::stoi(it->second);
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool parseBool(
+    const std::unordered_map<std::string, std::string>& params, const std::string& key, bool& out)
+{
+    const auto it = params.find(key);
+    if (it == params.end())
+    {
+        return false;
+    }
+    out = it->second == "true" || it->second == "True" || it->second == "1";
+    return true;
+}
+
+/// Splits "joint_name/interface_type" as ros2_control hands it to a mode switch.
+std::pair<std::string, std::string> splitInterface(const std::string& interface)
+{
+    const auto pos = interface.rfind('/');
+    if (pos == std::string::npos)
+    {
+        return { "", "" };
+    }
+    return { interface.substr(0, pos), interface.substr(pos + 1) };
+}
+}  // namespace
+
+G1LowCmdSystem::~G1LowCmdSystem() { shutdownSdk(); }
+
+hardware_interface::CallbackReturn
+G1LowCmdSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
+{
+    if (SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS)
+    {
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    const auto& info = get_hardware_info();
+    executor_        = params.executor;
+
+    const auto& hw = info.hardware_parameters;
+
+    // Empty by default, and that is deliberate: a non-empty interface makes the SDK build its own
+    // inline CycloneDDS config and discard CYCLONEDDS_URI. See docs/notes/lowcmd-dds-config.md.
+    if (const auto it = hw.find("network_interface"); it != hw.end())
+    {
+        network_interface_ = it->second;
+    }
+    if (!parseInt(hw, "domain_id", domain_id_))
+    {
+        RCLCPP_ERROR(logger_, "<hardware> needs a domain_id param");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    parseInt(hw, "motor_temp_warn_threshold", motor_temp_warn_threshold_);
+    parseBool(hw, "release_motion_mode", release_motion_mode_);
+
+    double lowstate_timeout_ms = 0.0;
+    if (!parseDouble(hw, "lowstate_timeout_ms", lowstate_timeout_ms) ||
+        !parseDouble(hw, "release_ramp_s", release_ramp_s_) ||
+        !parseDouble(hw, "release_kd", release_kd_))
+    {
+        RCLCPP_ERROR(logger_, "<hardware> is missing or has an unparseable <param>");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+    lowstate_timeout_s_ = lowstate_timeout_ms / 1000.0;
+
+    if (lowstate_timeout_s_ <= 0.0 || release_ramp_s_ <= 0.0 || release_kd_ <= 0.0)
+    {
+        RCLCPP_ERROR(logger_, "lowstate_timeout_ms, release_ramp_s and release_kd must be > 0");
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    registerJoints(info);
+    registerImuSensor(info);
+    buildJointSdkMapping();
+
+    for (const auto& jd : joint_data_)
+    {
+        if (jd.sdk_index < 0)
+        {
+            RCLCPP_ERROR(logger_, "joint '%s' is not a G1 body motor", jd.name.c_str());
+            return hardware_interface::CallbackReturn::ERROR;
+        }
+    }
+
+    // The checksum covers this struct's padding, so zero all 1004 bytes once here and only ever
+    // write named fields afterwards. bit_cast reaches the padding that value-init leaves alone.
+    low_cmd_ = std::bit_cast<unitree_hg::msg::dds_::LowCmd_>(
+        std::array<std::uint32_t, sizeof(unitree_hg::msg::dds_::LowCmd_) / 4>{});
+
+    node_ = std::make_shared<rclcpp::Node>(
+        "g1_lowcmd_system_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+    if (auto executor = executor_.lock())
+    {
+        executor->add_node(node_->get_node_base_interface());
+    }
+
+    RCLCPP_INFO(logger_, "G1LowCmdSystem holds %zu joints on rt/lowcmd", joint_data_.size());
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+void G1LowCmdSystem::registerJoints(const hardware_interface::HardwareInfo& info)
+{
+    joint_data_.clear();
+    joint_data_.reserve(info.joints.size());
+    joint_name_to_index_.clear();
+
+    for (const auto& joint : info.joints)
+    {
+        JointData jd;
+        jd.name = joint.name;
+        parseDouble(joint.parameters, "position_only_kp", jd.position_only_gains.kp);
+        parseDouble(joint.parameters, "position_only_kd", jd.position_only_gains.kd);
+
+        joint_name_to_index_[joint.name] = joint_data_.size();
+        joint_data_.push_back(std::move(jd));
+    }
+}
+
+void G1LowCmdSystem::registerImuSensor(const hardware_interface::HardwareInfo& info)
+{
+    for (const auto& sensor : info.sensors)
+    {
+        const bool has_orientation = std::any_of(
+            sensor.state_interfaces.begin(),
+            sensor.state_interfaces.end(),
+            [](const auto& iface) { return iface.name.find("orientation") != std::string::npos; });
+        if (has_orientation)
+        {
+            imu_data_.name = sensor.name;
+            has_imu_       = true;
+            RCLCPP_INFO(logger_, "IMU sensor '%s' registered", sensor.name.c_str());
+            return;
+        }
+    }
+}
+
+void G1LowCmdSystem::buildJointSdkMapping()
+{
+    for (auto& jd : joint_data_)
+    {
+        for (std::size_t i = 0; i < kG1JointNames.size(); ++i)
+        {
+            if (jd.name == kG1JointNames[i])
+            {
+                jd.sdk_index = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+}
+
+std::vector<hardware_interface::StateInterface> G1LowCmdSystem::export_state_interfaces()
+{
+    std::vector<hardware_interface::StateInterface> interfaces;
+    interfaces.reserve(joint_data_.size() * 3 + (has_imu_ ? 10 : 0));
+
+    for (auto& jd : joint_data_)
+    {
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_POSITION, &jd.position_state);
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_VELOCITY, &jd.velocity_state);
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_EFFORT, &jd.effort_state);
+    }
+
+    if (has_imu_)
+    {
+        interfaces.emplace_back(imu_data_.name, "orientation.x", &imu_data_.orientation_x);
+        interfaces.emplace_back(imu_data_.name, "orientation.y", &imu_data_.orientation_y);
+        interfaces.emplace_back(imu_data_.name, "orientation.z", &imu_data_.orientation_z);
+        interfaces.emplace_back(imu_data_.name, "orientation.w", &imu_data_.orientation_w);
+        interfaces.emplace_back(imu_data_.name, "angular_velocity.x", &imu_data_.angular_velocity_x);
+        interfaces.emplace_back(imu_data_.name, "angular_velocity.y", &imu_data_.angular_velocity_y);
+        interfaces.emplace_back(imu_data_.name, "angular_velocity.z", &imu_data_.angular_velocity_z);
+        interfaces.emplace_back(
+            imu_data_.name,
+            "linear_acceleration.x",
+            &imu_data_.linear_acceleration_x);
+        interfaces.emplace_back(
+            imu_data_.name,
+            "linear_acceleration.y",
+            &imu_data_.linear_acceleration_y);
+        interfaces.emplace_back(
+            imu_data_.name,
+            "linear_acceleration.z",
+            &imu_data_.linear_acceleration_z);
+    }
+
+    return interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> G1LowCmdSystem::export_command_interfaces()
+{
+    std::vector<hardware_interface::CommandInterface> interfaces;
+    interfaces.reserve(joint_data_.size() * 5);
+
+    for (auto& jd : joint_data_)
+    {
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_POSITION, &jd.command.position);
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_VELOCITY, &jd.command.velocity);
+        interfaces.emplace_back(jd.name, hardware_interface::HW_IF_EFFORT, &jd.command.effort);
+        interfaces.emplace_back(jd.name, kHwIfKp, &jd.command.kp);
+        interfaces.emplace_back(jd.name, kHwIfKd, &jd.command.kd);
+    }
+
+    return interfaces;
+}
+
+bool G1LowCmdSystem::releaseOnboardMotionMode()
+{
+    unitree::robot::b2::MotionSwitcherClient switcher;
+    switcher.SetTimeout(kMotionSwitchTimeoutS);
+    switcher.Init();
+
+    std::string form;
+    std::string name;
+    for (int attempt = 0; attempt < kMotionSwitchAttempts; ++attempt)
+    {
+        switcher.CheckMode(form, name);
+        if (name.empty())
+        {
+            RCLCPP_INFO(logger_, "no onboard motion mode holds the motors, rt/lowcmd is ours");
+            return true;
+        }
+        RCLCPP_WARN(logger_, "onboard mode '%s' still active, releasing", name.c_str());
+        switcher.ReleaseMode();
+        std::this_thread::sleep_for(kMotionSwitchBackoff);
+    }
+
+    RCLCPP_ERROR(
+        logger_,
+        "onboard mode '%s' survived %d release attempts -- refusing to fight it for the motors",
+        name.c_str(),
+        kMotionSwitchAttempts);
+    return false;
+}
+
+bool G1LowCmdSystem::initializeSdk()
+{
+    try
+    {
+        unitree::robot::ChannelFactory::Instance()->Init(domain_id_, network_interface_);
+
+        if (release_motion_mode_ && !releaseOnboardMotionMode())
+        {
+            return false;
+        }
+
+        lowstate_subscriber_ =
+            std::make_shared<unitree::robot::ChannelSubscriber<unitree_hg::msg::dds_::LowState_>>(
+                "rt/lowstate");
+        lowstate_subscriber_->InitChannel(
+            std::bind(&G1LowCmdSystem::lowStateCallback, this, std::placeholders::_1),
+            1);
+
+        lowcmd_publisher_ =
+            std::make_shared<unitree::robot::ChannelPublisher<unitree_hg::msg::dds_::LowCmd_>>(
+                "rt/lowcmd");
+        lowcmd_publisher_->InitChannel();
+
+        const auto deadline = std::chrono::steady_clock::now() + kFirstStateTimeout;
+        while (!first_state_received_.load())
+        {
+            if (std::chrono::steady_clock::now() > deadline)
+            {
+                RCLCPP_ERROR(logger_, "no rt/lowstate within 10 s -- is the robot or sim up?");
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        sdk_initialized_ = true;
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        RCLCPP_ERROR(logger_, "SDK init failed: %s", e.what());
+        return false;
+    }
+}
+
+void G1LowCmdSystem::shutdownSdk()
+{
+    if (!sdk_initialized_.load())
+    {
+        return;
+    }
+    lowstate_subscriber_.reset();
+    lowcmd_publisher_.reset();
+    sdk_initialized_ = false;
+}
+
+void G1LowCmdSystem::lowStateCallback(const void* message)
+{
+    StampedLowState sample;
+    sample.state   = *static_cast<const unitree_hg::msg::dds_::LowState_*>(message);
+    sample.arrival = std::chrono::steady_clock::now();
+    lowstate_buffer_.writeFromNonRT(sample);
+    first_state_received_ = true;
+}
+
+bool G1LowCmdSystem::lowStateIsStale() const
+{
+    const auto* sample = lowstate_buffer_.readFromNonRT();
+    const auto  age    = std::chrono::steady_clock::now() - sample->arrival;
+    return age > std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                     std::chrono::duration<double>(lowstate_timeout_s_));
+}
+
+hardware_interface::CallbackReturn
+G1LowCmdSystem::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    if (!initializeSdk())
+    {
+        return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    const StampedLowState* sample = lowstate_buffer_.readFromRT();
+    mode_machine_                 = sample->state.mode_machine();
+
+    // Seed at the measurement with zero gains: a controller that claims a joint must supply its
+    // own stiffness before anything moves.
+    for (auto& jd : joint_data_)
+    {
+        const auto& motor = sample->state.motor_state()[static_cast<std::size_t>(jd.sdk_index)];
+        jd.position_state = motor.q();
+        jd.velocity_state = motor.dq();
+        jd.effort_state   = motor.tau_est();
+        jd.command        = JointCommand{ motor.q(), 0.0, 0.0, 0.0, 0.0 };
+        jd.mode           = JointControlMode::kDisabled;
+        jd.claims         = InterfaceClaims{};
+    }
+
+    diagnostics_pub_ = node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+        "/diagnostics",
+        rclcpp::SystemDefaultsQoS());
+    diagnostics_timer_ = node_->create_wall_timer(std::chrono::milliseconds(500), [this] {
+        diagnostic_msgs::msg::DiagnosticArray msg;
+        msg.header.stamp = node_->now();
+        for (const auto& jd : joint_data_)
+        {
+            diagnostic_msgs::msg::DiagnosticStatus status;
+            status.name        = jd.name;
+            status.hardware_id = "unitree_g1";
+            status.level       = jd.winding_temperature >= motor_temp_warn_threshold_ ?
+                                     diagnostic_msgs::msg::DiagnosticStatus::WARN :
+                                     diagnostic_msgs::msg::DiagnosticStatus::OK;
+            status.message = "surface " + std::to_string(jd.surface_temperature) + " C, winding " +
+                             std::to_string(jd.winding_temperature) + " C";
+            msg.status.push_back(status);
+        }
+        diagnostics_pub_->publish(msg);
+    });
+
+    active_ = true;
+    RCLCPP_WARN(logger_, "rt/lowcmd is now ours: no onboard balance runs underneath this component");
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+G1LowCmdSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    releaseSynchronously();
+    diagnostics_timer_.reset();
+    diagnostics_pub_.reset();
+    shutdownSdk();
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+G1LowCmdSystem::on_error(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    releaseSynchronously();
+    shutdownSdk();
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type G1LowCmdSystem::perform_command_mode_switch(
+    const std::vector<std::string>& start_interfaces,
+    const std::vector<std::string>& stop_interfaces)
+{
+    // kp and kd move as a pair: one alone does not define an impedance, so the flag only changes
+    // when both appear on the same side of the switch.
+    const auto listed =
+        [](const std::vector<std::string>& list, const std::string& joint, const char* type) {
+            return std::find(list.begin(), list.end(), joint + "/" + type) != list.end();
+        };
+
+    const auto apply = [&](const std::vector<std::string>& list, bool held) {
+        for (const auto& interface : list)
+        {
+            const auto [joint_name, type] = splitInterface(interface);
+            const auto it                 = joint_name_to_index_.find(joint_name);
+            if (it == joint_name_to_index_.end())
+            {
+                continue;
+            }
+            auto& claims = joint_data_[it->second].claims;
+
+            if (type == hardware_interface::HW_IF_POSITION)
+            {
+                claims.position = held;
+                if (held)
+                {
+                    // Take over from where the joint is, so claiming it does not step the setpoint.
+                    joint_data_[it->second].command.position =
+                        joint_data_[it->second].position_state;
+                }
+            }
+            else if (type == hardware_interface::HW_IF_VELOCITY)
+            {
+                claims.velocity = held;
+            }
+            else if (type == hardware_interface::HW_IF_EFFORT)
+            {
+                claims.effort = held;
+            }
+            else if (
+                (type == kHwIfKp || type == kHwIfKd) && listed(list, joint_name, kHwIfKp) &&
+                listed(list, joint_name, kHwIfKd))
+            {
+                claims.impedance = held;
+            }
+        }
+    };
+
+    apply(stop_interfaces, false);
+    apply(start_interfaces, true);
+
+    for (auto& jd : joint_data_)
+    {
+        jd.mode = resolveJointMode(jd.claims);
+    }
+
+    return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type
+G1LowCmdSystem::read(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+    const StampedLowState* sample = lowstate_buffer_.readFromRT();
+
+    for (auto& jd : joint_data_)
+    {
+        const auto& motor = sample->state.motor_state()[static_cast<std::size_t>(jd.sdk_index)];
+        jd.position_state = motor.q();
+        jd.velocity_state = motor.dq();
+        jd.effort_state   = motor.tau_est();
+        jd.surface_temperature = motor.temperature()[0];
+        jd.winding_temperature = motor.temperature()[1];
+    }
+
+    if (has_imu_)
+    {
+        const auto& imu = sample->state.imu_state();
+        // Unitree order the quaternion w, x, y, z.
+        imu_data_.orientation_w = imu.quaternion()[0];
+        imu_data_.orientation_x = imu.quaternion()[1];
+        imu_data_.orientation_y = imu.quaternion()[2];
+        imu_data_.orientation_z = imu.quaternion()[3];
+
+        imu_data_.angular_velocity_x = imu.gyroscope()[0];
+        imu_data_.angular_velocity_y = imu.gyroscope()[1];
+        imu_data_.angular_velocity_z = imu.gyroscope()[2];
+
+        imu_data_.linear_acceleration_x = imu.accelerometer()[0];
+        imu_data_.linear_acceleration_y = imu.accelerometer()[1];
+        imu_data_.linear_acceleration_z = imu.accelerometer()[2];
+    }
+
+    mode_machine_ = sample->state.mode_machine();
+
+    const auto age = std::chrono::steady_clock::now() - sample->arrival;
+    if (active_.load() && age > std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                    std::chrono::duration<double>(lowstate_timeout_s_)))
+    {
+        RCLCPP_ERROR(logger_, "rt/lowstate went stale while active");
+        return hardware_interface::return_type::ERROR;
+    }
+    return hardware_interface::return_type::OK;
+}
+
+void G1LowCmdSystem::publishLowCmd()
+{
+    low_cmd_.mode_pr()      = kModePr;
+    low_cmd_.mode_machine() = mode_machine_;
+    computeLowCmdCrc(low_cmd_);
+    lowcmd_publisher_->Write(low_cmd_);
+}
+
+hardware_interface::return_type
+G1LowCmdSystem::write(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+    if (!active_.load() || !sdk_initialized_.load())
+    {
+        return hardware_interface::return_type::OK;
+    }
+
+    for (const auto& jd : joint_data_)
+    {
+        fillMotorCmd(
+            low_cmd_.motor_cmd()[static_cast<std::size_t>(jd.sdk_index)],
+            jd.mode,
+            jd.command,
+            jd.position_only_gains,
+            jd.position_state);
+    }
+
+    publishLowCmd();
+    return hardware_interface::return_type::OK;
+}
+
+void G1LowCmdSystem::releaseSynchronously()
+{
+    if (!active_.exchange(false) || !sdk_initialized_.load())
+    {
+        return;
+    }
+
+    for (auto& jd : joint_data_)
+    {
+        jd.release_hold_position = jd.position_state;
+        jd.release_kp =
+            jd.mode == JointControlMode::kImpedance ? jd.command.kp : jd.position_only_gains.kp;
+    }
+
+    const auto ticks = static_cast<int>(
+        release_ramp_s_ / std::chrono::duration<double>(kReleaseTickPeriod).count());
+    for (int tick = 0; tick <= ticks; ++tick)
+    {
+        const double scale = 1.0 - static_cast<double>(tick) / static_cast<double>(ticks);
+        for (const auto& jd : joint_data_)
+        {
+            fillReleaseCmd(
+                low_cmd_.motor_cmd()[static_cast<std::size_t>(jd.sdk_index)],
+                jd.release_hold_position,
+                jd.release_kp,
+                scale,
+                release_kd_);
+        }
+        publishLowCmd();
+        std::this_thread::sleep_for(kReleaseTickPeriod);
+    }
+
+    for (const auto& jd : joint_data_)
+    {
+        fillMotorCmd(
+            low_cmd_.motor_cmd()[static_cast<std::size_t>(jd.sdk_index)],
+            JointControlMode::kDisabled,
+            jd.command,
+            jd.position_only_gains,
+            jd.position_state);
+    }
+    publishLowCmd();
+}
+
+}  // namespace g1_hardware_interface
+
+PLUGINLIB_EXPORT_CLASS(g1_hardware_interface::G1LowCmdSystem, hardware_interface::SystemInterface)

--- a/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
+++ b/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
@@ -9,6 +9,7 @@
 #include <bit>
 #include <functional>
 #include <pluginlib/class_list_macros.hpp>
+#include <string_view>
 #include <thread>
 #include <unitree/robot/b2/motion_switcher/motion_switcher_client.hpp>
 #include <utility>
@@ -279,8 +280,8 @@ std::vector<hardware_interface::CommandInterface> G1LowCmdSystem::export_command
         interfaces.emplace_back(jd.name, hardware_interface::HW_IF_POSITION, &jd.command.position);
         interfaces.emplace_back(jd.name, hardware_interface::HW_IF_VELOCITY, &jd.command.velocity);
         interfaces.emplace_back(jd.name, hardware_interface::HW_IF_EFFORT, &jd.command.effort);
-        interfaces.emplace_back(jd.name, kHwIfKp, &jd.command.kp);
-        interfaces.emplace_back(jd.name, kHwIfKd, &jd.command.kd);
+        interfaces.emplace_back(jd.name, std::string(kHwIfKp), &jd.command.kp);
+        interfaces.emplace_back(jd.name, std::string(kHwIfKd), &jd.command.kd);
     }
 
     return interfaces;
@@ -330,7 +331,7 @@ bool G1LowCmdSystem::initializeSdk()
             std::make_shared<unitree::robot::ChannelSubscriber<unitree_hg::msg::dds_::LowState_>>(
                 "rt/lowstate");
         lowstate_subscriber_->InitChannel(
-            std::bind(&G1LowCmdSystem::lowStateCallback, this, std::placeholders::_1),
+            [this](const void* message) { lowStateCallback(message); },
             1);
 
         lowcmd_publisher_ =
@@ -462,8 +463,9 @@ hardware_interface::return_type G1LowCmdSystem::perform_command_mode_switch(
     // kp and kd move as a pair: one alone does not define an impedance, so the flag only changes
     // when both appear on the same side of the switch.
     const auto listed =
-        [](const std::vector<std::string>& list, const std::string& joint, const char* type) {
-            return std::find(list.begin(), list.end(), joint + "/" + type) != list.end();
+        [](const std::vector<std::string>& list, const std::string& joint, std::string_view type) {
+            const std::string full = joint + "/" + std::string(type);
+            return std::find(list.begin(), list.end(), full) != list.end();
         };
 
     const auto apply = [&](const std::vector<std::string>& list, bool held) {

--- a/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
+++ b/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
@@ -428,6 +428,16 @@ G1LowCmdSystem::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
                                      diagnostic_msgs::msg::DiagnosticStatus::OK;
             status.message = "surface " + std::to_string(jd.surface_temperature) + " C, winding " +
                              std::to_string(jd.winding_temperature) + " C";
+
+            // Same keys NVIDIA publish, so a consumer written against their stack reads ours.
+            diagnostic_msgs::msg::KeyValue surface;
+            surface.key   = "surface_temperature_C";
+            surface.value = std::to_string(jd.surface_temperature);
+            diagnostic_msgs::msg::KeyValue winding;
+            winding.key   = "winding_temperature_C";
+            winding.value = std::to_string(jd.winding_temperature);
+            status.values = { surface, winding };
+
             msg.status.push_back(status);
         }
         diagnostics_pub_->publish(msg);
@@ -451,6 +461,15 @@ G1LowCmdSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 hardware_interface::CallbackReturn
 G1LowCmdSystem::on_error(const rclcpp_lifecycle::State& /*previous_state*/)
 {
+    releaseSynchronously();
+    shutdownSdk();
+    return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+G1LowCmdSystem::on_shutdown(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+    // Idempotent: releaseSynchronously() returns immediately if a deactivate already ran.
     releaseSynchronously();
     shutdownSdk();
     return hardware_interface::CallbackReturn::SUCCESS;
@@ -562,12 +581,12 @@ G1LowCmdSystem::read(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*per
     return hardware_interface::return_type::OK;
 }
 
-void G1LowCmdSystem::publishLowCmd()
+bool G1LowCmdSystem::publishLowCmd()
 {
     low_cmd_.mode_pr()      = kModePr;
     low_cmd_.mode_machine() = mode_machine_;
     computeLowCmdCrc(low_cmd_);
-    lowcmd_publisher_->Write(low_cmd_);
+    return lowcmd_publisher_->Write(low_cmd_);
 }
 
 hardware_interface::return_type
@@ -588,7 +607,11 @@ G1LowCmdSystem::write(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*pe
             jd.position_state);
     }
 
-    publishLowCmd();
+    if (!publishLowCmd())
+    {
+        RCLCPP_ERROR(logger_, "rt/lowcmd write refused -- the robot is no longer being commanded");
+        return hardware_interface::return_type::ERROR;
+    }
     return hardware_interface::return_type::OK;
 }
 
@@ -606,8 +629,12 @@ void G1LowCmdSystem::releaseSynchronously()
             jd.mode == JointControlMode::kImpedance ? jd.command.kp : jd.position_only_gains.kp;
     }
 
-    const auto ticks = static_cast<int>(
-        release_ramp_s_ / std::chrono::duration<double>(kReleaseTickPeriod).count());
+    // At least one tick: release_ramp_s_ is only validated positive, and a sub-tick value would
+    // divide by zero below and put NaN gains on every motor.
+    const int ticks = std::max(
+        1,
+        static_cast<int>(
+            release_ramp_s_ / std::chrono::duration<double>(kReleaseTickPeriod).count()));
     for (int tick = 0; tick <= ticks; ++tick)
     {
         const double scale = 1.0 - static_cast<double>(tick) / static_cast<double>(ticks);

--- a/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
+++ b/workspace/src/g1_hardware_interface/src/g1_lowcmd_system.cpp
@@ -122,8 +122,8 @@ G1LowCmdSystem::on_init(const hardware_interface::HardwareComponentInterfacePara
 
     const auto& hw = info.hardware_parameters;
 
-    // Empty by default, and that is deliberate: a non-empty interface makes the SDK build its own
-    // inline CycloneDDS config and discard CYCLONEDDS_URI. See docs/notes/lowcmd-dds-config.md.
+    // Deliberately empty by default: a non-empty interface makes the SDK build its own inline
+    // CycloneDDS config and discard CYCLONEDDS_URI, which is what pins us to loopback.
     if (const auto it = hw.find("network_interface"); it != hw.end())
     {
         network_interface_ = it->second;

--- a/workspace/src/g1_hardware_interface/src/lowcmd_assembly.cpp
+++ b/workspace/src/g1_hardware_interface/src/lowcmd_assembly.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file lowcmd_assembly.cpp
+ * @brief Mode resolution and per-motor LowCmd packing for the rt/lowcmd path.
+ */
+
+#include "g1_hardware_interface/lowcmd_assembly.hpp"
+
+namespace g1_hardware_interface
+{
+
+namespace
+{
+/// MotorCmd.mode: 1 enables the motor, 0 leaves it unpowered. Unitree's hg low-level examples.
+constexpr std::uint8_t kMotorEnabled  = 1;
+constexpr std::uint8_t kMotorDisabled = 0;
+}  // namespace
+
+JointControlMode resolveJointMode(const InterfaceClaims& claims) noexcept
+{
+    if (claims.impedance)
+    {
+        return JointControlMode::kImpedance;
+    }
+    if (claims.effort)
+    {
+        return JointControlMode::kEffort;
+    }
+    if (claims.position)
+    {
+        return JointControlMode::kPositionOnly;
+    }
+    return JointControlMode::kDisabled;
+}
+
+void fillMotorCmd(
+    unitree_hg::msg::MotorCmd& motor, JointControlMode mode, const JointCommand& command,
+    const PositionOnlyGains& fallback, double measured_position)
+{
+    switch (mode)
+    {
+        case JointControlMode::kImpedance:
+            motor.mode = kMotorEnabled;
+            motor.q    = static_cast<float>(command.position);
+            motor.dq   = static_cast<float>(command.velocity);
+            motor.tau  = static_cast<float>(command.effort);
+            motor.kp   = static_cast<float>(command.kp);
+            motor.kd   = static_cast<float>(command.kd);
+            break;
+
+        case JointControlMode::kEffort:
+            motor.mode = kMotorEnabled;
+            motor.q    = static_cast<float>(measured_position);
+            motor.dq   = static_cast<float>(command.velocity);
+            motor.tau  = static_cast<float>(command.effort);
+            motor.kp   = 0.0F;
+            motor.kd   = static_cast<float>(command.kd);
+            break;
+
+        case JointControlMode::kPositionOnly:
+            motor.mode = kMotorEnabled;
+            motor.q    = static_cast<float>(command.position);
+            motor.dq   = 0.0F;
+            motor.tau  = 0.0F;
+            motor.kp   = static_cast<float>(fallback.kp);
+            motor.kd   = static_cast<float>(fallback.kd);
+            break;
+
+        case JointControlMode::kDisabled:
+            motor.mode = kMotorDisabled;
+            motor.q    = 0.0F;
+            motor.dq   = 0.0F;
+            motor.tau  = 0.0F;
+            motor.kp   = 0.0F;
+            motor.kd   = 0.0F;
+            break;
+    }
+}
+
+void fillReleaseCmd(
+    unitree_hg::msg::MotorCmd& motor, double hold_position, double kp_at_release,
+    double stiffness_scale, double release_kd)
+{
+    motor.mode = kMotorEnabled;
+    motor.q    = static_cast<float>(hold_position);
+    motor.dq   = 0.0F;
+    motor.tau  = 0.0F;
+    motor.kp   = static_cast<float>(kp_at_release * stiffness_scale);
+    motor.kd   = static_cast<float>(release_kd);
+}
+
+}  // namespace g1_hardware_interface

--- a/workspace/src/g1_hardware_interface/src/lowcmd_assembly.cpp
+++ b/workspace/src/g1_hardware_interface/src/lowcmd_assembly.cpp
@@ -1,9 +1,14 @@
 /**
  * @file lowcmd_assembly.cpp
- * @brief Mode resolution and per-motor LowCmd packing for the rt/lowcmd path.
+ * @brief Mode resolution, per-motor LowCmd packing and the checksum for the rt/lowcmd path.
  */
 
 #include "g1_hardware_interface/lowcmd_assembly.hpp"
+
+#include <bit>
+#include <type_traits>
+
+#include "g1_hardware_interface/motor_crc_hg.hpp"
 
 namespace g1_hardware_interface
 {
@@ -13,6 +18,14 @@ namespace
 /// MotorCmd.mode: 1 enables the motor, 0 leaves it unpowered. Unitree's hg low-level examples.
 constexpr std::uint8_t kMotorEnabled  = 1;
 constexpr std::uint8_t kMotorDisabled = 0;
+
+using LowCmd = unitree_hg::msg::dds_::LowCmd_;
+
+static_assert(
+    sizeof(LowCmd) == 1004 && sizeof(LowCmd) % sizeof(std::uint32_t) == 0,
+    "LowCmd_ must keep the wire layout the firmware checksums, in whole 32-bit words");
+static_assert(
+    std::is_trivially_copyable_v<LowCmd>, "bit_cast to a word array needs trivial copyability");
 }  // namespace
 
 JointControlMode resolveJointMode(const InterfaceClaims& claims) noexcept
@@ -33,59 +46,66 @@ JointControlMode resolveJointMode(const InterfaceClaims& claims) noexcept
 }
 
 void fillMotorCmd(
-    unitree_hg::msg::MotorCmd& motor, JointControlMode mode, const JointCommand& command,
+    unitree_hg::msg::dds_::MotorCmd_& motor, JointControlMode mode, const JointCommand& command,
     const PositionOnlyGains& fallback, double measured_position)
 {
     switch (mode)
     {
         case JointControlMode::kImpedance:
-            motor.mode = kMotorEnabled;
-            motor.q    = static_cast<float>(command.position);
-            motor.dq   = static_cast<float>(command.velocity);
-            motor.tau  = static_cast<float>(command.effort);
-            motor.kp   = static_cast<float>(command.kp);
-            motor.kd   = static_cast<float>(command.kd);
+            motor.mode() = kMotorEnabled;
+            motor.q()    = static_cast<float>(command.position);
+            motor.dq()   = static_cast<float>(command.velocity);
+            motor.tau()  = static_cast<float>(command.effort);
+            motor.kp()   = static_cast<float>(command.kp);
+            motor.kd()   = static_cast<float>(command.kd);
             break;
 
         case JointControlMode::kEffort:
-            motor.mode = kMotorEnabled;
-            motor.q    = static_cast<float>(measured_position);
-            motor.dq   = static_cast<float>(command.velocity);
-            motor.tau  = static_cast<float>(command.effort);
-            motor.kp   = 0.0F;
-            motor.kd   = static_cast<float>(command.kd);
+            motor.mode() = kMotorEnabled;
+            motor.q()    = static_cast<float>(measured_position);
+            motor.dq()   = static_cast<float>(command.velocity);
+            motor.tau()  = static_cast<float>(command.effort);
+            motor.kp()   = 0.0F;
+            motor.kd()   = static_cast<float>(command.kd);
             break;
 
         case JointControlMode::kPositionOnly:
-            motor.mode = kMotorEnabled;
-            motor.q    = static_cast<float>(command.position);
-            motor.dq   = 0.0F;
-            motor.tau  = 0.0F;
-            motor.kp   = static_cast<float>(fallback.kp);
-            motor.kd   = static_cast<float>(fallback.kd);
+            motor.mode() = kMotorEnabled;
+            motor.q()    = static_cast<float>(command.position);
+            motor.dq()   = 0.0F;
+            motor.tau()  = 0.0F;
+            motor.kp()   = static_cast<float>(fallback.kp);
+            motor.kd()   = static_cast<float>(fallback.kd);
             break;
 
         case JointControlMode::kDisabled:
-            motor.mode = kMotorDisabled;
-            motor.q    = 0.0F;
-            motor.dq   = 0.0F;
-            motor.tau  = 0.0F;
-            motor.kp   = 0.0F;
-            motor.kd   = 0.0F;
+            motor.mode() = kMotorDisabled;
+            motor.q()    = 0.0F;
+            motor.dq()   = 0.0F;
+            motor.tau()  = 0.0F;
+            motor.kp()   = 0.0F;
+            motor.kd()   = 0.0F;
             break;
     }
 }
 
 void fillReleaseCmd(
-    unitree_hg::msg::MotorCmd& motor, double hold_position, double kp_at_release,
+    unitree_hg::msg::dds_::MotorCmd_& motor, double hold_position, double kp_at_release,
     double stiffness_scale, double release_kd)
 {
-    motor.mode = kMotorEnabled;
-    motor.q    = static_cast<float>(hold_position);
-    motor.dq   = 0.0F;
-    motor.tau  = 0.0F;
-    motor.kp   = static_cast<float>(kp_at_release * stiffness_scale);
-    motor.kd   = static_cast<float>(release_kd);
+    motor.mode() = kMotorEnabled;
+    motor.q()    = static_cast<float>(hold_position);
+    motor.dq()   = 0.0F;
+    motor.tau()  = 0.0F;
+    motor.kp()   = static_cast<float>(kp_at_release * stiffness_scale);
+    motor.kd()   = static_cast<float>(release_kd);
+}
+
+void computeLowCmdCrc(unitree_hg::msg::dds_::LowCmd_& cmd)
+{
+    cmd.crc()        = 0;
+    const auto words = std::bit_cast<std::array<std::uint32_t, sizeof(LowCmd) / 4>>(cmd);
+    cmd.crc() = vendored::crc32Core(words.data(), static_cast<std::uint32_t>(words.size()) - 1);
 }
 
 }  // namespace g1_hardware_interface

--- a/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
+++ b/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
@@ -108,7 +108,7 @@ void computeLowCmdCrc(unitree_hg::msg::LowCmd& msg)
     raw.reserve = msg.reserve;
 
     // bit_cast, not a uint32_t* cast: that cast is a strict-aliasing violation GCC 13 acts on at
-    // -O2, dropping mode_pr/mode_machine. See docs/notes/lowcmd-crc-aliasing.md.
+    // -O2, silently dropping mode_pr and mode_machine from the sum.
     const auto words = std::bit_cast<std::array<std::uint32_t, sizeof(RawLowCmd) / 4>>(raw);
     raw.crc          = crc32Core(words.data(), static_cast<std::uint32_t>(words.size()) - 1);
     msg.crc          = raw.crc;

--- a/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
+++ b/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
@@ -107,12 +107,8 @@ void computeLowCmdCrc(unitree_hg::msg::LowCmd& msg)
     }
     raw.reserve = msg.reserve;
 
-    /*
-     * bit_cast, not reinterpret_cast: reading RawLowCmd through a uint32_t* is a strict-aliasing
-     * violation, and at -O2 GCC 13 acts on it -- measured, the mode_pr/mode_machine stores were
-     * dropped from the checksum entirely. Harmless on rt/arm_sdk where both are always 0, fatal
-     * on rt/lowcmd where mode_machine carries 5. test_motor_crc_hg pins it.
-     */
+    // bit_cast, not a uint32_t* cast: that cast is a strict-aliasing violation GCC 13 acts on at
+    // -O2, dropping mode_pr/mode_machine. See docs/notes/lowcmd-crc-aliasing.md.
     const auto words = std::bit_cast<std::array<std::uint32_t, sizeof(RawLowCmd) / 4>>(raw);
     raw.crc          = crc32Core(words.data(), static_cast<std::uint32_t>(words.size()) - 1);
     msg.crc          = raw.crc;

--- a/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
+++ b/workspace/src/g1_hardware_interface/src/motor_crc_hg.cpp
@@ -7,6 +7,7 @@
 #include "g1_hardware_interface/motor_crc_hg.hpp"
 
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <cstring>
 
@@ -106,10 +107,15 @@ void computeLowCmdCrc(unitree_hg::msg::LowCmd& msg)
     }
     raw.reserve = msg.reserve;
 
-    raw.crc = crc32Core(
-        reinterpret_cast<const std::uint32_t*>(&raw),
-        static_cast<std::uint32_t>(sizeof(RawLowCmd) >> 2) - 1);
-    msg.crc = raw.crc;
+    /*
+     * bit_cast, not reinterpret_cast: reading RawLowCmd through a uint32_t* is a strict-aliasing
+     * violation, and at -O2 GCC 13 acts on it -- measured, the mode_pr/mode_machine stores were
+     * dropped from the checksum entirely. Harmless on rt/arm_sdk where both are always 0, fatal
+     * on rt/lowcmd where mode_machine carries 5. test_motor_crc_hg pins it.
+     */
+    const auto words = std::bit_cast<std::array<std::uint32_t, sizeof(RawLowCmd) / 4>>(raw);
+    raw.crc          = crc32Core(words.data(), static_cast<std::uint32_t>(words.size()) - 1);
+    msg.crc          = raw.crc;
 }
 
 }  // namespace g1_hardware_interface::vendored

--- a/workspace/src/g1_hardware_interface/test/test_lowcmd_assembly.cpp
+++ b/workspace/src/g1_hardware_interface/test/test_lowcmd_assembly.cpp
@@ -4,8 +4,9 @@
  */
 #include <gmock/gmock.h>
 
+#include <cstring>
+
 #include "g1_hardware_interface/lowcmd_assembly.hpp"
-#include "unitree_hg/msg/low_cmd.hpp"
 
 namespace g1_hardware_interface
 {
@@ -18,7 +19,7 @@ JointCommand commandFixture() { return JointCommand{ 0.25, 1.5, -3.0, 80.0, 2.0 
 
 TEST(ResolveJointMode, ImpedanceWinsOverEveryOtherClaim)
 {
-    // kp+kd is the only claim that carries its own gains, so it outranks the rest.
+    // kp+kd is the only claim carrying its own gains, so it outranks the rest.
     EXPECT_EQ(
         resolveJointMode(InterfaceClaims{ true, true, true, true }),
         JointControlMode::kImpedance);
@@ -43,8 +44,7 @@ TEST(ResolveJointMode, PositionAloneIsPositionOnly)
 
 TEST(ResolveJointMode, VelocityAloneIsDisabled)
 {
-    // There is no velocity-only mode on this hardware: with kp and kd both zero the firmware's
-    // law has nothing left to act on, so claiming velocity alone must not look like control.
+    // No velocity-only mode exists on this hardware, so the claim must not look like control.
     EXPECT_EQ(
         resolveJointMode(InterfaceClaims{ false, true, false, false }),
         JointControlMode::kDisabled);
@@ -57,84 +57,83 @@ TEST(ResolveJointMode, NoClaimsIsDisabled)
 
 TEST(FillMotorCmd, ImpedancePassesEveryCommandedFieldThrough)
 {
-    unitree_hg::msg::MotorCmd motor{};
+    unitree_hg::msg::dds_::MotorCmd_ motor{};
     fillMotorCmd(motor, JointControlMode::kImpedance, commandFixture(), kFallback, 99.0);
 
-    EXPECT_EQ(motor.mode, 1U);
-    EXPECT_FLOAT_EQ(motor.q, 0.25F);
-    EXPECT_FLOAT_EQ(motor.dq, 1.5F);
-    EXPECT_FLOAT_EQ(motor.tau, -3.0F);
-    EXPECT_FLOAT_EQ(motor.kp, 80.0F);
-    EXPECT_FLOAT_EQ(motor.kd, 2.0F);
+    EXPECT_EQ(motor.mode(), 1U);
+    EXPECT_FLOAT_EQ(motor.q(), 0.25F);
+    EXPECT_FLOAT_EQ(motor.dq(), 1.5F);
+    EXPECT_FLOAT_EQ(motor.tau(), -3.0F);
+    EXPECT_FLOAT_EQ(motor.kp(), 80.0F);
+    EXPECT_FLOAT_EQ(motor.kd(), 2.0F);
 }
 
 TEST(FillMotorCmd, EffortPinsPositionToTheMeasurementAndZeroesStiffness)
 {
-    unitree_hg::msg::MotorCmd motor{};
+    unitree_hg::msg::dds_::MotorCmd_ motor{};
     fillMotorCmd(motor, JointControlMode::kEffort, commandFixture(), kFallback, 99.0);
 
-    // q must sit on the measurement, not the stale position command: kp is zero here, but a
-    // later gain change would otherwise turn a forgotten setpoint into a lurch.
-    EXPECT_FLOAT_EQ(motor.q, 99.0F);
-    EXPECT_FLOAT_EQ(motor.kp, 0.0F);
-    EXPECT_FLOAT_EQ(motor.tau, -3.0F);
-    EXPECT_FLOAT_EQ(motor.kd, 2.0F);
+    // q sits on the measurement, not a stale setpoint a later gain change could turn into a lurch.
+    EXPECT_FLOAT_EQ(motor.q(), 99.0F);
+    EXPECT_FLOAT_EQ(motor.kp(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau(), -3.0F);
+    EXPECT_FLOAT_EQ(motor.kd(), 2.0F);
 }
 
 TEST(FillMotorCmd, PositionOnlyUsesFallbackGainsAndNoFeedforward)
 {
-    unitree_hg::msg::MotorCmd motor{};
+    unitree_hg::msg::dds_::MotorCmd_ motor{};
     fillMotorCmd(motor, JointControlMode::kPositionOnly, commandFixture(), kFallback, 99.0);
 
-    EXPECT_FLOAT_EQ(motor.q, 0.25F);
-    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
-    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
-    EXPECT_FLOAT_EQ(motor.kp, 10.0F);
-    EXPECT_FLOAT_EQ(motor.kd, 1.0F);
+    EXPECT_FLOAT_EQ(motor.q(), 0.25F);
+    EXPECT_FLOAT_EQ(motor.dq(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.kp(), 10.0F);
+    EXPECT_FLOAT_EQ(motor.kd(), 1.0F);
 }
 
 TEST(FillMotorCmd, DisabledZeroesEverythingIncludingTheModeByte)
 {
-    unitree_hg::msg::MotorCmd motor{};
-    // Pre-load the slot so the test fails if the branch leaves a previous tick's values behind.
+    unitree_hg::msg::dds_::MotorCmd_ motor{};
+    // Pre-loaded, so the test fails if the branch leaves a previous tick's values behind.
     fillMotorCmd(motor, JointControlMode::kImpedance, commandFixture(), kFallback, 99.0);
     fillMotorCmd(motor, JointControlMode::kDisabled, commandFixture(), kFallback, 99.0);
 
-    EXPECT_EQ(motor.mode, 0U);
-    EXPECT_FLOAT_EQ(motor.q, 0.0F);
-    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
-    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
-    EXPECT_FLOAT_EQ(motor.kp, 0.0F);
-    EXPECT_FLOAT_EQ(motor.kd, 0.0F);
+    EXPECT_EQ(motor.mode(), 0U);
+    EXPECT_FLOAT_EQ(motor.q(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.dq(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.kp(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.kd(), 0.0F);
 }
 
 TEST(FillReleaseCmd, StiffnessFadesWhileDampingAndHoldPositionStay)
 {
-    unitree_hg::msg::MotorCmd start{};
+    unitree_hg::msg::dds_::MotorCmd_ start{};
     fillReleaseCmd(start, 0.4, 80.0, 1.0, 3.0);
-    EXPECT_FLOAT_EQ(start.q, 0.4F);
-    EXPECT_FLOAT_EQ(start.kp, 80.0F);
-    EXPECT_FLOAT_EQ(start.kd, 3.0F);
+    EXPECT_FLOAT_EQ(start.q(), 0.4F);
+    EXPECT_FLOAT_EQ(start.kp(), 80.0F);
+    EXPECT_FLOAT_EQ(start.kd(), 3.0F);
 
-    unitree_hg::msg::MotorCmd midway{};
+    unitree_hg::msg::dds_::MotorCmd_ midway{};
     fillReleaseCmd(midway, 0.4, 80.0, 0.5, 3.0);
-    EXPECT_FLOAT_EQ(midway.kp, 40.0F);
+    EXPECT_FLOAT_EQ(midway.kp(), 40.0F);
 
-    // Damping must outlive the stiffness, otherwise the last tick of the ramp is a free drop.
-    unitree_hg::msg::MotorCmd finish{};
+    // Damping outlives the stiffness, otherwise the ramp's last tick is a free drop.
+    unitree_hg::msg::dds_::MotorCmd_ finish{};
     fillReleaseCmd(finish, 0.4, 80.0, 0.0, 3.0);
-    EXPECT_FLOAT_EQ(finish.kp, 0.0F);
-    EXPECT_FLOAT_EQ(finish.kd, 3.0F);
-    EXPECT_FLOAT_EQ(finish.q, 0.4F);
-    EXPECT_EQ(finish.mode, 1U);
+    EXPECT_FLOAT_EQ(finish.kp(), 0.0F);
+    EXPECT_FLOAT_EQ(finish.kd(), 3.0F);
+    EXPECT_FLOAT_EQ(finish.q(), 0.4F);
+    EXPECT_EQ(finish.mode(), 1U);
 }
 
 TEST(FillReleaseCmd, NeverCommandsTorque)
 {
-    unitree_hg::msg::MotorCmd motor{};
+    unitree_hg::msg::dds_::MotorCmd_ motor{};
     fillReleaseCmd(motor, 0.4, 80.0, 0.7, 3.0);
-    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
-    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau(), 0.0F);
+    EXPECT_FLOAT_EQ(motor.dq(), 0.0F);
 }
 
 }  // namespace

--- a/workspace/src/g1_hardware_interface/test/test_lowcmd_assembly.cpp
+++ b/workspace/src/g1_hardware_interface/test/test_lowcmd_assembly.cpp
@@ -1,0 +1,141 @@
+/**
+ * @file test_lowcmd_assembly.cpp
+ * @brief Unit tests for the rt/lowcmd mode table and per-motor packing.
+ */
+#include <gmock/gmock.h>
+
+#include "g1_hardware_interface/lowcmd_assembly.hpp"
+#include "unitree_hg/msg/low_cmd.hpp"
+
+namespace g1_hardware_interface
+{
+namespace
+{
+
+constexpr PositionOnlyGains kFallback{ 10.0, 1.0 };
+
+JointCommand commandFixture() { return JointCommand{ 0.25, 1.5, -3.0, 80.0, 2.0 }; }
+
+TEST(ResolveJointMode, ImpedanceWinsOverEveryOtherClaim)
+{
+    // kp+kd is the only claim that carries its own gains, so it outranks the rest.
+    EXPECT_EQ(
+        resolveJointMode(InterfaceClaims{ true, true, true, true }),
+        JointControlMode::kImpedance);
+    EXPECT_EQ(
+        resolveJointMode(InterfaceClaims{ false, false, false, true }),
+        JointControlMode::kImpedance);
+}
+
+TEST(ResolveJointMode, EffortOutranksPosition)
+{
+    EXPECT_EQ(
+        resolveJointMode(InterfaceClaims{ true, false, true, false }),
+        JointControlMode::kEffort);
+}
+
+TEST(ResolveJointMode, PositionAloneIsPositionOnly)
+{
+    EXPECT_EQ(
+        resolveJointMode(InterfaceClaims{ true, false, false, false }),
+        JointControlMode::kPositionOnly);
+}
+
+TEST(ResolveJointMode, VelocityAloneIsDisabled)
+{
+    // There is no velocity-only mode on this hardware: with kp and kd both zero the firmware's
+    // law has nothing left to act on, so claiming velocity alone must not look like control.
+    EXPECT_EQ(
+        resolveJointMode(InterfaceClaims{ false, true, false, false }),
+        JointControlMode::kDisabled);
+}
+
+TEST(ResolveJointMode, NoClaimsIsDisabled)
+{
+    EXPECT_EQ(resolveJointMode(InterfaceClaims{}), JointControlMode::kDisabled);
+}
+
+TEST(FillMotorCmd, ImpedancePassesEveryCommandedFieldThrough)
+{
+    unitree_hg::msg::MotorCmd motor{};
+    fillMotorCmd(motor, JointControlMode::kImpedance, commandFixture(), kFallback, 99.0);
+
+    EXPECT_EQ(motor.mode, 1U);
+    EXPECT_FLOAT_EQ(motor.q, 0.25F);
+    EXPECT_FLOAT_EQ(motor.dq, 1.5F);
+    EXPECT_FLOAT_EQ(motor.tau, -3.0F);
+    EXPECT_FLOAT_EQ(motor.kp, 80.0F);
+    EXPECT_FLOAT_EQ(motor.kd, 2.0F);
+}
+
+TEST(FillMotorCmd, EffortPinsPositionToTheMeasurementAndZeroesStiffness)
+{
+    unitree_hg::msg::MotorCmd motor{};
+    fillMotorCmd(motor, JointControlMode::kEffort, commandFixture(), kFallback, 99.0);
+
+    // q must sit on the measurement, not the stale position command: kp is zero here, but a
+    // later gain change would otherwise turn a forgotten setpoint into a lurch.
+    EXPECT_FLOAT_EQ(motor.q, 99.0F);
+    EXPECT_FLOAT_EQ(motor.kp, 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau, -3.0F);
+    EXPECT_FLOAT_EQ(motor.kd, 2.0F);
+}
+
+TEST(FillMotorCmd, PositionOnlyUsesFallbackGainsAndNoFeedforward)
+{
+    unitree_hg::msg::MotorCmd motor{};
+    fillMotorCmd(motor, JointControlMode::kPositionOnly, commandFixture(), kFallback, 99.0);
+
+    EXPECT_FLOAT_EQ(motor.q, 0.25F);
+    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
+    EXPECT_FLOAT_EQ(motor.kp, 10.0F);
+    EXPECT_FLOAT_EQ(motor.kd, 1.0F);
+}
+
+TEST(FillMotorCmd, DisabledZeroesEverythingIncludingTheModeByte)
+{
+    unitree_hg::msg::MotorCmd motor{};
+    // Pre-load the slot so the test fails if the branch leaves a previous tick's values behind.
+    fillMotorCmd(motor, JointControlMode::kImpedance, commandFixture(), kFallback, 99.0);
+    fillMotorCmd(motor, JointControlMode::kDisabled, commandFixture(), kFallback, 99.0);
+
+    EXPECT_EQ(motor.mode, 0U);
+    EXPECT_FLOAT_EQ(motor.q, 0.0F);
+    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
+    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
+    EXPECT_FLOAT_EQ(motor.kp, 0.0F);
+    EXPECT_FLOAT_EQ(motor.kd, 0.0F);
+}
+
+TEST(FillReleaseCmd, StiffnessFadesWhileDampingAndHoldPositionStay)
+{
+    unitree_hg::msg::MotorCmd start{};
+    fillReleaseCmd(start, 0.4, 80.0, 1.0, 3.0);
+    EXPECT_FLOAT_EQ(start.q, 0.4F);
+    EXPECT_FLOAT_EQ(start.kp, 80.0F);
+    EXPECT_FLOAT_EQ(start.kd, 3.0F);
+
+    unitree_hg::msg::MotorCmd midway{};
+    fillReleaseCmd(midway, 0.4, 80.0, 0.5, 3.0);
+    EXPECT_FLOAT_EQ(midway.kp, 40.0F);
+
+    // Damping must outlive the stiffness, otherwise the last tick of the ramp is a free drop.
+    unitree_hg::msg::MotorCmd finish{};
+    fillReleaseCmd(finish, 0.4, 80.0, 0.0, 3.0);
+    EXPECT_FLOAT_EQ(finish.kp, 0.0F);
+    EXPECT_FLOAT_EQ(finish.kd, 3.0F);
+    EXPECT_FLOAT_EQ(finish.q, 0.4F);
+    EXPECT_EQ(finish.mode, 1U);
+}
+
+TEST(FillReleaseCmd, NeverCommandsTorque)
+{
+    unitree_hg::msg::MotorCmd motor{};
+    fillReleaseCmd(motor, 0.4, 80.0, 0.7, 3.0);
+    EXPECT_FLOAT_EQ(motor.tau, 0.0F);
+    EXPECT_FLOAT_EQ(motor.dq, 0.0F);
+}
+
+}  // namespace
+}  // namespace g1_hardware_interface

--- a/workspace/src/g1_hardware_interface/test/test_motor_crc_hg.cpp
+++ b/workspace/src/g1_hardware_interface/test/test_motor_crc_hg.cpp
@@ -1,10 +1,7 @@
 /**
  * @file test_motor_crc_hg.cpp
- * @brief Coverage tests for the LowCmd checksum the firmware validates.
- *
- * The bit loop is vendored and unmodified, so these do not re-derive it. What they pin down is
- * the part that can silently rot: which bytes the CRC actually covers, and whether the raw
- * mirror struct's padding is deterministic.
+ * @brief Which bytes the LowCmd checksum covers, and whether the mirror struct's padding is
+ *        deterministic. The bit loop itself is vendored, so it is not re-derived here.
  */
 #include <gmock/gmock.h>
 
@@ -19,7 +16,7 @@ namespace g1_hardware_interface::vendored
 namespace
 {
 
-/// A non-trivial baseline: an all-zero message makes too many mistakes look identical.
+/// Non-trivial on purpose: an all-zero message makes too many mistakes look identical.
 unitree_hg::msg::LowCmd baseline()
 {
     unitree_hg::msg::LowCmd cmd{};
@@ -72,8 +69,7 @@ TEST(MotorCrcHg, EveryMotorCmdFieldIsCovered)
 
 TEST(MotorCrcHg, TheLastMotorSlotIsCovered)
 {
-    // The covered length is derived from sizeof, so an off-by-one would drop the tail of the
-    // array. Slot 29 is the arm_sdk weight and 34 is the end of the message.
+    // The covered length comes from sizeof, so an off-by-one drops the tail of the array.
     expectCovered("motor_cmd[29]", [](auto& cmd) { cmd.motor_cmd[29].q = 1.0F; });
     expectCovered("motor_cmd[34]", [](auto& cmd) { cmd.motor_cmd[34].q = 1.0F; });
 }
@@ -87,9 +83,8 @@ TEST(MotorCrcHg, TheChecksumFieldItselfIsExcluded)
 
 TEST(MotorCrcHg, IdenticalContentChecksumsIdenticallyAcrossMessages)
 {
-    // The CRC runs over a raw mirror struct including its alignment padding, so a message built
-    // field by field must agree with one built any other way. Divergence here means uninitialised
-    // padding is reaching the wire.
+    // The CRC covers the mirror struct's alignment padding too, so divergence here means
+    // uninitialised padding is reaching the wire.
     unitree_hg::msg::LowCmd built_in_reverse{};
     built_in_reverse.mode_machine = 5;
     built_in_reverse.mode_pr      = 0;

--- a/workspace/src/g1_hardware_interface/test/test_motor_crc_hg.cpp
+++ b/workspace/src/g1_hardware_interface/test/test_motor_crc_hg.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file test_motor_crc_hg.cpp
+ * @brief Coverage tests for the LowCmd checksum the firmware validates.
+ *
+ * The bit loop is vendored and unmodified, so these do not re-derive it. What they pin down is
+ * the part that can silently rot: which bytes the CRC actually covers, and whether the raw
+ * mirror struct's padding is deterministic.
+ */
+#include <gmock/gmock.h>
+
+#include <cstdint>
+#include <functional>
+
+#include "g1_hardware_interface/motor_crc_hg.hpp"
+#include "unitree_hg/msg/low_cmd.hpp"
+
+namespace g1_hardware_interface::vendored
+{
+namespace
+{
+
+/// A non-trivial baseline: an all-zero message makes too many mistakes look identical.
+unitree_hg::msg::LowCmd baseline()
+{
+    unitree_hg::msg::LowCmd cmd{};
+    cmd.mode_pr      = 0;
+    cmd.mode_machine = 5;
+    for (std::size_t slot = 0; slot < cmd.motor_cmd.size(); ++slot)
+    {
+        auto& motor = cmd.motor_cmd[slot];
+        motor.mode  = 1;
+        motor.q     = 0.01F * static_cast<float>(slot);
+        motor.dq    = 0.0F;
+        motor.tau   = 0.0F;
+        motor.kp    = 40.0F;
+        motor.kd    = 1.0F;
+    }
+    return cmd;
+}
+
+std::uint32_t crcOf(unitree_hg::msg::LowCmd cmd)
+{
+    computeLowCmdCrc(cmd);
+    return cmd.crc;
+}
+
+/// Asserts a field is inside the checksummed range: perturb it, the CRC must move.
+void expectCovered(const char* what, const std::function<void(unitree_hg::msg::LowCmd&)>& perturb)
+{
+    unitree_hg::msg::LowCmd perturbed = baseline();
+    perturb(perturbed);
+    EXPECT_NE(crcOf(perturbed), crcOf(baseline())) << what << " is outside the checksummed range";
+}
+
+TEST(MotorCrcHg, EveryLowCmdHeaderFieldIsCovered)
+{
+    expectCovered("mode_pr", [](auto& cmd) { cmd.mode_pr = 1; });
+    expectCovered("mode_machine", [](auto& cmd) { cmd.mode_machine = 4; });
+    expectCovered("reserve", [](auto& cmd) { cmd.reserve[0] = 0xABCDEF01; });
+}
+
+TEST(MotorCrcHg, EveryMotorCmdFieldIsCovered)
+{
+    expectCovered("motor mode", [](auto& cmd) { cmd.motor_cmd[0].mode = 0; });
+    expectCovered("motor q", [](auto& cmd) { cmd.motor_cmd[0].q = 1.25F; });
+    expectCovered("motor dq", [](auto& cmd) { cmd.motor_cmd[0].dq = 1.25F; });
+    expectCovered("motor tau", [](auto& cmd) { cmd.motor_cmd[0].tau = 1.25F; });
+    expectCovered("motor kp", [](auto& cmd) { cmd.motor_cmd[0].kp = 55.0F; });
+    expectCovered("motor kd", [](auto& cmd) { cmd.motor_cmd[0].kd = 5.0F; });
+    expectCovered("motor reserve", [](auto& cmd) { cmd.motor_cmd[0].reserve = 7; });
+}
+
+TEST(MotorCrcHg, TheLastMotorSlotIsCovered)
+{
+    // The covered length is derived from sizeof, so an off-by-one would drop the tail of the
+    // array. Slot 29 is the arm_sdk weight and 34 is the end of the message.
+    expectCovered("motor_cmd[29]", [](auto& cmd) { cmd.motor_cmd[29].q = 1.0F; });
+    expectCovered("motor_cmd[34]", [](auto& cmd) { cmd.motor_cmd[34].q = 1.0F; });
+}
+
+TEST(MotorCrcHg, TheChecksumFieldItselfIsExcluded)
+{
+    unitree_hg::msg::LowCmd stale = baseline();
+    stale.crc                     = 0xDEADBEEF;
+    EXPECT_EQ(crcOf(stale), crcOf(baseline()));
+}
+
+TEST(MotorCrcHg, IdenticalContentChecksumsIdenticallyAcrossMessages)
+{
+    // The CRC runs over a raw mirror struct including its alignment padding, so a message built
+    // field by field must agree with one built any other way. Divergence here means uninitialised
+    // padding is reaching the wire.
+    unitree_hg::msg::LowCmd built_in_reverse{};
+    built_in_reverse.mode_machine = 5;
+    built_in_reverse.mode_pr      = 0;
+    for (std::size_t i = built_in_reverse.motor_cmd.size(); i > 0; --i)
+    {
+        auto& motor = built_in_reverse.motor_cmd[i - 1];
+        motor.kd    = 1.0F;
+        motor.kp    = 40.0F;
+        motor.q     = 0.01F * static_cast<float>(i - 1);
+        motor.mode  = 1;
+    }
+
+    EXPECT_EQ(crcOf(built_in_reverse), crcOf(baseline()));
+}
+
+TEST(MotorCrcHg, ChecksumIsWrittenBackOntoTheMessage)
+{
+    unitree_hg::msg::LowCmd cmd = baseline();
+    cmd.crc                     = 0;
+    computeLowCmdCrc(cmd);
+    EXPECT_NE(cmd.crc, 0U);
+}
+
+}  // namespace
+}  // namespace g1_hardware_interface::vendored

--- a/workspace/src/g1_hardware_interface/test/test_pluginlib_loading.cpp
+++ b/workspace/src/g1_hardware_interface/test/test_pluginlib_loading.cpp
@@ -1,6 +1,6 @@
 /**
  * @file test_pluginlib_loading.cpp
- * @brief Verifies the G1ArmSdkSystem hardware_interface plugin is discoverable via pluginlib.
+ * @brief Verifies both hardware_interface plugins in this package are discoverable via pluginlib.
  */
 
 #include <gmock/gmock.h>
@@ -24,5 +24,23 @@ TEST(G1ArmSdkSystemPluginlib, DiscoversAndInstantiates)
     ASSERT_TRUE(loader.isClassAvailable("g1_hardware_interface/G1ArmSdkSystem"));
 
     auto instance = loader.createUniqueInstance("g1_hardware_interface/G1ArmSdkSystem");
+    ASSERT_NE(instance, nullptr);
+}
+
+/**
+ * @brief Same discovery proof for the rt/lowcmd component.
+ *
+ * Two <library> blocks now live in one plugin description file, so this also catches a second
+ * entry that names a library or class that does not exist.
+ */
+TEST(G1LowCmdSystemPluginlib, DiscoversAndInstantiates)
+{
+    pluginlib::ClassLoader<hardware_interface::SystemInterface> loader(
+        "hardware_interface",
+        "hardware_interface::SystemInterface");
+
+    ASSERT_TRUE(loader.isClassAvailable("g1_hardware_interface/G1LowCmdSystem"));
+
+    auto instance = loader.createUniqueInstance("g1_hardware_interface/G1LowCmdSystem");
     ASSERT_NE(instance, nullptr);
 }


### PR DESCRIPTION
Third PR of the Jazzy migration, stacked on #30. Adds the whole-body `rt/lowcmd` hardware
component. Nothing switches over to it yet: `control_stack` still defaults to `arm_sdk`, and every
existing test runs on the old path unchanged.

## What's new

- **`g1_hardware_interface/G1LowCmdSystem`**, a second `ros2_control` plugin alongside
  `G1ArmSdkSystem`. Owns all 29 body motors over `rt/lowcmd`, with no onboard balance underneath.
  Per joint it exports `position`/`velocity`/`effort`/`kp`/`kd` as commands, plus an `imu` sensor.
  Which interfaces a controller claims decides that joint's mode for the tick: `kp`+`kd` is
  impedance, `position` alone uses the gains in the URDF, `effort` zeroes `kp`, nothing claimed
  leaves the motor unpowered.
- **`g1_controllers`**, a new package, with `G1FreezeController`. Unclaimed joints are unpowered by
  design, so holding the body is a controller you switch in rather than behaviour baked into the
  component.
- `control_stack:=lowcmd` in the launch graph, selecting the new description, controller set and
  middleware.

Adapted from NVIDIA's `unitree_g1_ros2_control` (Apache-2.0).

## Bug fix worth flagging

**The `LowCmd` checksum was dropping `mode_pr` and `mode_machine`.** `computeLowCmdCrc` read its
mirror struct through a `uint32_t*`, which is strict-aliasing UB, and GCC 13 acts on it at `-O2`:
those two stores never reached the sum. Harmless on `rt/arm_sdk`, where both fields are always 0,
which is why nothing ever showed. On `rt/lowcmd` `mode_machine` carries 5, so the firmware would
have rejected every frame. Fixed with `std::bit_cast` and pinned by `test_motor_crc_hg`.

## Running it

```bash
ros2 launch g1_bringup sim.launch.py control_stack:=lowcmd pin_pelvis:=true
```

`pin_pelvis` is not optional yet. There is no balance policy on this path until PR 4, so the robot
falls over without it.

The lowcmd stack runs on `rmw_fastrtps_cpp` rather than CycloneDDS, set per stack in
`control.launch.py`. The component reaches the robot through unitree_sdk2's own CycloneDDS, and
loading a second one in the same process corrupts the heap. `arm_sdk` is unaffected and keeps
CycloneDDS. PR 6 retires `arm_sdk` and the split goes with it.

## Verification

- `test_lowcmd_joint` 4/0: the component activates, both controllers activate, the probe joint
  tracks a commanded position toward its target, and a frozen joint holds.
- `g1_hardware_interface` 59/0 and `g1_controllers` 9/0, clang-format and clang-tidy green.
- CI's own command locally: 14 packages, exit 0.
- `test_sim_bringup` 5/0 afterwards, confirming the `arm_sdk` path did not regress.

## Not covered

`MotionSwitcherClient` needs the real robot, so `release_motion_mode` is false in sim. Whether
control can be handed back to the onboard service afterwards is still unproven; assume it cannot
without a reboot.
