### PR TITLE
docs: improve README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,25 @@ Two rules shape the design, and both apply in simulation so the habits transfer:
 
 ## Quick start
 
-Everything runs inside the dev container. The host is Ubuntu 24.04; the container provides the
-Ubuntu 22.04 and ROS 2 Humble combination the Unitree SDK needs.
+The ROS build and runtime commands run inside the dev container. The host is Ubuntu 24.04; the
+container provides the Ubuntu 22.04 and ROS 2 Humble combination the Unitree SDK needs.
+
+### Prerequisites
+
+Install Docker Engine with Docker Compose v2, the NVIDIA driver and NVIDIA Container Toolkit on
+the host. The simulator uses the GPU exposed by `docker-compose.yml`. For the GUI modes, run from
+an X11 desktop session; `manage.sh start` grants the container local X11 access.
+
+Install [`vcstool`](https://github.com/dirk-thomas/vcstool) on the host as well. The import script
+uses its `vcs` command before the development container exists:
+
+```bash
+python3 -m pip install --user vcstool
+```
+
+### Start the development container
+
+Run these commands from the repository root on the host:
 
 ```bash
 cp .env.example .env
@@ -93,6 +110,8 @@ cp .env.example .env
 `workspace/src` and puts the two that ship a non-standard layout into a buildable one. Run it
 again whenever `workspace.repos` changes.
 
+### Build and run the stack
+
 Inside the container:
 
 ```bash
@@ -104,27 +123,37 @@ source install/setup.bash
 Then bring up the robot. One command covers every mode:
 
 ```bash
-# Simulator only
-ros2 launch g1_bringup bringup.launch.py
+# Simulator only, with the MuJoCo viewer
+ros2 launch g1_bringup bringup.launch.py headless:=false
 
-# Build a map, with RViz
-ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true
+# Build a map, with RViz but without the MuJoCo viewer
+ros2 launch g1_bringup bringup.launch.py mode:=mapping rviz:=true headless:=true
 
-# Localize against the committed map and navigate
-ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true
+# Localize against the committed map and navigate, with RViz but without the MuJoCo viewer
+ros2 launch g1_bringup bringup.launch.py mode:=localization nav:=true rviz:=true headless:=true
 
 # Plan for the arms and hands, with the LiDAR octomap in the planning scene
-ros2 launch g1_bringup bringup.launch.py moveit:=true sensors:=true rviz:=true
+ros2 launch g1_bringup bringup.launch.py moveit:=true sensors:=true rviz:=true headless:=true
 
 # Pick and place skills, on the small test world where the object is already within reach
 ros2 launch g1_bringup bringup.launch.py \
   moveit:=true manipulation:=true pin_pelvis:=true world:=manipulation \
-  activate_arm:=true activate_arm_delay_s:=40.0
+  activate_arm:=true activate_arm_delay_s:=40.0 headless:=true
 
-# Everything at once: localized, navigating, planning, skills, arms acquired, RViz up
+# Everything at once, including the MuJoCo viewer and RViz
 ros2 launch g1_bringup bringup.launch.py \
   mode:=localization nav:=true moveit:=true manipulation:=true rviz:=true \
   activate_arm:=true activate_arm_delay_s:=40.0 headless:=false
+```
+
+`headless:=true` is the default and is appropriate for non-GUI runs. Set `headless:=false` only
+when a local display is available to open the MuJoCo viewer; do not use the viewer's Reload button
+while sensors are running.
+
+After launching a mode, confirm that the ROS graph is available from a second container shell:
+
+```bash
+ros2 topic list -t
 ```
 
 Run a mission. The tree drives navigation and manipulation; nothing else needs starting, and


### PR DESCRIPTION
## Summary

This documentation-only PR makes the root README easier to follow for first-time setup.

- Documents host prerequisites: Docker Compose v2, NVIDIA Container Toolkit, X11 for GUI use, and `vcstool`.
- Separates host-side external import/container startup from in-container ROS build and runtime commands.
- Makes `headless` explicit in every main `bringup.launch.py` example, including MuJoCo viewer mode with `headless:=false`.
- Adds a lightweight ROS graph verification command after launch.

## Why

The previous Quick start implied every step ran in the development container, although `import-externals.sh` runs on the host and requires `vcs`. The launch examples also relied on the implicit headless default, making MuJoCo viewer usage less obvious.

## Validation

- `git diff --check`

## Scope

- Documentation only (`README.md`)
- No runtime, configuration, or CI changes
- Existing CI badge unchanged