### PR TITLE
Add the interfaces, image deps and shared hand-contact library for the learned-grasp skill

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,7 @@
-# Extends your pre-built image (tag is provided by docker-compose.yml via BASE_IMAGE)
 
 ARG BASE_IMAGE=adyansh04/ros-dev:jazzy
 FROM ${BASE_IMAGE}
 
-# Pinned explicitly rather than inherited from the base image ENV: every `ros-${ROS_DISTRO}-*`
-# apt name below resolves through it, and an unset value would silently install nothing.
 ARG ROS_DISTRO=jazzy
 
 # Allow pip installs in distro-managed Python images (required on Ubuntu 24.04+/ROS Jazzy).
@@ -52,10 +49,6 @@ RUN apt-get update && apt-get install -y \
         xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Compilation parallelism for every source build below. NOT $(nproc): heavy C++ here runs
-# 0.5-1 GB per cc1plus, so one job per core OOM-kills a 32-core/30 GB machine mid-build --
-# observed, twice, taking the desktop session with it. One job per ~2 GB of RAM is the rule.
-# Raise on a bigger box with --build-arg BUILD_JOBS=N.
 ARG BUILD_JOBS=8
 
 # --- unitree_sdk2 -----------------------------------------------------------
@@ -75,7 +68,6 @@ RUN git init -q /opt/unitree_robotics/unitree_sdk2 && \
     rm -rf /opt/unitree_robotics/unitree_sdk2
 
 # --- MuJoCo ------------------------------------------------------------------
-# The full tarball, not the wheel: unitree_mujoco compiles the viewer sources directly.
 ARG MUJOCO_VERSION=3.3.6
 RUN mkdir -p /opt/unitree_robotics/mujoco-${MUJOCO_VERSION} && \
     curl -fsSL "https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz" \
@@ -125,31 +117,23 @@ RUN cat > /etc/cyclonedds/cyclonedds.hardware.xml <<'EOF'
 </CycloneDDS>
 EOF
 
-# ROS runs fastrtps and never loads a CycloneDDS RMW: unitree_sdk2 links its own CycloneDDS
-# inside the hardware component, and two libddsc.so.0 of different ABIs corrupt the heap.
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-# Still set: the SDK and unitree_mujoco read it directly, which is what pins them to loopback.
 ENV CYCLONEDDS_URI=file:///etc/cyclonedds/cyclonedds.xml
-# Sim-only domain; the robot's is set through GROVE_G1_ROS_DOMAIN_ID below.
 ENV ROS_DOMAIN_ID=1
 
-# Puts back the ROS_DOMAIN_ID that the base image's 10-ros-env.sh overwrites with 0. Read from
-# the GROVE_G1_-prefixed copy: the unprefixed name would read the 0 just written.
 RUN cat > /etc/profile.d/99-grove-g1-env.sh <<'EOF'
 export ROS_DOMAIN_ID="${GROVE_G1_ROS_DOMAIN_ID:-1}"
 EOF
 
-# rosidl needs empy 3.3.4 (apt python3-empy); pip's `em` and `empy` 4.x both shadow it from
-# /usr/local, and 4.x's rewritten API throws TransientParseError while expanding templates.
 RUN python3 -m pip uninstall -y em empy
 
-# --- Milestone 2: LocoClient deps -------------------------------------------
+# ---LocoClient deps -------------------------------------------
 
 # nlohmann-json: used for the LocoClient wire format (matches vendor's client).
 RUN apt-get update && apt-get install -y nlohmann-json3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Milestone 3: walking-policy deps ---------------------------------------
+# --- walking-policy deps ---------------------------------------
 
 # ONNX Runtime CPU tarball. ldconfig (not RPATH) avoids LD_LIBRARY_PATH shadowing
 # by ROS's /opt/ros/${ROS_DISTRO}/lib.
@@ -164,7 +148,7 @@ RUN mkdir -p /opt/onnxruntime && \
 RUN apt-get update && apt-get install -y ros-${ROS_DISTRO}-teleop-twist-keyboard \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Milestone 4: perception sim track ---------------------------------------
+# --- perception sim track ---------------------------------------
 
 # mujoco_ros2_control, the second simulation track (sensors + a simplified mobility body).
 # Pinned to main, not a release: only main has the 3D PointCloud2 lidar the Mid360 needs.
@@ -198,11 +182,8 @@ RUN mkdir -p /opt/mujoco_ros2_control_ws/src && \
 RUN printf '. /opt/mujoco_ros2_control_ws/install/setup.sh\n' \
       >> /etc/profile.d/99-grove-g1-env.sh
 
-# --- Milestone 6: SLAM + Nav2 -------------------------------------------------
+# --- SLAM + Nav2 -------------------------------------------------
 
-# Three of these four already ship in the base image; listed anyway, because the base tag
-# floats and a silent removal would surface as a missing launch file. pointcloud-to-laserscan
-# is the one genuinely absent -- slam_toolbox consumes LaserScan only.
 RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO}-navigation2 \
         ros-${ROS_DISTRO}-nav2-bringup \
@@ -210,25 +191,23 @@ RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO}-pointcloud-to-laserscan \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Milestone 7: MoveIt 2 (structured manipulation) --------------------------
+# --- MoveIt 2 (structured manipulation) --------------------------
 
-# Humble's 2.5.9. Each extra past the metapackage is deliberate: pick-ik replaces KDL for the
+# Jazzy's 2.12.4. Each extra past the metapackage is deliberate: pick-ik replaces KDL for the
 # 7-DoF arms, moveit-ros-perception carries the octomap updater plugins the metapackage omits,
-# realsense2-description supplies the D435's real geometry. moveit-servo is deliberately absent.
+# realsense2-description supplies the D435's real geometry, moveit-servo streams the arms.
 RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO}-moveit \
         ros-${ROS_DISTRO}-moveit-configs-utils \
         ros-${ROS_DISTRO}-moveit-setup-assistant \
+        ros-${ROS_DISTRO}-moveit-servo \
         ros-${ROS_DISTRO}-pick-ik \
         ros-${ROS_DISTRO}-moveit-ros-perception \
         ros-${ROS_DISTRO}-realsense2-description \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Milestone 9: orchestration + manipulation skills -------------------------
+# --- orchestration + manipulation skills -------------------------
 
-# behaviortree-cpp is v4 and coexists with the v3 Nav2 pulls in: disjoint files, disjoint
-# include roots, and nothing links both. vision-msgs carries the Detection3DArray that
-# g1_manipulation publishes. twist-mux is deliberately absent -- its Humble build is broken.
 RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO}-behaviortree-cpp \
         ros-${ROS_DISTRO}-vision-msgs \
@@ -240,7 +219,7 @@ RUN test -e /opt/ros/${ROS_DISTRO}/lib/libbehaviortree_cpp.so || \
     ln -s "$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libbehaviortree_cpp.so" \
           /opt/ros/${ROS_DISTRO}/lib/libbehaviortree_cpp.so
 
-# --- Milestone 10: LiDAR-inertial odometry ------------------------------------
+# --- LiDAR-inertial odometry ------------------------------------
 
 # Livox-SDK2, the Mid360's transport library. livox_ros_driver2 does find_library(... REQUIRED)
 # for it, and that driver defines the CustomMsg both FAST-LIO and the sim bridge speak -- so it
@@ -258,12 +237,18 @@ RUN git init -q /tmp/Livox-SDK2 && \
     ldconfig && \
     rm -rf /tmp/Livox-SDK2
 
+# --- learned grasp ----------------------------------------------
+
+# The policy adapter speaks the wire protocol directly, so this is the whole dependency.
+# --no-deps: apt satisfies both, and pip would otherwise shadow python3-msgpack like empy.
+RUN apt-get update && apt-get install -y \
+        python3-zmq \
+        python3-msgpack \
+    && rm -rf /var/lib/apt/lists/* && \
+    (python3 -m pip install --no-cache-dir --no-deps --break-system-packages msgpack-numpy==0.4.8 || \
+     python3 -m pip install --no-cache-dir --no-deps msgpack-numpy==0.4.8)
+
 # --- unitree_mujoco (the `simulate` app) ------------------------------------
-# LAST on purpose: the only block consuming COPYed host files, and cache invalidation flows
-# forward, so a one-line sensor edit here must not re-run every apt block above it.
-#
-# The source tree stays in the image -- the binary resolves assets relative to its own
-# location. Only the `unitree_mujoco` target is built; jstest fails against the current SDK.
 COPY workspace/patches/unitree_mujoco/ /tmp/unitree_mujoco_patches/
 COPY workspace/vendor/unitree_mujoco/ /tmp/unitree_mujoco_src/
 ARG UNITREE_MUJOCO_SHA=ae6a8403e272733e9996ef59990880330496177f
@@ -288,14 +273,8 @@ RUN git init -q /opt/unitree_robotics/unitree_mujoco && \
     cmake --build . --target unitree_mujoco --parallel "${BUILD_JOBS}" && \
     rm -rf CMakeFiles && \
     rm -rf ../mujoco/sample ../mujoco/bin ../mujoco/doc ../mujoco/model
-# include/ and simulate/ are kept deliberately: we compile our own sensor source into this app
-# and CMakeLists globs simulate/*.cc, so stripping them costs a full rebuild per edit. The bulk
-# (model/bin/doc/sample) is still removed. Binary at simulate/build/unitree_mujoco.
 
 # --- editor configs -----------------------------------------------------------
-# At /root, NOT /root/workspace: the ./workspace bind mount replaces that directory wholesale
-# at runtime. These tools all search ancestor directories, so they are found from anywhere
-# under it. Symlinks dangle at build time -- /root/.host-repo is a runtime mount.
 RUN ln -sf /root/.host-repo/.clangd       /root/.clangd && \
     ln -sf /root/.host-repo/.clang-format /root/.clang-format && \
     ln -sf /root/.host-repo/.clang-tidy   /root/.clang-tidy && \

--- a/.github/ci.Dockerfile
+++ b/.github/ci.Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ros-${ROS_DISTRO}-moveit \
         ros-${ROS_DISTRO}-moveit-configs-utils \
         ros-${ROS_DISTRO}-moveit-ros-perception \
+        ros-${ROS_DISTRO}-moveit-servo \
         ros-${ROS_DISTRO}-navigation2 \
         ros-${ROS_DISTRO}-nav2-bringup \
         ros-${ROS_DISTRO}-pcl-conversions \
@@ -82,6 +83,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ros-${ROS_DISTRO}-vision-msgs \
         ros-${ROS_DISTRO}-xacro \
     && rm -rf /var/lib/apt/lists/*
+
+# The policy adapter's runtime deps, mirrored from .devcontainer/Dockerfile.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-zmq \
+        python3-msgpack \
+    && rm -rf /var/lib/apt/lists/* && \
+    python3 -m pip install --no-cache-dir --no-deps --break-system-packages msgpack-numpy==0.4.8
 
 # behaviortree_cpp 4.9.1 installs under lib/<triplet>/ while its own CMake export looks in
 # lib/, so dependants fail to configure. Guarded so a fixed release keeps its real file.

--- a/workspace/src/g1_manipulation/CMakeLists.txt
+++ b/workspace/src/g1_manipulation/CMakeLists.txt
@@ -8,6 +8,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/g1_common.cmake)
 find_package(ament_cmake REQUIRED)
 find_package(g1_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(moveit_core REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -21,6 +22,14 @@ find_package(vision_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 # --- libraries -------------------------------------------------------------
+
+add_library(g1_hand_contact src/hand_contact.cpp)
+g1_target_defaults(g1_hand_contact)
+target_link_libraries(g1_hand_contact PUBLIC
+  rclcpp::rclcpp
+  moveit_core::moveit_robot_model
+  ${moveit_msgs_TARGETS}
+)
 
 add_library(g1_object_pose_source_node src/g1_object_pose_source_node.cpp)
 g1_target_defaults(g1_object_pose_source_node)
@@ -38,6 +47,7 @@ target_link_libraries(g1_object_pose_source_node PUBLIC
 add_library(g1_manipulation_server_node src/g1_manipulation_server_node.cpp)
 g1_target_defaults(g1_manipulation_server_node)
 target_link_libraries(g1_manipulation_server_node PUBLIC
+  g1_hand_contact
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action
   tf2::tf2
@@ -65,7 +75,7 @@ target_link_libraries(g1_manipulation_server PUBLIC g1_manipulation_server_node)
 
 install(DIRECTORY include/ DESTINATION include)
 install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
-install(TARGETS g1_object_pose_source_node g1_manipulation_server_node
+install(TARGETS g1_hand_contact g1_object_pose_source_node g1_manipulation_server_node
   EXPORT export_${PROJECT_NAME} DESTINATION lib)
 install(TARGETS g1_object_pose_source g1_manipulation_server DESTINATION lib/${PROJECT_NAME})
 
@@ -82,13 +92,10 @@ if(BUILD_TESTING)
   ament_add_gmock(test_grasp_geometry test/test_grasp_geometry.cpp)
   target_link_libraries(test_grasp_geometry g1_manipulation_server_node)
 
-  # test/test_pick_place.launch.py runs but does not pass, so it stays unregistered: a
-  # permanently red test trains people to ignore the result. The failure is real and not a
-  # test defect: the robot is staged at the workbench with its arms hanging, a hanging hand
-  # sits ~1 cm under the bench slab and so inside its octomap, and CheckStartStateCollision
-  # looks at the whole robot rather than the group being planned for, so every plan is refused.
-  # Fixing it is a rest-pose question for the control stack. Run it by hand meanwhile:
-  #
+  ament_add_gmock(test_hand_contact test/test_hand_contact.cpp)
+  target_link_libraries(test_hand_contact g1_hand_contact)
+
+  # test/test_pick_place.launch.py runs but does not pass, so it stays unregistered:
   #   python3 -m launch_testing.launch_test src/g1_manipulation/test/test_pick_place.launch.py
 
   g1_add_lint_tests()
@@ -98,5 +105,22 @@ endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
+# Without these the exported targets will not even configure in a dependant.
+ament_export_dependencies(
+  g1_msgs
+  geometry_msgs
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning_interface
+  rclcpp
+  rclcpp_action
+  rclcpp_lifecycle
+  shape_msgs
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
+  vision_msgs
+  visualization_msgs
+)
 
 ament_package()

--- a/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/g1_manipulation_server_node.hpp
@@ -251,11 +251,12 @@ private:
         bool include_links = true);
 
     /**
-     * @brief setHandContact() without the logging, for a caller that must see the failure.
+     * @brief setHandContact() without the error log, for a caller that must see the failure.
      *
-     * @return false if the planning-scene service did not answer, in which case the exemption
-     *         was neither applied nor restored. A silently failed restore leaves the scene
-     *         blinded, and a silently failed apply reads downstream as an unreachable pose.
+     * @return false if the arm has no hand group or a planning-scene service did not answer, in
+     *         which case the exemption was neither applied nor restored. A silently failed
+     *         restore leaves the scene blinded, and a silently failed apply reads downstream as
+     *         an unreachable pose.
      */
     [[nodiscard]] bool allowHandContact(
         const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed,

--- a/workspace/src/g1_manipulation/include/g1_manipulation/hand_contact.hpp
+++ b/workspace/src/g1_manipulation/include/g1_manipulation/hand_contact.hpp
@@ -1,0 +1,66 @@
+#ifndef G1_MANIPULATION__HAND_CONTACT_HPP_
+#define G1_MANIPULATION__HAND_CONTACT_HPP_
+
+/**
+ * @file hand_contact.hpp
+ * @brief Exempting a hand from collision checking while it is holding something.
+ *
+ * Shared by every skill that closes a hand, planned or learned, so which links are exempt and
+ * how the matrix is edited are each defined once.
+ */
+
+#include <moveit/robot_model/robot_model.hpp>
+#include <moveit_msgs/msg/allowed_collision_matrix.hpp>
+#include <moveit_msgs/srv/apply_planning_scene.hpp>
+#include <moveit_msgs/srv/get_planning_scene.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <vector>
+
+namespace g1_manipulation
+{
+
+/**
+ * @brief The links that unavoidably enter occupied space during a grasp.
+ *
+ * All three wrist links, not just pitch and yaw: roll is the one that reaches during a grasp.
+ *
+ * @param side "left" or "right".
+ * @return Empty if the model has no hand group for that side, which is an SRDF mismatch.
+ */
+[[nodiscard]] std::vector<std::string>
+handContactLinks(const moveit::core::RobotModel& model, const std::string& side);
+
+/**
+ * @brief Sets or clears the exemption in an allowed-collision matrix.
+ *
+ * Names the matrix has not seen are appended as a full row and column first. The touchables are
+ * exempted from each other too: lifting an object out of a surface drags it through its voxels.
+ *
+ * @param include_links false exempts the touchables from each other only, leaving the hand and
+ *        wrist collision-checked, which is what carrying an object over a surface wants.
+ */
+void editHandContact(
+    moveit_msgs::msg::AllowedCollisionMatrix& acm, const std::vector<std::string>& links,
+    const std::vector<std::string>& touchables, bool allowed, bool include_links);
+
+/**
+ * @brief Reads the live matrix, edits it, and applies it back.
+ *
+ * Read-modify-write because ApplyPlanningScene replaces the whole matrix rather than merging:
+ * sending only our entries would drop every self-collision rule the SRDF set up.
+ *
+ * Waited on WITHOUT spinning, so never call this from the thread owning the node's executor.
+ *
+ * @return false if either service did not answer, leaving the exemption neither applied nor
+ *         restored. A failed restore leaves the scene blinded to the octomap.
+ */
+[[nodiscard]] bool applyHandContact(
+    const rclcpp::Client<moveit_msgs::srv::GetPlanningScene>::SharedPtr&   get_scene,
+    const rclcpp::Client<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr& apply_scene,
+    const rclcpp::Logger& logger, const std::vector<std::string>& links,
+    const std::vector<std::string>& touchables, bool allowed, bool include_links);
+
+}  // namespace g1_manipulation
+
+#endif  // G1_MANIPULATION__HAND_CONTACT_HPP_

--- a/workspace/src/g1_manipulation/package.xml
+++ b/workspace/src/g1_manipulation/package.xml
@@ -20,6 +20,7 @@
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_msgs</depend>
   <depend>shape_msgs</depend>

--- a/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
+++ b/workspace/src/g1_manipulation/src/g1_manipulation_server_node.cpp
@@ -22,6 +22,8 @@
 #include <utility>
 #include <vector>
 
+#include "g1_manipulation/hand_contact.hpp"
+
 namespace g1_manipulation
 {
 
@@ -131,104 +133,27 @@ bool G1ManipulationServer::allowHandContact(
     const ArmContext& arm, const std::vector<std::string>& touchables, bool allowed,
     bool include_links)
 {
-    // The links that unavoidably enter occupied space during a grasp: the hand itself, and
-    // the wrist that carries it. Taken from the robot model rather than listed, so a renamed
-    // link is a build-time problem rather than a silently ineffective exemption.
     MoveGroup* hand = groupFor(arm.hand_group);
     if (hand == nullptr)
     {
         return false;
     }
-    std::vector<std::string> links =
-        hand->getRobotModel()->getJointModelGroup(arm.hand_group)->getLinkModelNames();
-    const std::string side = arm.is_left ? "left" : "right";
-    links.push_back(arm.palm_link);
-    links.push_back(side + "_wrist_pitch_link");
-    links.push_back(side + "_wrist_yaw_link");
-    // All THREE wrist joints, matching the touch_links the pick attaches the object with. Roll
-    // is easy to miss but is the one that reaches during a grasp, so omitting it leaves the
-    // exemption silently incomplete.
-    links.push_back(side + "_wrist_roll_link");
-
-    // The current matrix has to be read first: ApplyPlanningScene replaces the whole ACM
-    // rather than merging into it, so sending only our entries would drop every
-    // self-collision rule the SRDF set up.
-    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
-    request->components.components =
-        moveit_msgs::msg::PlanningSceneComponents::ALLOWED_COLLISION_MATRIX;
-    auto future = get_scene_->async_send_request(request);
-    // Waited on WITHOUT spinning: the executor already owns this node, and spinning it from
-    // here would re-enter the executor from inside its own callback.
-    if (future.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+    const std::string              side  = arm.is_left ? "left" : "right";
+    const std::vector<std::string> links = handContactLinks(*hand->getRobotModel(), side);
+    if (links.empty())
     {
-        RCLCPP_ERROR(get_logger(), "/get_planning_scene did not answer");
         return false;
     }
 
-    moveit_msgs::msg::AllowedCollisionMatrix acm = future.get()->scene.allowed_collision_matrix;
-
-    // A name the matrix has never seen has to be added as a full row and column first,
-    // otherwise the indices below run off the end.
-    const auto ensure_entry = [&acm](const std::string& name) {
-        if (std::find(acm.entry_names.begin(), acm.entry_names.end(), name) != acm.entry_names.end())
-        {
-            return;
-        }
-        acm.entry_names.push_back(name);
-        for (moveit_msgs::msg::AllowedCollisionEntry& row : acm.entry_values)
-        {
-            row.enabled.push_back(false);
-        }
-        moveit_msgs::msg::AllowedCollisionEntry row;
-        row.enabled.assign(acm.entry_names.size(), false);
-        acm.entry_values.push_back(row);
-    };
-    const auto index_of = [&acm](const std::string& name) {
-        return static_cast<std::size_t>(
-            std::find(acm.entry_names.begin(), acm.entry_names.end(), name) -
-            acm.entry_names.begin());
-    };
-
-    for (const std::string& touchable : touchables)
+    if (!applyHandContact(
+            get_scene_,
+            apply_scene_,
+            get_logger(),
+            links,
+            touchables,
+            allowed,
+            include_links))
     {
-        ensure_entry(touchable);
-    }
-    // The exempted things must also be allowed to touch each other, not just the hand: lifting
-    // an attached object out of a surface drags it through that surface's octomap voxels, which
-    // is a collision between two things the hand may already touch.
-    for (std::size_t i = 0; i < touchables.size(); ++i)
-    {
-        for (std::size_t j = i + 1; j < touchables.size(); ++j)
-        {
-            const std::size_t a            = index_of(touchables[i]);
-            const std::size_t b            = index_of(touchables[j]);
-            acm.entry_values[a].enabled[b] = allowed;
-            acm.entry_values[b].enabled[a] = allowed;
-        }
-    }
-    for (const std::string& touchable : include_links ? touchables : std::vector<std::string>{})
-    {
-        const std::size_t other = index_of(touchable);
-        for (const std::string& link : links)
-        {
-            const auto it = std::find(acm.entry_names.begin(), acm.entry_names.end(), link);
-            if (it == acm.entry_names.end())
-            {
-                continue;
-            }
-            const auto index = static_cast<std::size_t>(it - acm.entry_names.begin());
-            acm.entry_values[index].enabled[other] = allowed;
-            acm.entry_values[other].enabled[index] = allowed;
-        }
-    }
-
-    auto apply           = std::make_shared<moveit_msgs::srv::ApplyPlanningScene::Request>();
-    apply->scene.is_diff = true;
-    apply->scene.allowed_collision_matrix = acm;
-    auto applied                          = apply_scene_->async_send_request(apply);
-    if (applied.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
-    {
-        RCLCPP_ERROR(get_logger(), "/apply_planning_scene did not answer");
         return false;
     }
     RCLCPP_INFO(
@@ -237,7 +162,7 @@ bool G1ManipulationServer::allowHandContact(
         allowed ? "allowing" : "restoring",
         side.c_str(),
         touchables.size());
-    return applied.get()->success;
+    return true;
 }
 
 std::optional<geometry_msgs::msg::Pose> G1ManipulationServer::toPlanningFrame(

--- a/workspace/src/g1_manipulation/src/hand_contact.cpp
+++ b/workspace/src/g1_manipulation/src/hand_contact.cpp
@@ -1,0 +1,137 @@
+/**
+ * @file hand_contact.cpp
+ * @brief Allowed-collision-matrix edits for a hand that is holding something.
+ */
+
+#include "g1_manipulation/hand_contact.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <moveit/robot_model/joint_model_group.hpp>
+#include <moveit_msgs/msg/allowed_collision_entry.hpp>
+#include <moveit_msgs/msg/planning_scene_components.hpp>
+
+namespace g1_manipulation
+{
+
+namespace
+{
+
+// move_group answers both off its own scene, so this long a wait means wedged, not busy.
+constexpr std::chrono::seconds kSceneServiceTimeout{ 5 };
+
+std::size_t indexOf(const moveit_msgs::msg::AllowedCollisionMatrix& acm, const std::string& name)
+{
+    return static_cast<std::size_t>(
+        std::find(acm.entry_names.begin(), acm.entry_names.end(), name) - acm.entry_names.begin());
+}
+
+void ensureEntry(moveit_msgs::msg::AllowedCollisionMatrix& acm, const std::string& name)
+{
+    if (std::find(acm.entry_names.begin(), acm.entry_names.end(), name) != acm.entry_names.end())
+    {
+        return;
+    }
+    acm.entry_names.push_back(name);
+    for (moveit_msgs::msg::AllowedCollisionEntry& row : acm.entry_values)
+    {
+        row.enabled.push_back(false);
+    }
+    moveit_msgs::msg::AllowedCollisionEntry row;
+    row.enabled.assign(acm.entry_names.size(), false);
+    acm.entry_values.push_back(row);
+}
+
+}  // namespace
+
+std::vector<std::string>
+handContactLinks(const moveit::core::RobotModel& model, const std::string& side)
+{
+    const moveit::core::JointModelGroup* hand = model.getJointModelGroup(side + "_hand");
+    if (hand == nullptr)
+    {
+        return {};
+    }
+    std::vector<std::string> links = hand->getLinkModelNames();
+    links.push_back(side + "_hand_palm_link");
+    links.push_back(side + "_wrist_pitch_link");
+    links.push_back(side + "_wrist_yaw_link");
+    links.push_back(side + "_wrist_roll_link");
+    return links;
+}
+
+void editHandContact(
+    moveit_msgs::msg::AllowedCollisionMatrix& acm, const std::vector<std::string>& links,
+    const std::vector<std::string>& touchables, bool allowed, bool include_links)
+{
+    for (const std::string& touchable : touchables)
+    {
+        ensureEntry(acm, touchable);
+    }
+
+    for (std::size_t i = 0; i < touchables.size(); ++i)
+    {
+        for (std::size_t j = i + 1; j < touchables.size(); ++j)
+        {
+            const std::size_t a            = indexOf(acm, touchables[i]);
+            const std::size_t b            = indexOf(acm, touchables[j]);
+            acm.entry_values[a].enabled[b] = allowed;
+            acm.entry_values[b].enabled[a] = allowed;
+        }
+    }
+
+    if (!include_links)
+    {
+        return;
+    }
+    for (const std::string& touchable : touchables)
+    {
+        const std::size_t other = indexOf(acm, touchable);
+        for (const std::string& link : links)
+        {
+            const auto it = std::find(acm.entry_names.begin(), acm.entry_names.end(), link);
+            if (it == acm.entry_names.end())
+            {
+                continue;
+            }
+            const auto index = static_cast<std::size_t>(it - acm.entry_names.begin());
+            acm.entry_values[index].enabled[other] = allowed;
+            acm.entry_values[other].enabled[index] = allowed;
+        }
+    }
+}
+
+bool applyHandContact(
+    const rclcpp::Client<moveit_msgs::srv::GetPlanningScene>::SharedPtr&   get_scene,
+    const rclcpp::Client<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr& apply_scene,
+    const rclcpp::Logger& logger, const std::vector<std::string>& links,
+    const std::vector<std::string>& touchables, bool allowed, bool include_links)
+{
+    auto request = std::make_shared<moveit_msgs::srv::GetPlanningScene::Request>();
+    request->components.components =
+        moveit_msgs::msg::PlanningSceneComponents::ALLOWED_COLLISION_MATRIX;
+    auto future = get_scene->async_send_request(request);
+    if (future.wait_for(kSceneServiceTimeout) != std::future_status::ready)
+    {
+        RCLCPP_ERROR(logger, "/get_planning_scene did not answer");
+        return false;
+    }
+
+    moveit_msgs::msg::AllowedCollisionMatrix acm = future.get()->scene.allowed_collision_matrix;
+    editHandContact(acm, links, touchables, allowed, include_links);
+
+    auto apply           = std::make_shared<moveit_msgs::srv::ApplyPlanningScene::Request>();
+    apply->scene.is_diff = true;
+    apply->scene.allowed_collision_matrix = acm;
+    auto applied                          = apply_scene->async_send_request(apply);
+    if (applied.wait_for(kSceneServiceTimeout) != std::future_status::ready)
+    {
+        RCLCPP_ERROR(logger, "/apply_planning_scene did not answer");
+        return false;
+    }
+    return applied.get()->success;
+}
+
+}  // namespace g1_manipulation

--- a/workspace/src/g1_manipulation/test/test_hand_contact.cpp
+++ b/workspace/src/g1_manipulation/test/test_hand_contact.cpp
@@ -1,0 +1,138 @@
+/**
+ * @file test_hand_contact.cpp
+ * @brief The allowed-collision-matrix arithmetic, without a planning scene.
+ *
+ * The matrix is square and index-addressed, so the failures worth pinning are a grown name list
+ * with an ungrown row, and a half-written symmetric pair. Both read as an exemption that did
+ * nothing.
+ */
+
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "g1_manipulation/hand_contact.hpp"
+
+using g1_manipulation::editHandContact;
+using moveit_msgs::msg::AllowedCollisionEntry;
+using moveit_msgs::msg::AllowedCollisionMatrix;
+
+namespace
+{
+
+/// A square matrix over the given names with nothing allowed, the shape move_group answers with.
+AllowedCollisionMatrix matrixOver(const std::vector<std::string>& names)
+{
+    AllowedCollisionMatrix acm;
+    acm.entry_names = names;
+    for (std::size_t i = 0; i < names.size(); ++i)
+    {
+        AllowedCollisionEntry row;
+        row.enabled.assign(names.size(), false);
+        acm.entry_values.push_back(row);
+    }
+    return acm;
+}
+
+std::size_t indexOf(const AllowedCollisionMatrix& acm, const std::string& name)
+{
+    const auto it = std::find(acm.entry_names.begin(), acm.entry_names.end(), name);
+    return static_cast<std::size_t>(it - acm.entry_names.begin());
+}
+
+bool allowed(const AllowedCollisionMatrix& acm, const std::string& a, const std::string& b)
+{
+    return acm.entry_values[indexOf(acm, a)].enabled[indexOf(acm, b)];
+}
+
+/// Every row as long as the name list, which is what the index arithmetic assumes.
+bool isSquare(const AllowedCollisionMatrix& acm)
+{
+    if (acm.entry_values.size() != acm.entry_names.size())
+    {
+        return false;
+    }
+    return std::all_of(
+        acm.entry_values.begin(),
+        acm.entry_values.end(),
+        [&acm](const AllowedCollisionEntry& row) {
+            return row.enabled.size() == acm.entry_names.size();
+        });
+}
+
+const std::vector<std::string> kHandLinks = { "right_hand_palm_link", "right_wrist_roll_link" };
+
+}  // namespace
+
+TEST(HandContact, ExemptsHandLinksFromAnUnknownObject)
+{
+    AllowedCollisionMatrix acm = matrixOver(kHandLinks);
+
+    editHandContact(acm, kHandLinks, { "<octomap>" }, true, true);
+
+    EXPECT_TRUE(isSquare(acm));
+    EXPECT_TRUE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+    EXPECT_TRUE(allowed(acm, "right_wrist_roll_link", "<octomap>"));
+}
+
+TEST(HandContact, WritesBothHalvesOfEveryPair)
+{
+    AllowedCollisionMatrix acm = matrixOver(kHandLinks);
+
+    editHandContact(acm, kHandLinks, { "<octomap>", "red_cube" }, true, true);
+
+    EXPECT_TRUE(allowed(acm, "<octomap>", "right_hand_palm_link"));
+    EXPECT_TRUE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+    // The touchables against each other, not only against the hand.
+    EXPECT_TRUE(allowed(acm, "red_cube", "<octomap>"));
+    EXPECT_TRUE(allowed(acm, "<octomap>", "red_cube"));
+}
+
+TEST(HandContact, WithoutIncludeLinksLeavesTheHandChecked)
+{
+    AllowedCollisionMatrix acm = matrixOver(kHandLinks);
+
+    editHandContact(acm, kHandLinks, { "<octomap>", "red_cube" }, true, false);
+
+    EXPECT_TRUE(allowed(acm, "red_cube", "<octomap>"));
+    EXPECT_FALSE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+    EXPECT_FALSE(allowed(acm, "right_wrist_roll_link", "red_cube"));
+}
+
+TEST(HandContact, RestoreClearsWhatTheApplySet)
+{
+    AllowedCollisionMatrix acm = matrixOver(kHandLinks);
+
+    editHandContact(acm, kHandLinks, { "<octomap>" }, true, true);
+    editHandContact(acm, kHandLinks, { "<octomap>" }, false, true);
+
+    EXPECT_FALSE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+    EXPECT_FALSE(allowed(acm, "<octomap>", "right_wrist_roll_link"));
+}
+
+TEST(HandContact, KeepsRulesItDidNotTouch)
+{
+    AllowedCollisionMatrix acm = matrixOver({ "right_hand_palm_link", "pelvis", "waist_yaw_link" });
+    // A self-collision rule of the kind the SRDF sets up.
+    acm.entry_values[indexOf(acm, "pelvis")].enabled[indexOf(acm, "waist_yaw_link")] = true;
+    acm.entry_values[indexOf(acm, "waist_yaw_link")].enabled[indexOf(acm, "pelvis")] = true;
+
+    editHandContact(acm, kHandLinks, { "<octomap>" }, true, true);
+
+    EXPECT_TRUE(allowed(acm, "pelvis", "waist_yaw_link"));
+    EXPECT_TRUE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+}
+
+TEST(HandContact, IgnoresLinksTheMatrixDoesNotHave)
+{
+    AllowedCollisionMatrix acm = matrixOver({ "right_hand_palm_link" });
+
+    editHandContact(acm, kHandLinks, { "<octomap>" }, true, true);
+
+    EXPECT_TRUE(isSquare(acm));
+    EXPECT_EQ(acm.entry_names.size(), 2U);
+    EXPECT_TRUE(allowed(acm, "right_hand_palm_link", "<octomap>"));
+}

--- a/workspace/src/g1_msgs/CMakeLists.txt
+++ b/workspace/src/g1_msgs/CMakeLists.txt
@@ -7,16 +7,19 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(trajectory_msgs REQUIRED)
 
 # --- interfaces ------------------------------------------------------------
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/ApproachObject.action"
+  "action/Grasp.action"
   "action/Pick.action"
   "action/Place.action"
   "action/Retreat.action"
   "action/SetArmPosture.action"
-  DEPENDENCIES builtin_interfaces geometry_msgs
+  "srv/GetActionChunk.srv"
+  DEPENDENCIES builtin_interfaces geometry_msgs trajectory_msgs
 )
 
 # --- tests -----------------------------------------------------------------

--- a/workspace/src/g1_msgs/README.md
+++ b/workspace/src/g1_msgs/README.md
@@ -1,7 +1,8 @@
 # g1_msgs
 
-The stack's own interfaces: what `g1_locomotion` serves for the base approach, and what
-`g1_manipulation` serves to the behavior tree. Five actions, no messages.
+The stack's own interfaces: what `g1_locomotion` serves for the base approach, what
+`g1_manipulation` serves to the behavior tree, and what the learned-grasp pipeline in `g1_vla`
+serves. Six actions, one service, no messages.
 
 `ament_cmake` with `rosidl_default_generators`. No source of its own.
 
@@ -9,6 +10,8 @@ The stack's own interfaces: what `g1_locomotion` serves for the base approach, a
 flowchart LR
     BT["g1_bt_executor"] -- "Pick, Place,<br/>SetArmPosture" --> MS["g1_manipulation_server"]
     BT -- "ApproachObject, Retreat" --> BA["g1_base_approach"]
+    BT -- "Grasp" --> VS["g1_vla_server"]
+    VS -- "GetActionChunk" --> PE["policy engine"]
 ```
 
 ```bash
@@ -34,10 +37,23 @@ Served by `g1_base_approach` in `g1_locomotion`, called from the same tree.
 | `ApproachObject` | `object_id`, `arm`, `working_yaw`, `use_current_heading`, `timeout_s` | Walks the base until the object sits inside the arm's reach window, judged in the base frame. Nav2 parks within 0.5 m; the window is about 0.2 m wide. |
 | `Retreat` | `distance_m`, `timeout_s` | Reverses clear of a surface and stops. It does not turn, because a navigation goal normally follows. |
 
+## Learned grasp
+
+Served by `g1_vla_server` in `g1_vla`, called from the same tree.
+
+| Action | Goal | Notes |
+|---|---|---|
+| `Grasp` | `instruction`, `object_id`, `arm` | Runs a learned policy under a planning-scene check. `instruction` goes to the policy; `object_id` names the `/objects` entry whose lift decides success. Feedback carries chunks executed and rejected. |
+
+`GetActionChunk` is the service every policy engine implements: `instruction` in, one chunk of
+absolute joint positions out, plus `ok`/`message` when the engine cannot produce one. Positions may
+name any subset of the arm and hand joints and `time_from_start` must increase. `g1_vla_server`
+calls it; which engine answers is a launch argument.
+
 Every action except `SetArmPosture` publishes a phase as feedback and names that phase in the
 result message on failure. The phase strings are constants in the `.action` files, so each server
 and its tests share one definition instead of matching literals. `SetArmPosture` is one planned
 motion with nothing to report partway.
 
-All five are actions rather than services because each runs for seconds and has to be cancellable
+All six are actions rather than services because each runs for seconds and has to be cancellable
 while it runs.

--- a/workspace/src/g1_msgs/action/Grasp.action
+++ b/workspace/src/g1_msgs/action/Grasp.action
@@ -1,0 +1,23 @@
+# Grasp an object with one arm by running a learned policy, validating every chunk of its
+# output against the planning scene before any of it executes.
+
+# Natural-language task, handed to whichever policy engine is running.
+string instruction
+# Must match a class_id published on /objects. Its lift is the success test, so the outcome is
+# measured rather than taken from the policy.
+string object_id
+# "left" or "right". Selects the arm group and the hand whose contact is exempted while grasping.
+string ARM_LEFT=left
+string ARM_RIGHT=right
+string arm
+---
+bool success
+# Chunk counters and the measured lift; on failure, what stopped the skill. Not meant to be parsed.
+string message
+---
+string PHASE_PREPARING=preparing
+string PHASE_ACTING=acting
+string phase
+# Executed and rejected-before-moving. How much of the policy's output was usable.
+uint16 chunks_executed
+uint16 chunks_rejected

--- a/workspace/src/g1_msgs/package.xml
+++ b/workspace/src/g1_msgs/package.xml
@@ -5,9 +5,10 @@
   <version>0.1.0</version>
   <description>
     Interfaces for the G1 stack: the ApproachObject and Retreat actions the base
-    approach serves (g1_locomotion), and the Pick, Place and SetArmPosture actions
-    the manipulation skills serve (g1_manipulation). See README for why each is an
-    action rather than a service.
+    approach serves (g1_locomotion), the Pick, Place and SetArmPosture actions
+    the manipulation skills serve (g1_manipulation), and the Grasp action and
+    GetActionChunk service the learned-grasp pipeline serves (g1_vla). See README
+    for why each is an action rather than a service.
   </description>
   <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
   <license>BSD-3-Clause</license>
@@ -17,6 +18,7 @@
 
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
+  <depend>trajectory_msgs</depend>
   <!-- Requires action_msgs to build. -->
   <depend>action_msgs</depend>
 

--- a/workspace/src/g1_msgs/srv/GetActionChunk.srv
+++ b/workspace/src/g1_msgs/srv/GetActionChunk.srv
@@ -1,0 +1,13 @@
+# One turn of the policy loop: given the task, return the next chunk of joint targets.
+#
+# Every policy engine serves this and nothing else, which is what makes them interchangeable.
+# Chunk positions are absolute, may name any subset of the arm and hand joints, and
+# time_from_start must increase.
+
+# Natural-language task. Changing it starts a new episode at the engine.
+string instruction
+---
+bool ok
+# Why no chunk could be produced. Empty when ok.
+string message
+trajectory_msgs/JointTrajectory chunk


### PR DESCRIPTION
Groundwork for the learned-grasp pipeline. No behaviour change to anything that runs today.

- `g1_msgs`: `Grasp.action` and `GetActionChunk.srv`, the service every policy engine will serve. Adds a `trajectory_msgs` dependency.
- Both images: `moveit-servo`, plus `python3-zmq`/`python3-msgpack` and `msgpack-numpy` for the policy adapter. Installed `--no-deps` so pip does not shadow the apt msgpack.
- `g1_manipulation`: the hand collision exemption moves out of the action server into an exported `g1_hand_contact` library, so the grasp skill can share it instead of copying it. The matrix edit is now pure and covered by six gmock cases. `ament_export_dependencies` added, without which a dependant cannot configure.

Full gate green: 13 packages, `-LE simulator`, clang-format and clang-tidy included.