### PR TITLE
Add g1_vla: the planning-scene gate and a stand-in policy engine

### DIFF
--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -24,6 +24,21 @@ add_library(g1_vla_chunk_utils src/chunk_utils.cpp)
 g1_target_defaults(g1_vla_chunk_utils)
 target_link_libraries(g1_vla_chunk_utils PUBLIC ${trajectory_msgs_TARGETS})
 
+add_library(g1_vla_server_node src/g1_vla_server_node.cpp)
+g1_target_defaults(g1_vla_server_node)
+target_link_libraries(g1_vla_server_node PUBLIC
+  g1_vla_chunk_utils
+  g1_manipulation::g1_hand_contact
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
+  moveit_ros_planning::moveit_robot_model_loader
+  ${control_msgs_TARGETS}
+  ${g1_msgs_TARGETS}
+  ${moveit_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${vision_msgs_TARGETS}
+)
+
 add_library(g1_vla_mock_engine_node src/mock_engine_node.cpp)
 g1_target_defaults(g1_vla_mock_engine_node)
 target_link_libraries(g1_vla_mock_engine_node PUBLIC
@@ -35,6 +50,10 @@ target_link_libraries(g1_vla_mock_engine_node PUBLIC
 
 # --- executables -----------------------------------------------------------
 
+add_executable(g1_vla_server src/g1_vla_server_main.cpp)
+g1_target_defaults(g1_vla_server)
+target_link_libraries(g1_vla_server PUBLIC g1_vla_server_node)
+
 add_executable(g1_vla_mock_engine src/mock_engine_main.cpp)
 g1_target_defaults(g1_vla_mock_engine)
 target_link_libraries(g1_vla_mock_engine PUBLIC g1_vla_mock_engine_node)
@@ -42,10 +61,10 @@ target_link_libraries(g1_vla_mock_engine PUBLIC g1_vla_mock_engine_node)
 # --- install ---------------------------------------------------------------
 
 install(DIRECTORY include/ DESTINATION include)
-install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
-install(TARGETS g1_vla_chunk_utils g1_vla_mock_engine_node
+install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
+install(TARGETS g1_vla_chunk_utils g1_vla_server_node g1_vla_mock_engine_node
   EXPORT export_${PROJECT_NAME} DESTINATION lib)
-install(TARGETS g1_vla_mock_engine DESTINATION lib/${PROJECT_NAME})
+install(TARGETS g1_vla_server g1_vla_mock_engine DESTINATION lib/${PROJECT_NAME})
 
 # --- tests -----------------------------------------------------------------
 

--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -24,10 +24,28 @@ add_library(g1_vla_chunk_utils src/chunk_utils.cpp)
 g1_target_defaults(g1_vla_chunk_utils)
 target_link_libraries(g1_vla_chunk_utils PUBLIC ${trajectory_msgs_TARGETS})
 
+add_library(g1_vla_mock_engine_node src/mock_engine_node.cpp)
+g1_target_defaults(g1_vla_mock_engine_node)
+target_link_libraries(g1_vla_mock_engine_node PUBLIC
+  rclcpp::rclcpp
+  ${g1_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${trajectory_msgs_TARGETS}
+)
+
+# --- executables -----------------------------------------------------------
+
+add_executable(g1_vla_mock_engine src/mock_engine_main.cpp)
+g1_target_defaults(g1_vla_mock_engine)
+target_link_libraries(g1_vla_mock_engine PUBLIC g1_vla_mock_engine_node)
+
 # --- install ---------------------------------------------------------------
 
 install(DIRECTORY include/ DESTINATION include)
-install(TARGETS g1_vla_chunk_utils EXPORT export_${PROJECT_NAME} DESTINATION lib)
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+install(TARGETS g1_vla_chunk_utils g1_vla_mock_engine_node
+  EXPORT export_${PROJECT_NAME} DESTINATION lib)
+install(TARGETS g1_vla_mock_engine DESTINATION lib/${PROJECT_NAME})
 
 # --- tests -----------------------------------------------------------------
 

--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.16)
+project(g1_vla)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/g1_common.cmake)
+
+# --- dependencies ----------------------------------------------------------
+
+find_package(ament_cmake REQUIRED)
+find_package(control_msgs REQUIRED)
+find_package(g1_manipulation REQUIRED)
+find_package(g1_msgs REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+find_package(vision_msgs REQUIRED)
+
+# --- libraries -------------------------------------------------------------
+
+add_library(g1_vla_chunk_utils src/chunk_utils.cpp)
+g1_target_defaults(g1_vla_chunk_utils)
+target_link_libraries(g1_vla_chunk_utils PUBLIC ${trajectory_msgs_TARGETS})
+
+# --- install ---------------------------------------------------------------
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS g1_vla_chunk_utils EXPORT export_${PROJECT_NAME} DESTINATION lib)
+
+# --- tests -----------------------------------------------------------------
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gmock REQUIRED)
+
+  ament_add_gmock(test_chunk_utils test/test_chunk_utils.cpp)
+  target_link_libraries(test_chunk_utils g1_vla_chunk_utils)
+
+  g1_add_lint_tests()
+endif()
+
+# --- export ----------------------------------------------------------------
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+ament_export_dependencies(
+  control_msgs
+  g1_manipulation
+  g1_msgs
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning
+  rclcpp
+  rclcpp_action
+  sensor_msgs
+  trajectory_msgs
+  vision_msgs
+)
+
+ament_package()

--- a/workspace/src/g1_vla/README.md
+++ b/workspace/src/g1_vla/README.md
@@ -1,0 +1,87 @@
+# g1_vla
+
+The learned-grasp skill. A policy engine returns chunks of joint targets; `g1_vla_server`
+validates each chunk against the MoveIt planning scene and only then hands it to the trajectory
+controllers. Adds no command path: the chunks go out through the controllers MoveIt already
+drives.
+
+```mermaid
+flowchart LR
+    BT["g1_bt_executor"] -- "Grasp" --> S["g1_vla_server"]
+    S -- "GetActionChunk" --> E["policy engine"]
+    S -- "/check_state_validity" --> MG["move_group"]
+    S -- "FollowJointTrajectory" --> C["arm_trajectory_controller<br/>left/right_hand_controller"]
+```
+
+```bash
+colcon build --symlink-install --packages-select g1_vla
+```
+
+## Nodes
+
+| Node | Does |
+|---|---|
+| `g1_vla_server` | Serves `Grasp`. Queries the engine, validates, executes, and measures the lift. |
+| `g1_vla_mock_engine` | A stand-in engine that walks named joints toward a fixed target. No model needed. |
+
+## Interfaces
+
+| Direction | Name | Type |
+|---|---|---|
+| Action server | `~/grasp` | `g1_msgs/action/Grasp` |
+| Service client | `engine_service` | `g1_msgs/srv/GetActionChunk` |
+| Service client | `/check_state_validity` | `moveit_msgs/srv/GetStateValidity` |
+| Service client | `/get_planning_scene`, `/apply_planning_scene` | `moveit_msgs/srv` |
+| Action client | `/{arm_trajectory,left_hand,right_hand}_controller/follow_joint_trajectory` | `control_msgs/action/FollowJointTrajectory` |
+| Subscriber | `/objects` | `vision_msgs/msg/Detection3DArray` |
+| Subscriber | `/joint_states` | `sensor_msgs/msg/JointState` |
+| Service server (engine) | `~/get_action_chunk` | `g1_msgs/srv/GetActionChunk` |
+
+A chunk carries absolute joint positions, may name any subset of the 14 arm and 14 hand joints,
+and its `time_from_start` must increase. Every engine serves the same service, so which one runs
+is the `engine` launch argument.
+
+## Parameters
+
+`config/g1_vla_server.yaml`:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `engine_service` | `/g1_vla_engine/get_action_chunk` | Where the chunks come from |
+| `engine_timeout_s` | 10.0 | How long one chunk request may take |
+| `max_start_jump_rad` | 0.15 | Largest gap allowed between the measured pose and a chunk's first waypoint |
+| `max_segment_step_rad` | 0.20 | Largest move allowed between consecutive waypoints |
+| `velocity_scaling` | 0.5 | Fraction of each joint's planning velocity limit a chunk may ask for |
+| `max_rejected_chunks` | 5 | Consecutive rejections before the goal aborts |
+| `timeout_s` | 90.0 | Overall goal deadline |
+| `chunk_exec_timeout_s` | 10.0 | Per-controller deadline for one chunk |
+| `success_lift_m` | 0.05 | Rise in the object's height that counts as a grasp |
+| `object_timeout_ms` | 1000.0 | How stale an `/objects` pose may be |
+
+`config/g1_vla_mock_engine.yaml`: `joint_names`, `target_positions`, `steps_per_chunk`,
+`action_dt_s`, `step_rad`.
+
+The server reads velocity limits from `robot_description_planning.joint_limits`, which the launch
+supplies from `g1_moveit_config`. It logs the resolved arm limit at startup.
+
+## Failure behaviour
+
+A rejected chunk is not executed at all, so the robot has not moved; the server asks the engine
+again. After `max_rejected_chunks` in a row the goal aborts with a message starting `blocked:`.
+Any failure leaves the arm and hand where they are and restores the collision exemption. Moving
+away afterwards is the behavior tree's job.
+
+## Running
+
+The server needs `move_group`, the controllers, and an acquired arm, all of which `g1_bringup`
+composes. Standalone, against the mock engine:
+
+```bash
+ros2 launch g1_vla vla.launch.py engine:=mock
+```
+
+## Tests
+
+| Test | Covers |
+|---|---|
+| `test_chunk_utils` | Chunk shape, the start-jump, segment-step and velocity checks, and the controller split |

--- a/workspace/src/g1_vla/config/g1_vla_mock_engine.yaml
+++ b/workspace/src/g1_vla/config/g1_vla_mock_engine.yaml
@@ -1,0 +1,14 @@
+g1_vla_mock_engine:
+  ros__parameters:
+    # The right arm only. A target the gate can reach in free space, so a healthy stack executes
+    # every chunk; point it at a surface instead and every chunk should be rejected unmoved.
+    joint_names:
+      - right_shoulder_pitch_joint
+      - right_shoulder_roll_joint
+      - right_elbow_joint
+    target_positions: [-0.6, -0.2, 0.8]
+
+    steps_per_chunk: 8
+    action_dt_s: 0.1
+    # Under the server's max_segment_step_rad, so the walk itself never trips the gate.
+    step_rad: 0.05

--- a/workspace/src/g1_vla/config/g1_vla_server.yaml
+++ b/workspace/src/g1_vla/config/g1_vla_server.yaml
@@ -1,0 +1,23 @@
+g1_vla_server:
+  ros__parameters:
+    # Whichever engine is launched remaps its own ~/get_action_chunk onto this name.
+    engine_service: /g1_vla_engine/get_action_chunk
+    engine_timeout_s: 10.0
+
+    # A chunk opening this far from the measured pose means the policy misread the state, and
+    # executing it would snap the arm across space nothing has checked.
+    max_start_jump_rad: 0.15
+    # Per-waypoint validity only means something while consecutive waypoints stay close.
+    max_segment_step_rad: 0.20
+    # Fraction of each joint's model velocity limit a chunk may ask for.
+    velocity_scaling: 0.5
+
+    # A rejected chunk leaves the robot where it was, and the policy head is stochastic, so
+    # asking again is a real retry. This many in a row means the scene is genuinely blocking it.
+    max_rejected_chunks: 5
+    timeout_s: 90.0
+    chunk_exec_timeout_s: 10.0
+
+    # How far the object has to rise before the grasp counts. Measured off /objects, as a delta.
+    success_lift_m: 0.05
+    object_timeout_ms: 1000.0

--- a/workspace/src/g1_vla/include/g1_vla/chunk_utils.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/chunk_utils.hpp
@@ -1,0 +1,70 @@
+#ifndef G1_VLA__CHUNK_UTILS_HPP_
+#define G1_VLA__CHUNK_UTILS_HPP_
+
+/**
+ * @file chunk_utils.hpp
+ * @brief Kinematic checks and the controller split, over one chunk of policy output.
+ *
+ * Free functions with no node behind them, so the gate's arithmetic is testable on its own.
+ */
+
+#include <map>
+#include <optional>
+#include <string>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <vector>
+
+namespace g1_vla
+{
+
+/// Joint positions by name, as read from /joint_states.
+using JointMap = std::map<std::string, double>;
+
+/**
+ * @brief Whether a chunk is shaped like a trajectory at all.
+ *
+ * Names and points non-empty, every point as wide as the name list, and time_from_start
+ * positive and strictly increasing. Everything below assumes this passed.
+ */
+[[nodiscard]] bool wellFormed(const trajectory_msgs::msg::JointTrajectory& chunk);
+
+/**
+ * @brief The part of @p chunk that a controller owning @p joints can execute.
+ *
+ * @return Empty joint_names when the chunk names none of them, which is a controller to skip.
+ */
+[[nodiscard]] trajectory_msgs::msg::JointTrajectory splitByController(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const std::vector<std::string>& joints);
+
+/**
+ * @brief Largest per-joint gap between the measured pose and the chunk's first waypoint.
+ *
+ * A policy that misread the state opens its chunk somewhere the arm is not, and executing that
+ * snaps the arm across space nothing has collision-checked.
+ *
+ * @return nullopt if a joint in the chunk was not measured.
+ */
+[[nodiscard]] std::optional<double>
+startJump(const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured);
+
+/**
+ * @brief Largest per-joint move between consecutive waypoints.
+ *
+ * Per-waypoint collision checking only means something while consecutive waypoints stay close:
+ * the space swept between two far-apart ones is never looked at.
+ */
+[[nodiscard]] double maxSegmentStep(const trajectory_msgs::msg::JointTrajectory& chunk);
+
+/**
+ * @brief Fastest segment as a fraction of that joint's limit, counting measured to first point.
+ *
+ * @return nullopt if a chunk joint has no positive limit, meaning the model and the chunk
+ *         disagree about what the robot is.
+ */
+[[nodiscard]] std::optional<double> maxVelocityRatio(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured,
+    const JointMap& limits);
+
+}  // namespace g1_vla
+
+#endif  // G1_VLA__CHUNK_UTILS_HPP_

--- a/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
@@ -1,0 +1,162 @@
+#ifndef G1_VLA__G1_VLA_SERVER_NODE_HPP_
+#define G1_VLA__G1_VLA_SERVER_NODE_HPP_
+
+/**
+ * @file g1_vla_server_node.hpp
+ * @brief The grasp skill: a policy's action chunks, checked against the planning scene before
+ *        any of them reach a controller.
+ *
+ * Adds no command path. Chunks go out through the same trajectory controllers MoveIt already
+ * drives, so the one-writer rule is unaffected by this node existing, and the legs stay on the
+ * balance policy throughout.
+ *
+ * Takes no control authority of its own: the arm and hands must already be acquired.
+ */
+
+#include <atomic>
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <cstdint>
+#include <g1_msgs/action/grasp.hpp>
+#include <g1_msgs/srv/get_action_chunk.hpp>
+#include <memory>
+#include <moveit/robot_model_loader/robot_model_loader.hpp>
+#include <moveit_msgs/srv/apply_planning_scene.hpp>
+#include <moveit_msgs/srv/get_planning_scene.hpp>
+#include <moveit_msgs/srv/get_state_validity.hpp>
+#include <mutex>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <string>
+#include <vector>
+#include <vision_msgs/msg/detection3_d_array.hpp>
+
+#include "g1_vla/chunk_utils.hpp"
+
+namespace g1_vla
+{
+
+/// One trajectory controller the gate can hand a slice of a chunk to.
+struct ControllerTarget
+{
+    std::string              name;    ///< For failure messages; also the action namespace.
+    std::vector<std::string> joints;  ///< What it owns, read from the robot model.
+    rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SharedPtr client;
+};
+
+class G1VlaServer : public rclcpp::Node
+{
+public:
+    explicit G1VlaServer(const rclcpp::NodeOptions& options);
+
+    /// Waits for a goal still running on a detached thread, which outlives its clients otherwise.
+    ~G1VlaServer() override;
+
+    /**
+     * @brief Loads the robot model and builds the controller clients.
+     *
+     * Separate from the constructor because the model arrives on this node's own callbacks, so
+     * loading it before something spins the node deadlocks.
+     */
+    void initialize();
+
+private:
+    using Grasp                 = g1_msgs::action::Grasp;
+    using GoalHandle            = rclcpp_action::ServerGoalHandle<Grasp>;
+    using GetActionChunk        = g1_msgs::srv::GetActionChunk;
+    using FollowJointTrajectory = control_msgs::action::FollowJointTrajectory;
+    using JointTrajectory       = trajectory_msgs::msg::JointTrajectory;
+
+    /// What one goal ended up doing. Its counters are the record the experiment reads.
+    struct Outcome
+    {
+        bool        success{ false };
+        std::string message;
+        uint16_t    executed{ 0 };
+        uint16_t    rejected{ 0 };
+    };
+
+    /// Claims the arm for one goal.
+    bool acquire();
+
+    void executeGrasp(const std::shared_ptr<GoalHandle>& goal_handle);
+
+    /**
+     * @brief The query-validate-execute loop, between the collision exemption and its restore.
+     *
+     * Split out so every way this can end still passes through the one restore in its caller.
+     */
+    Outcome runGrasp(
+        const std::shared_ptr<GoalHandle>& goal_handle, const std::string& side, double start_z);
+
+    /// Asks the engine for the next chunk. @return nullopt with @p why set.
+    std::optional<JointTrajectory> requestChunk(const std::string& instruction, std::string& why);
+
+    /**
+     * @brief Every reason this chunk must not be executed.
+     *
+     * @return Empty when the chunk may run. The kinematic checks come first because they are
+     *         local; the planning-scene calls are the expensive part.
+     */
+    std::string rejectionReason(const JointTrajectory& chunk, const std::string& side);
+
+    /// Asks move_group whether each waypoint is a legal state. Uses its live scene and matrix.
+    std::string checkWaypoints(const JointTrajectory& chunk, const std::string& group);
+
+    /// Splits the chunk across the controllers, sends it, and waits for all of them.
+    bool executeChunk(const JointTrajectory& chunk, std::string& why);
+
+    /// Cancels anything still running on the controllers.
+    void cancelAll();
+
+    /// Allows or restores contact between one hand and the octomap. @return false on failure.
+    bool setHandContact(const std::string& side, bool allowed);
+
+    JointMap measuredJoints();
+
+    /// Height of @p object_id on /objects. @return nullopt if unknown or too old.
+    std::optional<double> objectHeight(const std::string& object_id);
+
+    void onObjects(const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg);
+    void onJointStates(const sensor_msgs::msg::JointState::ConstSharedPtr& msg);
+
+    rclcpp::Subscription<vision_msgs::msg::Detection3DArray>::SharedPtr objects_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr       joint_states_sub_;
+
+    std::mutex                         objects_mutex_;
+    vision_msgs::msg::Detection3DArray objects_;
+    std::mutex                         joints_mutex_;
+    JointMap                           measured_;
+
+    rclcpp::Client<GetActionChunk>::SharedPtr                       engine_;
+    rclcpp::Client<moveit_msgs::srv::GetStateValidity>::SharedPtr   validity_;
+    rclcpp::Client<moveit_msgs::srv::GetPlanningScene>::SharedPtr   get_scene_;
+    rclcpp::Client<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr apply_scene_;
+    rclcpp_action::Server<Grasp>::SharedPtr                         grasp_server_;
+
+    robot_model_loader::RobotModelLoaderPtr model_loader_;
+    moveit::core::RobotModelConstPtr        model_;
+    std::vector<ControllerTarget>           controllers_;
+    /// Velocity limits by joint, read from the model once.
+    JointMap limits_;
+
+    std::string engine_service_;
+    double      engine_timeout_s_{ 10.0 };
+    double      max_start_jump_rad_{ 0.15 };
+    double      max_segment_step_rad_{ 0.20 };
+    double      velocity_scaling_{ 0.5 };
+    int         max_rejected_chunks_{ 5 };
+    double      timeout_s_{ 90.0 };
+    double      chunk_exec_timeout_s_{ 10.0 };
+    double      success_lift_m_{ 0.05 };
+    double      object_timeout_s_{ 1.0 };
+
+    /// One goal at a time: two would drive overlapping joints through the same controllers.
+    std::atomic<bool> busy_{ false };
+    std::atomic<int>  goals_running_{ 0 };
+};
+
+}  // namespace g1_vla
+
+#endif  // G1_VLA__G1_VLA_SERVER_NODE_HPP_

--- a/workspace/src/g1_vla/include/g1_vla/mock_engine_node.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/mock_engine_node.hpp
@@ -1,0 +1,55 @@
+#ifndef G1_VLA__MOCK_ENGINE_NODE_HPP_
+#define G1_VLA__MOCK_ENGINE_NODE_HPP_
+
+/**
+ * @file mock_engine_node.hpp
+ * @brief A deterministic stand-in for a policy engine.
+ *
+ * Serves the same chunk service a real policy does, walking the named joints toward a fixed
+ * target a bounded step at a time. It exists so the gate can be tested without a model: aim it
+ * at free space and every chunk should execute, aim it into a surface and every chunk should be
+ * rejected before the arm moves.
+ */
+
+#include <g1_msgs/srv/get_action_chunk.hpp>
+#include <map>
+#include <mutex>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <string>
+#include <vector>
+
+namespace g1_vla
+{
+
+class G1VlaMockEngine : public rclcpp::Node
+{
+public:
+    explicit G1VlaMockEngine(const rclcpp::NodeOptions& options);
+
+private:
+    using GetActionChunk = g1_msgs::srv::GetActionChunk;
+
+    /// Builds one chunk from the measured pose, or refuses if no joint state has arrived.
+    void onGetActionChunk(
+        const GetActionChunk::Request::SharedPtr&  request,
+        const GetActionChunk::Response::SharedPtr& response);
+
+    void onJointStates(const sensor_msgs::msg::JointState::ConstSharedPtr& msg);
+
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
+    rclcpp::Service<GetActionChunk>::SharedPtr                    chunk_service_;
+
+    std::mutex                    joints_mutex_;
+    std::map<std::string, double> measured_;
+
+    std::vector<std::string> joint_names_;
+    std::vector<double>      target_positions_;
+    int                      steps_per_chunk_{ 8 };
+    double                   action_dt_s_{ 0.1 };
+    double                   step_rad_{ 0.05 };
+};
+
+}  // namespace g1_vla
+
+#endif  // G1_VLA__MOCK_ENGINE_NODE_HPP_

--- a/workspace/src/g1_vla/launch/vla.launch.py
+++ b/workspace/src/g1_vla/launch/vla.launch.py
@@ -1,0 +1,84 @@
+"""The grasp skill and the policy engine that feeds it.
+
+No simulator and no move_group: g1_bringup composes both alongside this. The engine is chosen
+here rather than in the server, which only ever sees one service.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import EqualsSubstitution, LaunchConfiguration
+from launch_ros.actions import Node
+from moveit_configs_utils import MoveItConfigsBuilder
+
+SHARE = get_package_share_directory("g1_vla")
+DESCRIPTION_SHARE = get_package_share_directory("g1_description")
+MOVEIT_SHARE = get_package_share_directory("g1_moveit_config")
+
+ENGINE_SERVICE = "/g1_vla_engine/get_action_chunk"
+
+
+def _config(share, name):
+    return os.path.join(share, "config", name)
+
+
+def _moveit_config():
+    """The server loads the robot model from its own parameters, for the groups and the hand
+    links it exempts; without them it builds against an empty model. joint_limits carries the
+    velocities it checks chunks against, which are not the URDF's."""
+    return (
+        MoveItConfigsBuilder("g1", package_name="g1_moveit_config")
+        .robot_description(
+            file_path=os.path.join(DESCRIPTION_SHARE, "urdf", "g1_lowcmd.urdf.xacro")
+        )
+        .robot_description_semantic(file_path=_config(MOVEIT_SHARE, "g1.srdf"))
+        .joint_limits(file_path=_config(MOVEIT_SHARE, "joint_limits.yaml"))
+        # Named, or the builder assembles every pipeline it knows and pilz fails the launch.
+        .planning_pipelines(pipelines=["ompl"], default_planning_pipeline="ompl")
+        .to_moveit_configs()
+    )
+
+
+def _server():
+    return Node(
+        package="g1_vla",
+        executable="g1_vla_server",
+        name="g1_vla_server",
+        output="screen",
+        parameters=[
+            _moveit_config().to_dict(),
+            _config(SHARE, "g1_vla_server.yaml"),
+            {"engine_service": ENGINE_SERVICE},
+        ],
+    )
+
+
+def _mock_engine():
+    return Node(
+        package="g1_vla",
+        executable="g1_vla_mock_engine",
+        name="g1_vla_mock_engine",
+        output="screen",
+        condition=IfCondition(EqualsSubstitution(LaunchConfiguration("engine"), "mock")),
+        parameters=[_config(SHARE, "g1_vla_mock_engine.yaml")],
+        remappings=[("~/get_action_chunk", ENGINE_SERVICE)],
+    )
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "engine",
+                default_value="mock",
+                choices=["mock"],
+                description="Which policy engine answers the server. 'mock' walks the arm "
+                "toward a fixed target and needs no model.",
+            ),
+            _server(),
+            _mock_engine(),
+        ]
+    )

--- a/workspace/src/g1_vla/package.xml
+++ b/workspace/src/g1_vla/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>g1_vla</name>
+  <version>0.1.0</version>
+  <description>
+    The learned-grasp skill: a policy engine emits chunks of joint targets, and this
+    package validates each one against the MoveIt planning scene before any of it
+    reaches a controller. Ships the gate, a stand-in engine for testing it, and the
+    launch that pairs them.
+  </description>
+  <maintainer email="gupta.adyansh@gmail.com">Adyansh</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>control_msgs</depend>
+  <depend>g1_manipulation</depend>
+  <depend>g1_msgs</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_msgs</depend>
+  <depend>moveit_ros_planning</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>sensor_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>vision_msgs</depend>
+
+  <!-- The launch reads the description and semantics through the MoveIt config builder. -->
+  <exec_depend>g1_moveit_config</exec_depend>
+  <exec_depend>moveit_configs_utils</exec_depend>
+
+  <!-- ament_lint_common intentionally not used to avoid clang-format conflicts. -->
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/workspace/src/g1_vla/src/chunk_utils.cpp
+++ b/workspace/src/g1_vla/src/chunk_utils.cpp
@@ -1,0 +1,150 @@
+/**
+ * @file chunk_utils.cpp
+ * @brief Chunk shape, continuity and speed checks.
+ */
+
+#include "g1_vla/chunk_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace g1_vla
+{
+
+namespace
+{
+
+double seconds(const builtin_interfaces::msg::Duration& d)
+{
+    return static_cast<double>(d.sec) + (static_cast<double>(d.nanosec) * 1e-9);
+}
+
+}  // namespace
+
+bool wellFormed(const trajectory_msgs::msg::JointTrajectory& chunk)
+{
+    if (chunk.joint_names.empty() || chunk.points.empty())
+    {
+        return false;
+    }
+    double previous = 0.0;
+    for (const trajectory_msgs::msg::JointTrajectoryPoint& point : chunk.points)
+    {
+        if (point.positions.size() != chunk.joint_names.size())
+        {
+            return false;
+        }
+        const double t = seconds(point.time_from_start);
+        if (!(t > previous))
+        {
+            return false;
+        }
+        previous = t;
+    }
+    return true;
+}
+
+trajectory_msgs::msg::JointTrajectory splitByController(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const std::vector<std::string>& joints)
+{
+    std::vector<std::size_t> keep;
+    for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+    {
+        if (std::find(joints.begin(), joints.end(), chunk.joint_names[i]) != joints.end())
+        {
+            keep.push_back(i);
+        }
+    }
+
+    trajectory_msgs::msg::JointTrajectory out;
+    out.header = chunk.header;
+    if (keep.empty())
+    {
+        return out;
+    }
+    for (const std::size_t i : keep)
+    {
+        out.joint_names.push_back(chunk.joint_names[i]);
+    }
+    for (const trajectory_msgs::msg::JointTrajectoryPoint& point : chunk.points)
+    {
+        trajectory_msgs::msg::JointTrajectoryPoint kept;
+        kept.time_from_start = point.time_from_start;
+        for (const std::size_t i : keep)
+        {
+            kept.positions.push_back(point.positions[i]);
+        }
+        out.points.push_back(kept);
+    }
+    return out;
+}
+
+std::optional<double>
+startJump(const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured)
+{
+    double worst = 0.0;
+    for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+    {
+        const auto it = measured.find(chunk.joint_names[i]);
+        if (it == measured.end())
+        {
+            return std::nullopt;
+        }
+        worst = std::max(worst, std::abs(chunk.points.front().positions[i] - it->second));
+    }
+    return worst;
+}
+
+double maxSegmentStep(const trajectory_msgs::msg::JointTrajectory& chunk)
+{
+    double worst = 0.0;
+    for (std::size_t p = 1; p < chunk.points.size(); ++p)
+    {
+        for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+        {
+            worst = std::max(
+                worst,
+                std::abs(chunk.points[p].positions[i] - chunk.points[p - 1].positions[i]));
+        }
+    }
+    return worst;
+}
+
+std::optional<double> maxVelocityRatio(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured,
+    const JointMap& limits)
+{
+    std::vector<double> previous;
+    previous.reserve(chunk.joint_names.size());
+    std::vector<double> limit;
+    limit.reserve(chunk.joint_names.size());
+    for (const std::string& name : chunk.joint_names)
+    {
+        const auto measured_it = measured.find(name);
+        const auto limit_it    = limits.find(name);
+        if (measured_it == measured.end() || limit_it == limits.end() || !(limit_it->second > 0.0))
+        {
+            return std::nullopt;
+        }
+        previous.push_back(measured_it->second);
+        limit.push_back(limit_it->second);
+    }
+
+    double worst      = 0.0;
+    double previous_t = 0.0;
+    for (const trajectory_msgs::msg::JointTrajectoryPoint& point : chunk.points)
+    {
+        const double dt = seconds(point.time_from_start) - previous_t;
+        for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+        {
+            const double speed = std::abs(point.positions[i] - previous[i]) / dt;
+            worst              = std::max(worst, speed / limit[i]);
+            previous[i]        = point.positions[i];
+        }
+        previous_t = seconds(point.time_from_start);
+    }
+    return worst;
+}
+
+}  // namespace g1_vla

--- a/workspace/src/g1_vla/src/g1_vla_server_main.cpp
+++ b/workspace/src/g1_vla/src/g1_vla_server_main.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file g1_vla_server_main.cpp
+ * @brief Entry point for the grasp skill.
+ */
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <thread>
+
+#include "g1_vla/g1_vla_server_node.hpp"
+
+int main(int argc, char** argv)
+{
+    rclcpp::init(argc, argv);
+
+    // Multi-threaded, and spinning BEFORE initialize(): the robot model arrives on this node's
+    // own callbacks, and goals then wait on service futures without spinning.
+    auto node = std::make_shared<g1_vla::G1VlaServer>(rclcpp::NodeOptions());
+    rclcpp::executors::MultiThreadedExecutor executor;
+    executor.add_node(node);
+    std::thread spinner([&executor] { executor.spin(); });
+
+    node->initialize();
+    spinner.join();
+
+    rclcpp::shutdown();
+    return 0;
+}

--- a/workspace/src/g1_vla/src/g1_vla_server_node.cpp
+++ b/workspace/src/g1_vla/src/g1_vla_server_node.cpp
@@ -1,0 +1,578 @@
+/**
+ * @file g1_vla_server_node.cpp
+ * @brief The grasp action server: query a policy, validate the chunk, then execute it.
+ */
+
+#include "g1_vla/g1_vla_server_node.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <g1_manipulation/hand_contact.hpp>
+#include <moveit/robot_model/joint_model_group.hpp>
+#include <moveit_msgs/msg/robot_state.hpp>
+#include <thread>
+#include <utility>
+
+namespace g1_vla
+{
+
+namespace
+{
+
+/// The one thing a grasping hand is always allowed to touch: space the sensor saw as occupied.
+const std::vector<std::string> kTouchables = { "<octomap>" };
+
+rclcpp::QoS objectsQos()
+{
+    return rclcpp::QoS(rclcpp::KeepLast(1)).reliable().durability_volatile();
+}
+
+/// Waits on a future without spinning: the executor owns this node and re-entering it deadlocks.
+template <typename FutureT>
+bool settled(FutureT& future, double timeout_s)
+{
+    return future.wait_for(std::chrono::duration<double>(timeout_s)) == std::future_status::ready;
+}
+
+}  // namespace
+
+G1VlaServer::G1VlaServer(const rclcpp::NodeOptions& options)
+  : rclcpp::Node("g1_vla_server", options)
+{
+    engine_service_ =
+        declare_parameter<std::string>("engine_service", "/g1_vla_engine/get_action_chunk");
+    engine_timeout_s_ = declare_parameter<double>("engine_timeout_s", 10.0);
+    // A chunk that opens away from where the arm actually is means the policy misread the state.
+    max_start_jump_rad_ = declare_parameter<double>("max_start_jump_rad", 0.15);
+    // Waypoints further apart than this sweep space no validity check ever looked at.
+    max_segment_step_rad_ = declare_parameter<double>("max_segment_step_rad", 0.20);
+    velocity_scaling_     = declare_parameter<double>("velocity_scaling", 0.5);
+    max_rejected_chunks_  = static_cast<int>(declare_parameter<int64_t>("max_rejected_chunks", 5));
+    timeout_s_            = declare_parameter<double>("timeout_s", 90.0);
+    chunk_exec_timeout_s_ = declare_parameter<double>("chunk_exec_timeout_s", 10.0);
+    success_lift_m_       = declare_parameter<double>("success_lift_m", 0.05);
+    object_timeout_s_     = declare_parameter<double>("object_timeout_ms", 1000.0) / 1000.0;
+
+    objects_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
+        "/objects",
+        objectsQos(),
+        [this](const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg) { onObjects(msg); });
+    joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+        "/joint_states",
+        rclcpp::QoS(rclcpp::KeepLast(1)),
+        [this](const sensor_msgs::msg::JointState::ConstSharedPtr& msg) { onJointStates(msg); });
+
+    engine_      = create_client<GetActionChunk>(engine_service_);
+    validity_    = create_client<moveit_msgs::srv::GetStateValidity>("/check_state_validity");
+    get_scene_   = create_client<moveit_msgs::srv::GetPlanningScene>("/get_planning_scene");
+    apply_scene_ = create_client<moveit_msgs::srv::ApplyPlanningScene>("/apply_planning_scene");
+}
+
+G1VlaServer::~G1VlaServer()
+{
+    while (goals_running_.load() > 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+}
+
+void G1VlaServer::initialize()
+{
+    model_loader_ = std::make_shared<robot_model_loader::RobotModelLoader>(shared_from_this());
+    model_        = model_loader_->getModel();
+    if (model_ == nullptr)
+    {
+        throw std::runtime_error("no robot model; is robot_description on this node?");
+    }
+
+    const auto joints_of = [this](const std::vector<std::string>& groups) {
+        std::vector<std::string> names;
+        for (const std::string& group : groups)
+        {
+            const moveit::core::JointModelGroup* jmg = model_->getJointModelGroup(group);
+            if (jmg == nullptr)
+            {
+                throw std::runtime_error("the SRDF has no group '" + group + "'");
+            }
+            const std::vector<std::string>& active = jmg->getActiveJointModelNames();
+            names.insert(names.end(), active.begin(), active.end());
+        }
+        return names;
+    };
+
+    // Which joints each controller owns comes from the model, not from a list here, so the two
+    // cannot drift. The names match g1_moveit_config's controller list.
+    const std::vector<std::pair<std::string, std::vector<std::string>>> layout = {
+        { "arm_trajectory_controller", { "left_arm", "right_arm" } },
+        { "left_hand_controller", { "left_hand" } },
+        { "right_hand_controller", { "right_hand" } },
+    };
+    for (const auto& [name, groups] : layout)
+    {
+        ControllerTarget target;
+        target.name   = name;
+        target.joints = joints_of(groups);
+        target.client = rclcpp_action::create_client<FollowJointTrajectory>(
+            this,
+            "/" + name + "/follow_joint_trajectory");
+        controllers_.push_back(std::move(target));
+    }
+
+    // The URDF's velocity limits are what the motor can do, not what the arm tracks: 22 to 37
+    // rad/s against the 0.8 MoveIt actually times trajectories against. Checking a chunk against
+    // the motor spec would pass everything, so the planning limits win wherever they exist.
+    std::vector<std::string> fell_back;
+    for (const ControllerTarget& controller : controllers_)
+    {
+        for (const std::string& joint : controller.joints)
+        {
+            // Declared already if the model loader read the same limits; declared here so the
+            // lookup still works when nothing did.
+            const std::string name =
+                "robot_description_planning.joint_limits." + joint + ".max_velocity";
+            if (!has_parameter(name))
+            {
+                declare_parameter<double>(name, 0.0);
+            }
+            const double planning = get_parameter(name).as_double();
+            if (planning > 0.0)
+            {
+                limits_[joint] = planning;
+                continue;
+            }
+            const moveit::core::VariableBounds& bounds = model_->getVariableBounds(joint);
+            limits_[joint] = bounds.velocity_bounded_ ? bounds.max_velocity_ : 0.0;
+            fell_back.push_back(joint);
+        }
+    }
+    if (!fell_back.empty())
+    {
+        RCLCPP_WARN(
+            get_logger(),
+            "%zu joint(s) have no planning velocity limit and are checked against the URDF's "
+            "motor spec instead, starting with '%s'",
+            fell_back.size(),
+            fell_back.front().c_str());
+    }
+
+    grasp_server_ = rclcpp_action::create_server<Grasp>(
+        this,
+        "~/grasp",
+        [this](const rclcpp_action::GoalUUID&, const std::shared_ptr<const Grasp::Goal>&) {
+            return acquire() ? rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE :
+                               rclcpp_action::GoalResponse::REJECT;
+        },
+        [](const std::shared_ptr<GoalHandle>&) { return rclcpp_action::CancelResponse::ACCEPT; },
+        [this](const std::shared_ptr<GoalHandle>& handle) {
+            std::thread([this, handle] {
+                goals_running_.fetch_add(1);
+                try
+                {
+                    executeGrasp(handle);
+                }
+                catch (const std::exception& e)
+                {
+                    RCLCPP_ERROR(get_logger(), "grasp goal threw: %s", e.what());
+                    auto result     = std::make_shared<Grasp::Result>();
+                    result->success = false;
+                    result->message = std::string("aborted on an internal error: ") + e.what();
+                    if (handle->is_executing() || handle->is_canceling())
+                    {
+                        handle->abort(result);
+                    }
+                }
+                busy_.store(false);
+                goals_running_.fetch_sub(1);
+            }).detach();
+        });
+
+    // The arm limit is logged because it is the one number that decides whether the velocity
+    // check means anything, and it has two very different plausible values.
+    RCLCPP_INFO(
+        get_logger(),
+        "grasp server ready, engine at '%s', arm velocity limit %.2f rad/s",
+        engine_service_.c_str(),
+        limits_.at("right_elbow_joint"));
+}
+
+bool G1VlaServer::acquire()
+{
+    bool expected = false;
+    if (!busy_.compare_exchange_strong(expected, true))
+    {
+        RCLCPP_WARN(get_logger(), "rejecting a goal: the arm is already running one");
+        return false;
+    }
+    return true;
+}
+
+void G1VlaServer::onObjects(const vision_msgs::msg::Detection3DArray::ConstSharedPtr& msg)
+{
+    const std::lock_guard<std::mutex> lock(objects_mutex_);
+    objects_ = *msg;
+}
+
+void G1VlaServer::onJointStates(const sensor_msgs::msg::JointState::ConstSharedPtr& msg)
+{
+    const std::lock_guard<std::mutex> lock(joints_mutex_);
+    for (std::size_t i = 0; i < msg->name.size() && i < msg->position.size(); ++i)
+    {
+        measured_[msg->name[i]] = msg->position[i];
+    }
+}
+
+JointMap G1VlaServer::measuredJoints()
+{
+    const std::lock_guard<std::mutex> lock(joints_mutex_);
+    return measured_;
+}
+
+std::optional<double> G1VlaServer::objectHeight(const std::string& object_id)
+{
+    vision_msgs::msg::Detection3DArray snapshot;
+    {
+        const std::lock_guard<std::mutex> lock(objects_mutex_);
+        snapshot = objects_;
+    }
+    if (snapshot.detections.empty() ||
+        (now() - rclcpp::Time(snapshot.header.stamp)).seconds() > object_timeout_s_)
+    {
+        return std::nullopt;
+    }
+    for (const vision_msgs::msg::Detection3D& detection : snapshot.detections)
+    {
+        if (!detection.results.empty() && detection.results.front().hypothesis.class_id == object_id)
+        {
+            return detection.bbox.center.position.z;
+        }
+    }
+    return std::nullopt;
+}
+
+bool G1VlaServer::setHandContact(const std::string& side, bool allowed)
+{
+    const std::vector<std::string> links = g1_manipulation::handContactLinks(*model_, side);
+    if (links.empty())
+    {
+        RCLCPP_ERROR(get_logger(), "the model has no '%s_hand' group", side.c_str());
+        return false;
+    }
+    return g1_manipulation::applyHandContact(
+        get_scene_,
+        apply_scene_,
+        get_logger(),
+        links,
+        kTouchables,
+        allowed,
+        true);
+}
+
+std::optional<G1VlaServer::JointTrajectory>
+G1VlaServer::requestChunk(const std::string& instruction, std::string& why)
+{
+    auto request         = std::make_shared<GetActionChunk::Request>();
+    request->instruction = instruction;
+    auto future          = engine_->async_send_request(request);
+    if (!settled(future, engine_timeout_s_))
+    {
+        why = "the policy engine did not answer within " + std::to_string(engine_timeout_s_) + " s";
+        return std::nullopt;
+    }
+    GetActionChunk::Response::SharedPtr response = future.get();
+    if (!response->ok)
+    {
+        why = "the policy engine refused: " + response->message;
+        return std::nullopt;
+    }
+    return response->chunk;
+}
+
+std::string G1VlaServer::rejectionReason(const JointTrajectory& chunk, const std::string& side)
+{
+    if (!wellFormed(chunk))
+    {
+        return "malformed chunk";
+    }
+
+    const JointMap measured = measuredJoints();
+
+    const std::optional<double> jump = startJump(chunk, measured);
+    if (!jump.has_value())
+    {
+        return "the chunk names a joint that is not being measured";
+    }
+    if (*jump > max_start_jump_rad_)
+    {
+        return "starts " + std::to_string(*jump) + " rad from the measured pose";
+    }
+
+    const double step = maxSegmentStep(chunk);
+    if (step > max_segment_step_rad_)
+    {
+        return "steps " + std::to_string(step) + " rad between waypoints";
+    }
+
+    const std::optional<double> ratio = maxVelocityRatio(chunk, measured, limits_);
+    if (!ratio.has_value())
+    {
+        return "the chunk names a joint with no velocity limit in the model";
+    }
+    if (*ratio > velocity_scaling_)
+    {
+        return "asks for " + std::to_string(*ratio * 100.0) + "% of a joint's velocity limit";
+    }
+
+    return checkWaypoints(chunk, side + "_arm");
+}
+
+std::string G1VlaServer::checkWaypoints(const JointTrajectory& chunk, const std::string& group)
+{
+    const JointMap measured = measuredJoints();
+
+    for (std::size_t p = 0; p < chunk.points.size(); ++p)
+    {
+        JointMap state = measured;
+        for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+        {
+            state[chunk.joint_names[i]] = chunk.points[p].positions[i];
+        }
+
+        auto request        = std::make_shared<moveit_msgs::srv::GetStateValidity::Request>();
+        request->group_name = group;
+        request->robot_state.is_diff = false;
+        for (const auto& [name, position] : state)
+        {
+            request->robot_state.joint_state.name.push_back(name);
+            request->robot_state.joint_state.position.push_back(position);
+        }
+
+        auto future = validity_->async_send_request(request);
+        if (!settled(future, 5.0))
+        {
+            return "/check_state_validity did not answer";
+        }
+        if (!future.get()->valid)
+        {
+            return "waypoint " + std::to_string(p) + " of " + std::to_string(chunk.points.size()) +
+                   " is in collision";
+        }
+    }
+    return {};
+}
+
+bool G1VlaServer::executeChunk(const JointTrajectory& chunk, std::string& why)
+{
+    using GoalHandleFJT = rclcpp_action::ClientGoalHandle<FollowJointTrajectory>;
+    std::vector<std::shared_future<GoalHandleFJT::WrappedResult>> results;
+    std::vector<std::string>                                      sent_to;
+
+    for (const ControllerTarget& controller : controllers_)
+    {
+        const JointTrajectory slice = splitByController(chunk, controller.joints);
+        if (slice.joint_names.empty())
+        {
+            continue;
+        }
+        if (!controller.client->action_server_is_ready())
+        {
+            why = controller.name + " is not accepting trajectories; is the arm acquired?";
+            return false;
+        }
+
+        FollowJointTrajectory::Goal goal;
+        goal.trajectory = slice;
+        auto handle     = controller.client->async_send_goal(goal);
+        if (!settled(handle, chunk_exec_timeout_s_) || handle.get() == nullptr)
+        {
+            why = controller.name + " rejected the trajectory";
+            return false;
+        }
+        results.push_back(controller.client->async_get_result(handle.get()));
+        sent_to.push_back(controller.name);
+    }
+
+    if (results.empty())
+    {
+        why = "the chunk names no joint any controller owns";
+        return false;
+    }
+
+    for (std::size_t i = 0; i < results.size(); ++i)
+    {
+        if (!settled(results[i], chunk_exec_timeout_s_))
+        {
+            why = sent_to[i] + " did not finish the trajectory in time";
+            return false;
+        }
+        const GoalHandleFJT::WrappedResult result = results[i].get();
+        if (result.code != rclcpp_action::ResultCode::SUCCEEDED)
+        {
+            why = sent_to[i] + " failed the trajectory: " + result.result->error_string;
+            return false;
+        }
+    }
+    return true;
+}
+
+void G1VlaServer::cancelAll()
+{
+    for (const ControllerTarget& controller : controllers_)
+    {
+        if (controller.client->action_server_is_ready())
+        {
+            controller.client->async_cancel_all_goals();
+        }
+    }
+}
+
+G1VlaServer::Outcome G1VlaServer::runGrasp(
+    const std::shared_ptr<GoalHandle>& goal_handle, const std::string& side, double start_z)
+{
+    const std::shared_ptr<const Grasp::Goal> goal = goal_handle->get_goal();
+    Outcome                                  outcome;
+    auto                                     feedback = std::make_shared<Grasp::Feedback>();
+    feedback->phase                                   = Grasp::Feedback::PHASE_ACTING;
+
+    const rclcpp::Time deadline            = now() + rclcpp::Duration::from_seconds(timeout_s_);
+    int                consecutive_rejects = 0;
+
+    while (rclcpp::ok())
+    {
+        if (goal_handle->is_canceling())
+        {
+            cancelAll();
+            outcome.message = "cancelled";
+            return outcome;
+        }
+        if (now() > deadline)
+        {
+            outcome.message = "timed out after " + std::to_string(timeout_s_) + " s";
+            return outcome;
+        }
+
+        std::string                          why;
+        const std::optional<JointTrajectory> chunk = requestChunk(goal->instruction, why);
+        if (!chunk.has_value())
+        {
+            outcome.message = why;
+            return outcome;
+        }
+
+        const std::string rejected = rejectionReason(*chunk, side);
+        if (!rejected.empty())
+        {
+            ++outcome.rejected;
+            ++consecutive_rejects;
+            RCLCPP_WARN(
+                get_logger(),
+                "rejected a chunk (%d of %d before aborting): %s",
+                consecutive_rejects,
+                max_rejected_chunks_,
+                rejected.c_str());
+            if (consecutive_rejects >= max_rejected_chunks_)
+            {
+                // Named "blocked" so the tree can tell a refused skill from a broken one.
+                outcome.message = "blocked: " + rejected;
+                return outcome;
+            }
+            feedback->chunks_rejected = outcome.rejected;
+            goal_handle->publish_feedback(feedback);
+            continue;
+        }
+        consecutive_rejects = 0;
+
+        if (!executeChunk(*chunk, why))
+        {
+            cancelAll();
+            outcome.message = why;
+            return outcome;
+        }
+        ++outcome.executed;
+        feedback->chunks_executed = outcome.executed;
+        goal_handle->publish_feedback(feedback);
+
+        const std::optional<double> height = objectHeight(goal->object_id);
+        if (height.has_value() && (*height - start_z) >= success_lift_m_)
+        {
+            outcome.success = true;
+            outcome.message =
+                "lifted " + goal->object_id + " by " + std::to_string(*height - start_z) + " m";
+            return outcome;
+        }
+    }
+
+    outcome.message = "shutting down";
+    return outcome;
+}
+
+void G1VlaServer::executeGrasp(const std::shared_ptr<GoalHandle>& goal_handle)
+{
+    const std::shared_ptr<const Grasp::Goal> goal   = goal_handle->get_goal();
+    auto                                     result = std::make_shared<Grasp::Result>();
+
+    auto feedback   = std::make_shared<Grasp::Feedback>();
+    feedback->phase = Grasp::Feedback::PHASE_PREPARING;
+    goal_handle->publish_feedback(feedback);
+
+    if (goal->arm != Grasp::Goal::ARM_LEFT && goal->arm != Grasp::Goal::ARM_RIGHT)
+    {
+        result->message =
+            "arm must be '" + Grasp::Goal::ARM_LEFT + "' or '" + Grasp::Goal::ARM_RIGHT + "'";
+        goal_handle->abort(result);
+        return;
+    }
+
+    const std::optional<double> start_z = objectHeight(goal->object_id);
+    if (!start_z.has_value())
+    {
+        result->message = "no recent pose for '" + goal->object_id +
+                          "' on /objects, so nothing could measure the lift";
+        goal_handle->abort(result);
+        return;
+    }
+
+    if (!setHandContact(goal->arm, true))
+    {
+        result->message = "could not exempt the hand from collision checking";
+        goal_handle->abort(result);
+        return;
+    }
+
+    const Outcome outcome = runGrasp(goal_handle, goal->arm, *start_z);
+
+    if (!setHandContact(goal->arm, false))
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "the hand exemption was not restored; the scene is blinded to the "
+            "octomap until move_group restarts");
+    }
+
+    result->success = outcome.success;
+    // Counters on every path, not just the happy one: how much of a policy's output survived the
+    // gate is the measurement this skill exists to produce.
+    result->message = outcome.message + " [" + std::to_string(outcome.executed) + " executed, " +
+                      std::to_string(outcome.rejected) + " rejected]";
+    if (outcome.success)
+    {
+        RCLCPP_INFO(get_logger(), "%s", outcome.message.c_str());
+        goal_handle->succeed(result);
+    }
+    else if (goal_handle->is_canceling())
+    {
+        goal_handle->canceled(result);
+    }
+    else
+    {
+        RCLCPP_ERROR(
+            get_logger(),
+            "grasp failed after %u chunk(s), %u rejected: %s",
+            outcome.executed,
+            outcome.rejected,
+            outcome.message.c_str());
+        goal_handle->abort(result);
+    }
+}
+
+}  // namespace g1_vla

--- a/workspace/src/g1_vla/src/mock_engine_main.cpp
+++ b/workspace/src/g1_vla/src/mock_engine_main.cpp
@@ -1,0 +1,16 @@
+/**
+ * @file mock_engine_main.cpp
+ * @brief Entry point for the stand-in policy engine.
+ */
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+#include "g1_vla/mock_engine_node.hpp"
+
+int main(int argc, char** argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<g1_vla::G1VlaMockEngine>(rclcpp::NodeOptions()));
+    rclcpp::shutdown();
+    return 0;
+}

--- a/workspace/src/g1_vla/src/mock_engine_node.cpp
+++ b/workspace/src/g1_vla/src/mock_engine_node.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file mock_engine_node.cpp
+ * @brief The stand-in policy engine: a bounded walk toward a fixed target.
+ */
+
+#include "g1_vla/mock_engine_node.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <trajectory_msgs/msg/joint_trajectory_point.hpp>
+
+namespace g1_vla
+{
+
+G1VlaMockEngine::G1VlaMockEngine(const rclcpp::NodeOptions& options)
+  : rclcpp::Node("g1_vla_mock_engine", options)
+{
+    joint_names_ =
+        declare_parameter<std::vector<std::string>>("joint_names", std::vector<std::string>{});
+    target_positions_ =
+        declare_parameter<std::vector<double>>("target_positions", std::vector<double>{});
+    steps_per_chunk_ = static_cast<int>(declare_parameter<int64_t>("steps_per_chunk", 8));
+    action_dt_s_     = declare_parameter<double>("action_dt_s", 0.1);
+    // Small enough that consecutive waypoints stay inside the gate's segment-step budget, which
+    // is what makes per-waypoint collision checking meaningful.
+    step_rad_ = declare_parameter<double>("step_rad", 0.05);
+
+    if (joint_names_.size() != target_positions_.size())
+    {
+        throw std::runtime_error("joint_names and target_positions must be the same length");
+    }
+
+    joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+        "/joint_states",
+        rclcpp::QoS(rclcpp::KeepLast(1)),
+        [this](const sensor_msgs::msg::JointState::ConstSharedPtr& msg) { onJointStates(msg); });
+
+    chunk_service_ = create_service<GetActionChunk>(
+        "~/get_action_chunk",
+        [this](
+            const GetActionChunk::Request::SharedPtr&  request,
+            const GetActionChunk::Response::SharedPtr& response) {
+            onGetActionChunk(request, response);
+        });
+
+    RCLCPP_INFO(get_logger(), "mock engine serving %zu joint(s)", joint_names_.size());
+}
+
+void G1VlaMockEngine::onJointStates(const sensor_msgs::msg::JointState::ConstSharedPtr& msg)
+{
+    const std::lock_guard<std::mutex> lock(joints_mutex_);
+    for (std::size_t i = 0; i < msg->name.size() && i < msg->position.size(); ++i)
+    {
+        measured_[msg->name[i]] = msg->position[i];
+    }
+}
+
+void G1VlaMockEngine::onGetActionChunk(
+    const GetActionChunk::Request::SharedPtr&  request,
+    const GetActionChunk::Response::SharedPtr& response)
+{
+    std::vector<double> current;
+    current.reserve(joint_names_.size());
+    {
+        const std::lock_guard<std::mutex> lock(joints_mutex_);
+        for (const std::string& name : joint_names_)
+        {
+            const auto it = measured_.find(name);
+            if (it == measured_.end())
+            {
+                response->ok      = false;
+                response->message = "no joint state yet for " + name;
+                return;
+            }
+            current.push_back(it->second);
+        }
+    }
+
+    response->chunk.joint_names = joint_names_;
+    for (int step = 1; step <= steps_per_chunk_; ++step)
+    {
+        trajectory_msgs::msg::JointTrajectoryPoint point;
+        for (std::size_t i = 0; i < joint_names_.size(); ++i)
+        {
+            const double remaining = target_positions_[i] - current[i];
+            current[i] += std::clamp(remaining, -step_rad_, step_rad_);
+            point.positions.push_back(current[i]);
+        }
+        const double t                = action_dt_s_ * step;
+        point.time_from_start.sec     = static_cast<int32_t>(t);
+        point.time_from_start.nanosec = static_cast<uint32_t>(std::lround(std::fmod(t, 1.0) * 1e9));
+        response->chunk.points.push_back(point);
+    }
+
+    response->ok = true;
+    RCLCPP_DEBUG(get_logger(), "chunk for '%s'", request->instruction.c_str());
+}
+
+}  // namespace g1_vla

--- a/workspace/src/g1_vla/test/test_chunk_utils.cpp
+++ b/workspace/src/g1_vla/test/test_chunk_utils.cpp
@@ -1,0 +1,188 @@
+/**
+ * @file test_chunk_utils.cpp
+ * @brief The checks a chunk has to survive before any of it is executed.
+ *
+ * These are the gate's whole reject-before-moving story, so what matters is that each one
+ * actually fires: a check that silently passes everything reads exactly like a safe robot.
+ */
+
+#include <gmock/gmock.h>
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "g1_vla/chunk_utils.hpp"
+
+using g1_vla::JointMap;
+using g1_vla::maxSegmentStep;
+using g1_vla::maxVelocityRatio;
+using g1_vla::splitByController;
+using g1_vla::startJump;
+using g1_vla::wellFormed;
+using trajectory_msgs::msg::JointTrajectory;
+using trajectory_msgs::msg::JointTrajectoryPoint;
+
+namespace
+{
+
+const std::vector<std::string> kArm  = { "right_elbow_joint", "right_shoulder_pitch_joint" };
+const std::vector<std::string> kHand = { "right_hand_index_0_joint" };
+
+/// A chunk over @p names whose rows are the successive waypoints, each one dt further along.
+JointTrajectory chunkOf(
+    const std::vector<std::string>& names, const std::vector<std::vector<double>>& rows, double dt)
+{
+    JointTrajectory chunk;
+    chunk.joint_names = names;
+    double t          = dt;
+    for (const std::vector<double>& row : rows)
+    {
+        JointTrajectoryPoint point;
+        point.positions           = row;
+        point.time_from_start.sec = static_cast<int32_t>(t);
+        point.time_from_start.nanosec =
+            static_cast<uint32_t>(std::lround((t - std::floor(t)) * 1e9));
+        chunk.points.push_back(point);
+        t += dt;
+    }
+    return chunk;
+}
+
+}  // namespace
+
+TEST(WellFormed, AcceptsAPlainChunk)
+{
+    EXPECT_TRUE(wellFormed(chunkOf(kArm, { { 0.0, 0.0 }, { 0.1, 0.1 } }, 0.1)));
+}
+
+TEST(WellFormed, RejectsAnEmptyChunk)
+{
+    EXPECT_FALSE(wellFormed(JointTrajectory{}));
+    EXPECT_FALSE(wellFormed(chunkOf(kArm, {}, 0.1)));
+}
+
+TEST(WellFormed, RejectsARowNarrowerThanTheNames)
+{
+    JointTrajectory chunk = chunkOf(kArm, { { 0.0, 0.0 } }, 0.1);
+    chunk.points[0].positions.pop_back();
+    EXPECT_FALSE(wellFormed(chunk));
+}
+
+TEST(WellFormed, RejectsTimesThatDoNotAdvance)
+{
+    JointTrajectory chunk           = chunkOf(kArm, { { 0.0, 0.0 }, { 0.1, 0.1 } }, 0.1);
+    chunk.points[1].time_from_start = chunk.points[0].time_from_start;
+    EXPECT_FALSE(wellFormed(chunk));
+
+    // A first waypoint at t=0 is one the controller has no time to reach.
+    JointTrajectory immediate           = chunkOf(kArm, { { 0.0, 0.0 } }, 0.1);
+    immediate.points[0].time_from_start = builtin_interfaces::msg::Duration{};
+    EXPECT_FALSE(wellFormed(immediate));
+}
+
+TEST(Split, KeepsOnlyTheControllersOwnJoints)
+{
+    JointTrajectory chunk = chunkOf(
+        { "right_elbow_joint", "right_hand_index_0_joint", "right_shoulder_pitch_joint" },
+        { { 1.0, 2.0, 3.0 }, { 4.0, 5.0, 6.0 } },
+        0.1);
+
+    const JointTrajectory arm = splitByController(chunk, kArm);
+
+    EXPECT_THAT(
+        arm.joint_names,
+        testing::ElementsAre("right_elbow_joint", "right_shoulder_pitch_joint"));
+    EXPECT_THAT(arm.points[0].positions, testing::ElementsAre(1.0, 3.0));
+    EXPECT_THAT(arm.points[1].positions, testing::ElementsAre(4.0, 6.0));
+    EXPECT_EQ(arm.points.size(), 2U);
+}
+
+TEST(Split, CarriesTheWaypointTimesThrough)
+{
+    JointTrajectory chunk = chunkOf(kArm, { { 0.0, 0.0 }, { 0.1, 0.1 } }, 0.25);
+
+    const JointTrajectory arm = splitByController(chunk, kArm);
+
+    EXPECT_EQ(arm.points[1].time_from_start, chunk.points[1].time_from_start);
+}
+
+TEST(Split, ReturnsNothingForAControllerTheChunkDoesNotName)
+{
+    const JointTrajectory hand = splitByController(chunkOf(kArm, { { 0.0, 0.0 } }, 0.1), kHand);
+
+    EXPECT_TRUE(hand.joint_names.empty());
+    EXPECT_TRUE(hand.points.empty());
+}
+
+TEST(StartJump, MeasuresTheGapToTheFirstWaypoint)
+{
+    const JointMap measured = { { "right_elbow_joint", 0.5 },
+                                { "right_shoulder_pitch_joint", -0.2 } };
+
+    const auto jump = startJump(chunkOf(kArm, { { 0.55, 0.1 } }, 0.1), measured);
+
+    ASSERT_TRUE(jump.has_value());
+    EXPECT_NEAR(*jump, 0.3, 1e-9);
+}
+
+TEST(StartJump, FailsWhenAJointWasNotMeasured)
+{
+    const JointMap measured = { { "right_elbow_joint", 0.5 } };
+
+    EXPECT_FALSE(startJump(chunkOf(kArm, { { 0.5, 0.0 } }, 0.1), measured).has_value());
+}
+
+TEST(SegmentStep, FindsTheWidestGapBetweenWaypoints)
+{
+    const JointTrajectory chunk = chunkOf(kArm, { { 0.0, 0.0 }, { 0.1, 0.0 }, { 0.1, 0.7 } }, 0.1);
+
+    EXPECT_NEAR(maxSegmentStep(chunk), 0.7, 1e-9);
+}
+
+TEST(SegmentStep, IsZeroForASingleWaypoint)
+{
+    EXPECT_EQ(maxSegmentStep(chunkOf(kArm, { { 3.0, 3.0 } }, 0.1)), 0.0);
+}
+
+TEST(VelocityRatio, CountsTheMoveOffTheMeasuredPose)
+{
+    const JointMap measured = { { "right_elbow_joint", 0.0 },
+                                { "right_shoulder_pitch_joint", 0.0 } };
+    const JointMap limits = { { "right_elbow_joint", 1.0 }, { "right_shoulder_pitch_joint", 1.0 } };
+
+    // 0.2 rad in the first 0.1 s is 2 rad/s against a limit of 1.
+    const auto ratio = maxVelocityRatio(chunkOf(kArm, { { 0.2, 0.0 } }, 0.1), measured, limits);
+
+    ASSERT_TRUE(ratio.has_value());
+    EXPECT_NEAR(*ratio, 2.0, 1e-9);
+}
+
+TEST(VelocityRatio, UsesEachSegmentsOwnDuration)
+{
+    const JointMap measured = { { "right_elbow_joint", 0.0 },
+                                { "right_shoulder_pitch_joint", 0.0 } };
+    const JointMap limits = { { "right_elbow_joint", 2.0 }, { "right_shoulder_pitch_joint", 2.0 } };
+
+    const auto ratio =
+        maxVelocityRatio(chunkOf(kArm, { { 0.1, 0.0 }, { 0.5, 0.0 } }, 0.1), measured, limits);
+
+    ASSERT_TRUE(ratio.has_value());
+    // The second segment moves 0.4 rad in 0.1 s: 4 rad/s, twice the limit.
+    EXPECT_NEAR(*ratio, 2.0, 1e-9);
+}
+
+TEST(VelocityRatio, FailsWhenAJointHasNoUsableLimit)
+{
+    const JointMap        measured = { { "right_elbow_joint", 0.0 },
+                                       { "right_shoulder_pitch_joint", 0.0 } };
+    const JointTrajectory chunk    = chunkOf(kArm, { { 0.0, 0.0 } }, 0.1);
+
+    EXPECT_FALSE(maxVelocityRatio(chunk, measured, { { "right_elbow_joint", 1.0 } }).has_value());
+    EXPECT_FALSE(maxVelocityRatio(
+                     chunk,
+                     measured,
+                     { { "right_elbow_joint", 1.0 }, { "right_shoulder_pitch_joint", 0.0 } })
+                     .has_value());
+}


### PR DESCRIPTION
The gate itself. A policy engine returns a chunk of absolute joint targets; nothing reaches a controller until that chunk has passed every check.

- `chunk_utils`: shape, start-jump against the measured pose, per-segment step, and segment speed against the joint velocity limits. Pure functions, 14 gmock cases.
- `g1_vla_server`: serves `Grasp`. Exempts the grasping hand from collision checking for the goal, then loops query → validate → execute. A rejected chunk is not executed at all, so the robot has not moved and it asks again; `max_rejected_chunks` in a row aborts with `blocked:`. Success is the object measurably rising on `/objects`, not the policy saying so.
- `g1_vla_mock_engine`: walks named joints toward a fixed target. Aim it at free space and every chunk executes; aim it into the bench and every chunk should be rejected unmoved.

Two things worth a look:

The velocity check reads `robot_description_planning.joint_limits`, not the robot model. The URDF limits are the motor spec (22-37 rad/s); what the arm tracks is 0.8. Checking against the URDF would pass anything while looking like a working gate. The server logs the resolved arm limit at startup so this is visible.

`max_segment_step_rad` is new, not in the original plan. Per-waypoint validity says nothing about the space swept between two waypoints, so without a step bound the sampling is decorative.

Validity is checked against the driven arm group rather than the whole robot: at the workbench pose a hanging hand sits inside the bench octomap, which is the same condition that keeps `test_pick_place` unregistered.

Verified: full gate green (14 packages, `-LE simulator`); both intermediate commits build on their own; launch brings both nodes up, the action and the engine service appear, and the engine correctly refuses when no joint states exist.