### PR TITLE
Add the policy adapter that talks to a model served over ZMQ

### DIFF
--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -65,6 +65,7 @@ install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
 install(TARGETS g1_vla_chunk_utils g1_vla_server_node g1_vla_mock_engine_node
   EXPORT export_${PROJECT_NAME} DESTINATION lib)
 install(TARGETS g1_vla_server g1_vla_mock_engine DESTINATION lib/${PROJECT_NAME})
+install(PROGRAMS scripts/g1_vla_groot_adapter DESTINATION lib/${PROJECT_NAME})
 
 # --- tests -----------------------------------------------------------------
 
@@ -73,8 +74,14 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gmock REQUIRED)
 
+  find_package(launch_testing_ament_cmake REQUIRED)
+
   ament_add_gmock(test_chunk_utils test/test_chunk_utils.cpp)
   target_link_libraries(test_chunk_utils g1_vla_chunk_utils)
+
+  # Not a simulator test: it runs the adapter against a stub policy server, so it needs neither
+  # MuJoCo nor a GPU and CI can run it.
+  add_launch_test(test/test_groot_adapter.launch.py TARGET test_groot_adapter TIMEOUT 180)
 
   g1_add_lint_tests()
 endif()

--- a/workspace/src/g1_vla/README.md
+++ b/workspace/src/g1_vla/README.md
@@ -23,6 +23,13 @@ colcon build --symlink-install --packages-select g1_vla
 |---|---|
 | `g1_vla_server` | Serves `Grasp`. Queries the engine, validates, executes, and measures the lift. |
 | `g1_vla_mock_engine` | A stand-in engine that walks named joints toward a fixed target. No model needed. |
+| `g1_vla_groot_adapter` | An engine backed by a vision-language-action model served over ZMQ. |
+
+`g1_vla_groot_adapter` is the one Python node here. It is a request-response translator on a
+slow path with no timing or safety role, and its whole job is marshalling dictionaries and arrays
+against a schema discovered at runtime. It speaks the policy server's wire protocol directly
+rather than importing that server's package, which keeps this container free of the model's
+dependency tree. Everything with a timing or safety role is C++.
 
 ## Interfaces
 
@@ -80,8 +87,19 @@ composes. Standalone, against the mock engine:
 ros2 launch g1_vla vla.launch.py engine:=mock
 ```
 
+Against a real policy, with the model server already running outside the container:
+
+```bash
+ros2 launch g1_vla vla.launch.py engine:=groot
+```
+
+The model's modality keys belong to its checkpoint, so `config/g1_vla_groot_adapter.yaml` maps
+them to joint names rather than assuming them. Start the adapter once against the server: it logs
+every key the server reports and refuses to serve until each one is mapped.
+
 ## Tests
 
 | Test | Covers |
 |---|---|
 | `test_chunk_utils` | Chunk shape, the start-jump, segment-step and velocity checks, and the controller split |
+| `test_groot_adapter` | The adapter against a stub policy server: wire protocol, key mapping, and action integration. No simulator or GPU. |

--- a/workspace/src/g1_vla/config/g1_vla_groot_adapter.yaml
+++ b/workspace/src/g1_vla/config/g1_vla_groot_adapter.yaml
@@ -1,0 +1,27 @@
+g1_vla_groot_adapter:
+  ros__parameters:
+    # The server runs on the host, outside this container. Compose is host-networked.
+    server_address: tcp://127.0.0.1:5555
+    zmq_timeout_ms: 8000
+
+    # Spacing between the chunk's waypoints, and how many of them to keep. The gate's
+    # max_segment_step_rad and velocity_scaling are both judged against this spacing.
+    action_dt_s: 0.05
+    max_horizon: 16
+
+    # "relative_to_observation" adds each action to the joint position it was computed from;
+    # "absolute" passes the server's numbers through untouched.
+    action_mode: relative_to_observation
+    instruction_key: annotation.human.action.task_description
+
+    # The model's modality keys are its own and change with the checkpoint, so they are mapped
+    # here rather than guessed. Start the adapter once against the server: it logs every key the
+    # server reports and refuses to serve until each one appears below. The joint order in each
+    # list must match the order of that key's vector. Shape, with the names the server reported:
+    #
+    # state_joints:
+    #   state.right_arm: [right_shoulder_pitch_joint, right_shoulder_roll_joint, ...]
+    # action_joints:
+    #   action.right_arm: [right_shoulder_pitch_joint, right_shoulder_roll_joint, ...]
+    # video_topics:
+    #   video.ego_view: /camera/color/image_raw

--- a/workspace/src/g1_vla/launch/vla.launch.py
+++ b/workspace/src/g1_vla/launch/vla.launch.py
@@ -68,17 +68,31 @@ def _mock_engine():
     )
 
 
+def _groot_engine():
+    return Node(
+        package="g1_vla",
+        executable="g1_vla_groot_adapter",
+        name="g1_vla_groot_adapter",
+        output="screen",
+        condition=IfCondition(EqualsSubstitution(LaunchConfiguration("engine"), "groot")),
+        parameters=[_config(SHARE, "g1_vla_groot_adapter.yaml")],
+        remappings=[("~/get_action_chunk", ENGINE_SERVICE)],
+    )
+
+
 def generate_launch_description():
     return LaunchDescription(
         [
             DeclareLaunchArgument(
                 "engine",
                 default_value="mock",
-                choices=["mock"],
+                choices=["mock", "groot"],
                 description="Which policy engine answers the server. 'mock' walks the arm "
-                "toward a fixed target and needs no model.",
+                "toward a fixed target and needs no model; 'groot' talks to a policy server "
+                "running outside the container.",
             ),
             _server(),
             _mock_engine(),
+            _groot_engine(),
         ]
     )

--- a/workspace/src/g1_vla/package.xml
+++ b/workspace/src/g1_vla/package.xml
@@ -30,9 +30,17 @@
   <exec_depend>g1_moveit_config</exec_depend>
   <exec_depend>moveit_configs_utils</exec_depend>
 
+  <!-- The policy adapter's own; it speaks the server's protocol rather than importing it. -->
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-zmq</exec_depend>
+  <exec_depend>python3-msgpack</exec_depend>
+
   <!-- ament_lint_common intentionally not used to avoid clang-format conflicts. -->
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
 

--- a/workspace/src/g1_vla/scripts/g1_vla_groot_adapter
+++ b/workspace/src/g1_vla/scripts/g1_vla_groot_adapter
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Policy engine backed by a vision-language-action model served over ZMQ.
+
+Serves the same GetActionChunk the mock engine does, so the gate cannot tell them apart. What is
+specific here is the wire protocol and the mapping between the model's modality keys and this
+robot's joint names, which is read from the server at startup and checked against config rather
+than assumed.
+
+Speaks the protocol directly instead of importing the model's own package, which keeps the ROS
+container free of its dependency tree.
+"""
+
+import io
+import json
+
+import msgpack
+import msgpack_numpy as mnp
+import numpy as np
+import rclpy
+import zmq
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import Image, JointState
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+from g1_msgs.srv import GetActionChunk
+
+# Endpoints that carry no request body. Sending one a "data" field is an error server-side.
+_NO_INPUT = ("ping", "kill", "get_modality_config")
+
+
+def _decode_hook(obj):
+    """Undo the server's array and config encodings.
+
+    Two array forms are in circulation: a raw .npy payload and msgpack_numpy's. Both are
+    accepted because both are shipped by the reference servers.
+    """
+    if isinstance(obj, dict):
+        if obj.get("__ndarray_class__") or obj.get(b"__ndarray_class__"):
+            payload = obj.get("as_npy", obj.get(b"as_npy"))
+            if payload is None:
+                raise ValueError("array payload marked but empty")
+            return np.load(io.BytesIO(payload), allow_pickle=False)
+        for marker in ("__ModalityConfig__", "__ModalityConfig_class__"):
+            if marker in obj or marker.encode() in obj:
+                as_json = obj.get("as_json", obj.get(b"as_json"))
+                if isinstance(as_json, bytes):
+                    as_json = as_json.decode()
+                return json.loads(as_json) if isinstance(as_json, str) else as_json
+    return mnp.decode(obj)
+
+
+class PolicyClient:
+    """A REQ socket to the policy server.
+
+    REQ sockets alternate send and recv strictly, so a timed-out request leaves the socket
+    unusable and it is rebuilt rather than reused.
+    """
+
+    def __init__(self, address, timeout_ms):
+        self._context = zmq.Context()
+        self._address = address
+        self._timeout_ms = timeout_ms
+        self._socket = None
+        self._connect()
+
+    def _connect(self):
+        if self._socket is not None:
+            self._socket.close(linger=0)
+        self._socket = self._context.socket(zmq.REQ)
+        self._socket.setsockopt(zmq.RCVTIMEO, self._timeout_ms)
+        self._socket.setsockopt(zmq.SNDTIMEO, self._timeout_ms)
+        self._socket.connect(self._address)
+
+    def call(self, endpoint, data=None):
+        request = {"endpoint": endpoint}
+        if endpoint not in _NO_INPUT:
+            request["data"] = data if data is not None else {}
+        try:
+            self._socket.send(msgpack.packb(request, default=mnp.encode))
+            reply = msgpack.unpackb(self._socket.recv(), object_hook=_decode_hook, raw=False)
+        except zmq.ZMQError as error:
+            self._connect()
+            raise RuntimeError(f"{endpoint} did not complete: {error}") from error
+        if isinstance(reply, dict) and "error" in reply:
+            raise RuntimeError(f"the policy server refused {endpoint}: {reply['error']}")
+        return reply
+
+    def close(self):
+        self._socket.close(linger=0)
+        self._context.term()
+
+
+def _image_to_array(msg):
+    """An rgb8 Image as (H, W, 3) uint8, without pulling in cv_bridge for one reshape."""
+    if msg.encoding != "rgb8":
+        raise ValueError(f"expected rgb8, the camera published {msg.encoding}")
+    flat = np.frombuffer(msg.data, dtype=np.uint8)
+    # step can exceed width*3 when rows are padded, so index by row rather than reshaping whole.
+    return flat.reshape(msg.height, msg.step)[:, : msg.width * 3].reshape(msg.height, msg.width, 3)
+
+
+def _mapping_param(node, prefix):
+    """A {modality key: value} map read from a nested parameter block."""
+    return {
+        name: parameter.value
+        for name, parameter in node.get_parameters_by_prefix(prefix).items()
+    }
+
+
+class GrootAdapter(Node):
+    def __init__(self):
+        super().__init__(
+            "g1_vla_groot_adapter", automatically_declare_parameters_from_overrides=True
+        )
+
+        self._address = self._param("server_address", "tcp://127.0.0.1:5555")
+        self._action_dt_s = float(self._param("action_dt_s", 0.05))
+        self._max_horizon = int(self._param("max_horizon", 16))
+        # Relative actions are read as offsets from the observation, not from each other. Read
+        # the wrong way round that would compound into an overshoot; this way it under-reaches,
+        # and the gate's start-jump check catches the difference on a stationary robot.
+        self._action_mode = self._param("action_mode", "relative_to_observation")
+        self._instruction_key = self._param(
+            "instruction_key", "annotation.human.action.task_description"
+        )
+
+        self._state_joints = _mapping_param(self, "state_joints")
+        self._action_joints = _mapping_param(self, "action_joints")
+        self._video_topics = _mapping_param(self, "video_topics")
+
+        self._measured = {}
+        self._images = {}
+        self._instruction = None
+
+        self.create_subscription(JointState, "/joint_states", self._on_joint_states, 1)
+        for key, topic in self._video_topics.items():
+            # Sensor QoS deliberately: the relay publishes best-effort, and a reliable
+            # subscriber silently never matches it.
+            self.create_subscription(
+                Image,
+                topic,
+                lambda msg, key=key: self._images.__setitem__(key, msg),
+                qos_profile_sensor_data,
+            )
+
+        self._client = PolicyClient(self._address, int(self._param("zmq_timeout_ms", 8000)))
+        self._ready = self._handshake()
+
+        self.create_service(GetActionChunk, "~/get_action_chunk", self._on_get_action_chunk)
+
+    def _param(self, name, default):
+        return self.get_parameter_or(name, rclpy.parameter.Parameter(name, value=default)).value
+
+    def _on_joint_states(self, msg):
+        # strict=False: a JointState may name joints it has no position for.
+        for name, position in zip(msg.name, msg.position, strict=False):
+            self._measured[name] = position
+
+    def _handshake(self):
+        """Reads the server's modality keys and checks config accounts for every one.
+
+        The keys are the model's, not ours, and they change with the checkpoint. Refusing here
+        with the actual key list is what makes a mismatch a five-minute fix instead of a silently
+        transposed joint vector.
+        """
+        try:
+            self._client.call("ping")
+            config = self._client.call("get_modality_config")
+        except RuntimeError as error:
+            self.get_logger().error(f"{error}. Is the policy server up at {self._address}?")
+            return False
+
+        served = {}
+        for modality, entry in config.items():
+            keys = entry.get("modality_keys", []) if isinstance(entry, dict) else []
+            served[modality] = keys
+            self.get_logger().info(f"server modality '{modality}': {keys}")
+
+        mapped = set(self._state_joints) | set(self._action_joints) | set(self._video_topics)
+        mapped.add(self._instruction_key)
+        missing = [
+            key
+            for modality, keys in served.items()
+            if modality in ("state", "action", "video")
+            for key in keys
+            if key not in mapped
+        ]
+        if missing:
+            self.get_logger().error(
+                f"no mapping configured for {missing}; fill state_joints, action_joints or "
+                "video_topics in the adapter's config and restart"
+            )
+            return False
+        if not self._action_joints:
+            self.get_logger().error("action_joints is empty, so no chunk could name a joint")
+            return False
+        return True
+
+    def _observation(self, instruction):
+        """The request body, in the shapes the server expects: a leading batch axis of one."""
+        obs = {}
+        for key, joints in self._state_joints.items():
+            missing = [joint for joint in joints if joint not in self._measured]
+            if missing:
+                raise RuntimeError(f"no joint state yet for {missing[0]}")
+            obs[key] = np.array(
+                [[self._measured[joint] for joint in joints]], dtype=np.float64
+            )
+        for key in self._video_topics:
+            msg = self._images.get(key)
+            if msg is None:
+                raise RuntimeError(f"no image yet on the topic for '{key}'")
+            age = (self.get_clock().now() - rclpy.time.Time.from_msg(msg.header.stamp)).nanoseconds
+            if age > 1_000_000_000:
+                raise RuntimeError(f"the image for '{key}' is {age / 1e9:.1f} s old")
+            obs[key] = _image_to_array(msg)[np.newaxis, ...]
+        obs[self._instruction_key] = [instruction]
+        return obs
+
+    def _chunk(self, action):
+        """Turns the server's per-key action arrays into one trajectory of absolute positions."""
+        chunk = JointTrajectory()
+        columns = []
+        for key, joints in self._action_joints.items():
+            if key not in action:
+                raise RuntimeError(f"the server returned no '{key}'")
+            values = np.atleast_2d(np.asarray(action[key], dtype=np.float64))
+            if values.shape[1] != len(joints):
+                raise RuntimeError(
+                    f"'{key}' is {values.shape[1]} wide but {len(joints)} joints are mapped to it"
+                )
+            for index, joint in enumerate(joints):
+                offset = self._measured[joint] if self._action_mode != "absolute" else 0.0
+                columns.append((joint, values[:, index] + offset))
+
+        horizon = min(min(len(column) for _, column in columns), self._max_horizon)
+        chunk.joint_names = [joint for joint, _ in columns]
+        for step in range(horizon):
+            point = JointTrajectoryPoint()
+            point.positions = [float(column[step]) for _, column in columns]
+            elapsed = self._action_dt_s * (step + 1)
+            point.time_from_start.sec = int(elapsed)
+            point.time_from_start.nanosec = int((elapsed % 1.0) * 1e9)
+            chunk.points.append(point)
+        return chunk
+
+    def _on_get_action_chunk(self, request, response):
+        if not self._ready:
+            response.ok = False
+            response.message = "the adapter did not complete its handshake; see its startup log"
+            return response
+
+        try:
+            if request.instruction != self._instruction:
+                # A new instruction is a new episode, which is what clears the model's history.
+                self._client.call("reset", {})
+                self._instruction = request.instruction
+                self.get_logger().info(f"new episode: '{request.instruction}'")
+
+            observation = self._observation(request.instruction)
+            response.chunk = self._chunk(self._client.call("get_action", observation))
+            response.ok = True
+        except (RuntimeError, ValueError) as error:
+            response.ok = False
+            response.message = str(error)
+        return response
+
+
+def main():
+    rclpy.init()
+    node = GrootAdapter()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node._client.close()
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/workspace/src/g1_vla/test/policy_server_stub.py
+++ b/workspace/src/g1_vla/test/policy_server_stub.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""A policy server that answers the real wire protocol with fixed numbers.
+
+Stands in for the model so the adapter's protocol, key mapping and action integration can be
+tested without a GPU. It encodes the way the reference servers do, including the ModalityConfig
+marker, so the adapter's decode path is exercised rather than bypassed.
+
+Usage: policy_server_stub.py <port> <horizon> <delta>
+"""
+
+import json
+import sys
+
+import msgpack
+import msgpack_numpy as mnp
+import numpy as np
+
+STATE_KEY = "state.test_arm"
+ACTION_KEY = "action.test_arm"
+VIDEO_KEY = "video.test_cam"
+ANNOTATION_KEY = "annotation.human.action.task_description"
+
+
+def _modality_config():
+    """Each entry wrapped the way the server wraps a ModalityConfig."""
+
+    def wrap(keys):
+        return {
+            "__ModalityConfig__": True,
+            "as_json": json.dumps({"delta_indices": [0], "modality_keys": keys}),
+        }
+
+    return {
+        "state": wrap([STATE_KEY]),
+        "action": wrap([ACTION_KEY]),
+        "video": wrap([VIDEO_KEY]),
+        "annotation": wrap([ANNOTATION_KEY]),
+    }
+
+
+def main():
+    import zmq
+
+    port, horizon, delta = int(sys.argv[1]), int(sys.argv[2]), float(sys.argv[3])
+    socket = zmq.Context().socket(zmq.REP)
+    socket.bind(f"tcp://127.0.0.1:{port}")
+    print(f"stub policy server on {port}", flush=True)
+
+    while True:
+        request = msgpack.unpackb(socket.recv(), object_hook=mnp.decode, raw=False)
+        endpoint = request.get("endpoint")
+        if endpoint == "ping":
+            reply = {"status": "ok"}
+        elif endpoint == "get_modality_config":
+            reply = _modality_config()
+        elif endpoint == "reset":
+            reply = {"status": "ok"}
+        elif endpoint == "get_action":
+            data = request.get("data", {})
+            width = np.asarray(data[STATE_KEY]).shape[-1]
+            # A constant offset per step, so the adapter's integration is checkable by hand.
+            reply = {ACTION_KEY: np.full((horizon, width), delta, dtype=np.float64)}
+        else:
+            reply = {"error": f"unknown endpoint {endpoint}"}
+        socket.send(msgpack.packb(reply, default=mnp.encode))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        # SIGINT lands inside the blocking recv; a traceback here reads like a test failure.
+        pass

--- a/workspace/src/g1_vla/test/test_groot_adapter.launch.py
+++ b/workspace/src/g1_vla/test/test_groot_adapter.launch.py
@@ -1,0 +1,148 @@
+"""The adapter has to speak the policy server's protocol and integrate its actions correctly.
+
+Both halves fail quietly if they are wrong. A mis-encoded request comes back as a server error
+that reads like a model problem, and an action integrated the wrong way round produces a
+plausible trajectory to the wrong place. So this runs the adapter against a stub server that
+answers the real wire format with numbers chosen so the arithmetic is checkable by hand.
+
+No simulator and no GPU: the stub is the point.
+"""
+
+import os
+import sys
+import unittest
+
+import launch_testing
+import pytest
+import rclpy
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, TimerAction
+from launch_ros.actions import Node
+from rclpy.node import Node as RclpyNode
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import Image, JointState
+
+from g1_msgs.srv import GetActionChunk
+
+PORT = 5599
+HORIZON = 6
+DELTA = 0.02
+
+JOINTS = ["right_shoulder_pitch_joint", "right_elbow_joint"]
+MEASURED = {"right_shoulder_pitch_joint": 0.25, "right_elbow_joint": -0.10}
+CAMERA_TOPIC = "/camera/color/image_raw"
+
+STUB = os.path.join(os.path.dirname(__file__), "policy_server_stub.py")
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    adapter = Node(
+        package="g1_vla",
+        executable="g1_vla_groot_adapter",
+        name="g1_vla_groot_adapter",
+        output="screen",
+        parameters=[
+            {
+                "server_address": f"tcp://127.0.0.1:{PORT}",
+                "zmq_timeout_ms": 5000,
+                "action_dt_s": 0.1,
+                "max_horizon": HORIZON,
+                "action_mode": "relative_to_observation",
+                "state_joints": {"state.test_arm": JOINTS},
+                "action_joints": {"action.test_arm": JOINTS},
+                "video_topics": {"video.test_cam": CAMERA_TOPIC},
+            }
+        ],
+    )
+    return LaunchDescription(
+        [
+            ExecuteProcess(
+                cmd=[sys.executable, STUB, str(PORT), str(HORIZON), str(DELTA)],
+                output="screen",
+            ),
+            # The adapter handshakes in its constructor, so the stub has to be bound first.
+            TimerAction(period=3.0, actions=[adapter]),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    )
+
+
+class TestGrootAdapter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = RclpyNode("groot_adapter_probe")
+        cls.joints = cls.node.create_publisher(JointState, "/joint_states", 1)
+        cls.camera = cls.node.create_publisher(Image, CAMERA_TOPIC, qos_profile_sensor_data)
+        cls.client = cls.node.create_client(
+            GetActionChunk, "/g1_vla_groot_adapter/get_action_chunk"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _publish_observation(self):
+        state = JointState()
+        state.header.stamp = self.node.get_clock().now().to_msg()
+        state.name = list(MEASURED)
+        state.position = [MEASURED[name] for name in state.name]
+        self.joints.publish(state)
+
+        image = Image()
+        image.header.stamp = self.node.get_clock().now().to_msg()
+        image.height, image.width = 4, 4
+        image.encoding = "rgb8"
+        image.step = image.width * 3
+        image.data = bytes(image.height * image.step)
+        self.camera.publish(image)
+
+    def _call(self, instruction):
+        request = GetActionChunk.Request()
+        request.instruction = instruction
+        future = self.client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=30.0)
+        self.assertIsNotNone(future.result(), "the adapter never answered")
+        return future.result()
+
+    def test_01_the_adapter_serves_the_chunk_service(self):
+        self.assertTrue(
+            self.client.wait_for_service(timeout_sec=60.0),
+            "the adapter did not come up; check its handshake against the stub",
+        )
+
+    def test_02_a_chunk_comes_back_shaped_correctly(self):
+        # Republished on every attempt: the adapter keeps only the latest of each.
+        for _ in range(30):
+            self._publish_observation()
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        result = self._call("pick up the red cube")
+
+        self.assertTrue(result.ok, result.message)
+        self.assertEqual(list(result.chunk.joint_names), JOINTS)
+        self.assertEqual(len(result.chunk.points), HORIZON)
+        # Waypoint times advance, which is what the gate's shape check demands.
+        times = [p.time_from_start.sec + p.time_from_start.nanosec / 1e9 for p in result.chunk.points]
+        self.assertEqual(times, sorted(set(times)))
+        self.assertAlmostEqual(times[0], 0.1, places=6)
+
+    def test_03_actions_are_offsets_from_the_observed_pose(self):
+        for _ in range(30):
+            self._publish_observation()
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        result = self._call("pick up the red cube")
+
+        self.assertTrue(result.ok, result.message)
+        # The stub returns the same delta at every step, so every waypoint sits one delta from
+        # the measured pose. Read as per-step deltas instead, they would compound.
+        for point in result.chunk.points:
+            for index, joint in enumerate(JOINTS):
+                self.assertAlmostEqual(point.positions[index], MEASURED[joint] + DELTA, places=6)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    def test_the_adapter_exited_cleanly(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=[0, -2, -15])


### PR DESCRIPTION
The second engine behind the same `GetActionChunk` the mock already serves, so the gate cannot tell them apart.

- `scripts/g1_vla_groot_adapter`: speaks the policy server wire protocol directly rather than importing that server package, which keeps the container free of the model dependency tree. It is the one Python node here, and the README says why.
- `test/test_groot_adapter.launch.py` runs the adapter against a stub server that answers the real wire format. No simulator, no GPU, so CI runs it.

Three things I got from reading the protocol rather than assuming it:

The format is msgpack driven directly with a chained codec: msgpack_numpy for arrays plus a hook that also accepts a raw `.npy` payload under `__ndarray_class__` and decodes `ModalityConfig` from its own marker. Two reference servers disagree on the array form, so the adapter accepts both and emits the msgpack_numpy one. `get_modality_config` takes no request body.

The modality keys belong to the checkpoint, not to us, and cannot be known before serving one. So they are mapped to joint names in config, and the adapter reads the real keys at startup, logs every one, and refuses to serve until config accounts for all of them. A wrong mapping otherwise looks like a plausible trajectory to the wrong place.

Relative actions are integrated as offsets from the observation, not from each other. Read the wrong way round this under-reaches; the opposite reading compounds into an overshoot. `test_03` pins it, and the gate start-jump check separates the two on a stationary robot at bring-up.

The model server runs on the host. Not for GPU reasons, compose already passes the GPU through, but because the container system Python is what runs rosidl and it already needs a `pip uninstall empy` and a `--no-deps` to survive pip shadowing apt. Compose is host-networked so the container reaches `tcp://127.0.0.1:5555` with no setup, and the gate only knows the service, so moving the engine later is a launch argument.

Verified: full gate green (14 packages, `-LE simulator`); the adapter test passes 4/4 against the stub.