### PR TITLE
Wire the grasp skill into the tree and bringup, and prove the gate in sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ Two rules shape the design, and both apply in simulation so the habits transfer:
 | [`g1_locomotion`](workspace/src/g1_locomotion) | Walks the base into arm's reach of a measured object, and backs it out again. |
 | [`g1_manipulation`](workspace/src/g1_manipulation) | Pick and place as actions, and the object-pose source behind them. |
 | [`g1_moveit_config`](workspace/src/g1_moveit_config) | MoveIt config: arm and hand planning groups, kinematics, the octomap. |
-| [`g1_msgs`](workspace/src/g1_msgs) | The mission's own actions: pick, place, approach, retreat, arm posture. |
+| [`g1_msgs`](workspace/src/g1_msgs) | The mission's own interfaces: pick, place, approach, retreat, arm posture, grasp. |
 | [`g1_navigation`](workspace/src/g1_navigation) | SLAM Toolbox mapping, AMCL localization and Nav2. |
 | [`g1_orchestration`](workspace/src/g1_orchestration) | The behaviour tree that sequences navigation and manipulation into a mission. |
 | [`g1_sensor_relay`](workspace/src/g1_sensor_relay) | Publishes LiDAR and depth frames sampled inside the simulator. |
 | [`g1_state_estimation`](workspace/src/g1_state_estimation) | Publishes `odom` to `base_footprint` and the TF chain Nav2 needs. |
+| [`g1_vla`](workspace/src/g1_vla) | Learned grasping: a policy's action chunks, checked against the planning scene before they run. |
 
 ## Quick start
 
@@ -169,6 +170,13 @@ Groot2 on the host can watch it tick at `localhost:1667`:
 
 ```bash
 ros2 launch g1_orchestration mission.launch.py tree:=pick_and_place_in_place.xml
+```
+
+The same scene has a learned-grasp variant. It needs `vla:=true` on the bringup above, and
+`vla_engine:=groot` additionally needs a policy server running on the host:
+
+```bash
+ros2 launch g1_orchestration mission.launch.py tree:=vla_grasp_in_place.xml
 ```
 
 The full navigate-pick-carry-place mission needs the facility world and a map:

--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -44,6 +44,7 @@ _ENABLED_BY = {
     "g1_navigation": "mode:=mapping and mode:=localization",
     "g1_moveit_config": "moveit:=true",
     "g1_manipulation": "manipulation:=true",
+    "g1_vla": "vla:=true",
 }
 
 
@@ -73,7 +74,7 @@ def _include(path, **launch_args):
 # --- validation -----------------------------------------------------------------------------
 
 
-def _validate(mode, want_nav, want_moveit, want_manipulation, pin_pelvis):
+def _validate(mode, want_nav, want_moveit, want_manipulation, want_vla, pin_pelvis):
     if mode not in MODES:
         raise RuntimeError(
             f"mode:={mode!r} is not a mode. 'none' is the simulator on its own; 'mapping' "
@@ -90,6 +91,12 @@ def _validate(mode, want_nav, want_moveit, want_manipulation, pin_pelvis):
             "manipulation:=true needs moveit:=true. The skills plan and execute through "
             "move_group, so without it every goal fails on a planning pipeline that is not "
             "there."
+        )
+    if want_vla and not want_manipulation:
+        raise RuntimeError(
+            "vla:=true needs manipulation:=true. The grasp skill validates against "
+            "move_group's planning scene and measures its result off /objects, and the "
+            "object-pose source comes with manipulation."
         )
     if pin_pelvis and mode != "none":
         raise RuntimeError(
@@ -151,6 +158,13 @@ def _manipulation():
     return _include(
         os.path.join(_share("g1_manipulation"), "launch", "manipulation.launch.py"),
         object_source=LaunchConfiguration("object_source"),
+    )
+
+
+def _vla():
+    return _include(
+        os.path.join(_share("g1_vla"), "launch", "vla.launch.py"),
+        engine=LaunchConfiguration("vla_engine"),
     )
 
 
@@ -220,10 +234,11 @@ def _setup(context, *args, **kwargs):
     want_rviz = _flag(context, "rviz")
     want_moveit = _flag(context, "moveit")
     want_manipulation = _flag(context, "manipulation")
+    want_vla = _flag(context, "vla")
     pin_pelvis = _flag(context, "pin_pelvis")
     navigating = mode != "none"
 
-    _validate(mode, want_nav, want_moveit, want_manipulation, pin_pelvis)
+    _validate(mode, want_nav, want_moveit, want_manipulation, want_vla, pin_pelvis)
 
     actions = [
         _simulator(_sim_args(context, navigating, want_manipulation, want_moveit, pin_pelvis))
@@ -234,6 +249,8 @@ def _setup(context, *args, **kwargs):
         actions.append(_moveit())
     if want_manipulation:
         actions.append(_manipulation())
+    if want_vla:
+        actions.append(_vla())
     if want_moveit and _flag(context, "activate_arm"):
         actions.append(
             _activate_arm(float(LaunchConfiguration("activate_arm_delay_s").perform(context)))
@@ -276,6 +293,18 @@ def generate_launch_description():
             default_value="false",
             description="Start the pick and place skills and the object-pose source. Needs "
             "moveit:=true, since the skills plan through move_group.",
+        ),
+        DeclareLaunchArgument(
+            "vla",
+            default_value="false",
+            description="Start the learned-grasp skill and its policy engine. Needs "
+            "manipulation:=true.",
+        ),
+        DeclareLaunchArgument(
+            "vla_engine",
+            default_value="mock",
+            description="Which policy engine answers with vla:=true. 'mock' needs no model; "
+            "'groot' talks to a policy server running outside the container.",
         ),
         DeclareLaunchArgument(
             "object_source",

--- a/workspace/src/g1_orchestration/CMakeLists.txt
+++ b/workspace/src/g1_orchestration/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(g1_bt_nodes
   src/skills/arm_authority_leaves.cpp
   src/skills/clear_costmaps.cpp
   src/skills/clear_octomap.cpp
+  src/skills/grasp.cpp
   src/skills/navigate_to_pose.cpp
   src/skills/pick.cpp
   src/skills/place.cpp

--- a/workspace/src/g1_orchestration/include/g1_orchestration/skill_nodes.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/skill_nodes.hpp
@@ -16,6 +16,7 @@
 #include "g1_orchestration/skills/arm_authority_leaves.hpp"
 #include "g1_orchestration/skills/clear_costmaps.hpp"
 #include "g1_orchestration/skills/clear_octomap.hpp"
+#include "g1_orchestration/skills/grasp.hpp"
 #include "g1_orchestration/skills/navigate_to_pose.hpp"
 #include "g1_orchestration/skills/pick.hpp"
 #include "g1_orchestration/skills/place.hpp"

--- a/workspace/src/g1_orchestration/include/g1_orchestration/skills/grasp.hpp
+++ b/workspace/src/g1_orchestration/include/g1_orchestration/skills/grasp.hpp
@@ -1,0 +1,36 @@
+#ifndef G1_ORCHESTRATION__SKILLS__GRASP_HPP_
+#define G1_ORCHESTRATION__SKILLS__GRASP_HPP_
+
+/**
+ * @file grasp.hpp
+ * @brief BT leaf for the learned-grasp skill.
+ */
+
+#include <g1_msgs/action/grasp.hpp>
+#include <string>
+
+#include "g1_orchestration/skill_action_node.hpp"
+
+namespace g1_orchestration
+{
+
+/**
+ * @brief Grasps an object by running a learned policy under a planning-scene check.
+ *
+ * Sits beside Pick rather than replacing it: same authority, same controllers, different way of
+ * deciding where the arm goes. A failure leaves the arm where it stopped, so a tree using this
+ * needs its own recovery.
+ */
+class Grasp : public SkillActionNode<g1_msgs::action::Grasp>
+{
+public:
+    Grasp(const std::string& name, const BT::NodeConfig& config, RosContext context);
+    static BT::PortsList providedPorts();
+
+protected:
+    bool fillGoal(Goal& goal) override;
+};
+
+}  // namespace g1_orchestration
+
+#endif  // G1_ORCHESTRATION__SKILLS__GRASP_HPP_

--- a/workspace/src/g1_orchestration/src/registration.cpp
+++ b/workspace/src/g1_orchestration/src/registration.cpp
@@ -13,6 +13,7 @@
 #include "g1_orchestration/skills/arm_authority_leaves.hpp"
 #include "g1_orchestration/skills/clear_costmaps.hpp"
 #include "g1_orchestration/skills/clear_octomap.hpp"
+#include "g1_orchestration/skills/grasp.hpp"
 #include "g1_orchestration/skills/navigate_to_pose.hpp"
 #include "g1_orchestration/skills/pick.hpp"
 #include "g1_orchestration/skills/place.hpp"
@@ -29,6 +30,7 @@ void registerSkillNodes(BT::BehaviorTreeFactory& factory, const RosContext& cont
     registerLeaf<Retreat>(factory, "Retreat", context);
     registerLeaf<Pick>(factory, "Pick", context);
     registerLeaf<Place>(factory, "Place", context);
+    registerLeaf<Grasp>(factory, "Grasp", context);
     registerLeaf<SetArmPosture>(factory, "SetArmPosture", context);
     registerLeaf<ClearCostmaps>(factory, "ClearCostmaps", context);
     registerLeaf<ClearOctomap>(factory, "ClearOctomap", context);

--- a/workspace/src/g1_orchestration/src/skills/grasp.cpp
+++ b/workspace/src/g1_orchestration/src/skills/grasp.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file grasp.cpp
+ * @brief Ports and goal for the Grasp leaf.
+ */
+
+#include "g1_orchestration/skills/grasp.hpp"
+
+#include <string>
+
+#include "g1_orchestration/ports.hpp"
+
+namespace g1_orchestration
+{
+
+Grasp::Grasp(const std::string& name, const BT::NodeConfig& config, RosContext context)
+  : SkillActionNode(name, config, std::move(context), "/g1_vla_server/grasp")
+{}
+
+BT::PortsList Grasp::providedPorts()
+{
+    return providedBasicPorts({ BT::InputPort<std::string>(
+                                    "instruction",
+                                    "What the policy is asked to do, in plain language."),
+                                ports::objectId(),
+                                ports::arm() });
+}
+
+bool Grasp::fillGoal(Goal& goal)
+{
+    const auto instruction = getInput<std::string>("instruction");
+    if (!instruction || instruction->empty())
+    {
+        RCLCPP_ERROR(node_->get_logger(), "[%s] needs an instruction", name().c_str());
+        return false;
+    }
+    // Separate from the instruction on purpose: the policy is told what to do, and this names
+    // the object whose measured lift decides whether it did it.
+    const auto object_id = getInput<std::string>("object_id");
+    if (!object_id || object_id->empty())
+    {
+        RCLCPP_ERROR(node_->get_logger(), "[%s] needs an object_id", name().c_str());
+        return false;
+    }
+    goal.instruction = *instruction;
+    goal.object_id   = *object_id;
+    goal.arm         = getInput<std::string>("arm").value_or("right");
+    return true;
+}
+
+}  // namespace g1_orchestration

--- a/workspace/src/g1_orchestration/trees/g1_orchestration_nodes.xml
+++ b/workspace/src/g1_orchestration/trees/g1_orchestration_nodes.xml
@@ -20,6 +20,12 @@
             <input_port name="service" type="std::string" default="/clear_octomap">move_group's octomap clear service. Empty skips it.</input_port>
             <input_port name="timeout_s" type="double" default="5.000000">Service budget.</input_port>
         </Action>
+        <Action ID="Grasp">
+            <input_port name="server_timeout_s" type="double" default="10.000000">How long to wait for the action server to appear.</input_port>
+            <input_port name="object_id" type="std::string">Must match a class_id published on /objects.</input_port>
+            <input_port name="arm" type="std::string" default="right">'left' or 'right'.</input_port>
+            <input_port name="instruction" type="std::string">What the policy is asked to do, in plain language.</input_port>
+        </Action>
         <Action ID="NavigateToPose">
             <output_port name="goal_yaw" type="double">The goal's heading, for an ApproachObject that has to hold it.</output_port>
             <input_port name="behavior_tree" type="std::string" default="">Nav2 tree to drive with. Empty uses its default.</input_port>

--- a/workspace/src/g1_orchestration/trees/vla_grasp_in_place.xml
+++ b/workspace/src/g1_orchestration/trees/vla_grasp_in_place.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  Grasp the cube with a learned policy instead of a planned pick, then carry and tuck. No
+  navigation.
+
+  Same shape as pick_and_place_in_place.xml and the same world, deliberately: the two trees
+  differ only in how the arm decides where to go, so running both against the same scene is
+  what makes the comparison mean anything.
+
+  The retry is worth having for a different reason than it is on Pick. A planned pick fails the
+  same way twice; a policy's action head is stochastic, so a second attempt genuinely resamples.
+
+  A failed Grasp leaves the arm wherever it stopped, holding whatever it was holding. The
+  postures after it are the recovery, and they run on the way out whether or not the grasp
+  worked, which is why they sit outside the retry.
+-->
+<root BTCPP_format="4" main_tree_to_execute="VlaGraspInPlace">
+  <BehaviorTree ID="VlaGraspInPlace">
+    <Sequence name="grasp_and_tuck">
+      <AcquireArm name="take_the_arm"/>
+
+      <RetryUntilSuccessful name="grasp_with_one_retry" num_attempts="2">
+        <Grasp name="grasp_the_cube" instruction="pick up the red cube" object_id="red_cube"
+               arm="right"/>
+      </RetryUntilSuccessful>
+
+      <SetArmPosture name="hold_it_close" group="right_arm" named_target="carry"/>
+      <SetArmPosture name="tuck_away" group="right_arm" named_target="tucked"/>
+      <ReleaseArm name="hand_the_arm_back"/>
+    </Sequence>
+  </BehaviorTree>
+</root>

--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -83,6 +83,10 @@ if(BUILD_TESTING)
   # MuJoCo nor a GPU and CI can run it.
   add_launch_test(test/test_groot_adapter.launch.py TARGET test_groot_adapter TIMEOUT 180)
 
+  add_launch_test(test/test_vla_grasp_mock.launch.py TARGET test_vla_grasp_mock TIMEOUT 500)
+  set_tests_properties(test_vla_grasp_mock PROPERTIES
+    LABELS simulator RESOURCE_LOCK mujoco_sim COST 95)
+
   g1_add_lint_tests()
 endif()
 

--- a/workspace/src/g1_vla/README.md
+++ b/workspace/src/g1_vla/README.md
@@ -65,6 +65,9 @@ is the `engine` launch argument.
 | `success_lift_m` | 0.05 | Rise in the object's height that counts as a grasp |
 | `object_timeout_ms` | 1000.0 | How stale an `/objects` pose may be |
 
+These are re-read at the start of every goal, so changing one with `ros2 param set` takes effect
+on the next grasp rather than needing a restart.
+
 `config/g1_vla_mock_engine.yaml`: `joint_names`, `target_positions`, `steps_per_chunk`,
 `action_dt_s`, `step_rad`.
 
@@ -103,3 +106,4 @@ every key the server reports and refuses to serve until each one is mapped.
 |---|---|
 | `test_chunk_utils` | Chunk shape, the start-jump, segment-step and velocity checks, and the controller split |
 | `test_groot_adapter` | The adapter against a stub policy server: wire protocol, key mapping, and action integration. No simulator or GPU. |
+| `test_vla_grasp_mock` | Sim, `-L simulator`. Valid chunks reach the controllers and move the arm; a chunk aimed at a colliding pose is refused with the arm still where it started. |

--- a/workspace/src/g1_vla/config/g1_vla_mock_engine.yaml
+++ b/workspace/src/g1_vla/config/g1_vla_mock_engine.yaml
@@ -1,14 +1,16 @@
 g1_vla_mock_engine:
   ros__parameters:
-    # The right arm only. A target the gate can reach in free space, so a healthy stack executes
-    # every chunk; point it at a surface instead and every chunk should be rejected unmoved.
+    # The right arm only, and a modest forward reach measured to be collision-free the whole way
+    # from the workbench rest pose. Point target_positions somewhere the arm cannot legally go
+    # and every chunk should be rejected with the robot still where it started.
     joint_names:
       - right_shoulder_pitch_joint
       - right_shoulder_roll_joint
       - right_elbow_joint
-    target_positions: [-0.6, -0.2, 0.8]
+    target_positions: [-0.6, -0.15, 0.3]
 
     steps_per_chunk: 8
     action_dt_s: 0.1
-    # Under the server's max_segment_step_rad, so the walk itself never trips the gate.
-    step_rad: 0.05
+    # 0.03 rad per 0.1 s is 0.3 rad/s against the arm's 0.8 limit, inside the server's
+    # velocity_scaling of 0.5. At 0.05 the walk itself would be refused for speed.
+    step_rad: 0.03

--- a/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
@@ -80,6 +80,14 @@ private:
     /// Claims the arm for one goal.
     bool acquire();
 
+    /**
+     * @brief Re-reads the tunables so a change takes effect on the next goal.
+     *
+     * Caching them at construction would mean every threshold needed a restart to move, which
+     * is the wrong trade for numbers whose right value is found by watching the robot.
+     */
+    void refreshTunables();
+
     void executeGrasp(const std::shared_ptr<GoalHandle>& goal_handle);
 
     /**

--- a/workspace/src/g1_vla/include/g1_vla/mock_engine_node.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/mock_engine_node.hpp
@@ -44,10 +44,8 @@ private:
     std::map<std::string, double> measured_;
 
     std::vector<std::string> joint_names_;
-    std::vector<double>      target_positions_;
     int                      steps_per_chunk_{ 8 };
     double                   action_dt_s_{ 0.1 };
-    double                   step_rad_{ 0.05 };
 };
 
 }  // namespace g1_vla

--- a/workspace/src/g1_vla/src/g1_vla_server_node.cpp
+++ b/workspace/src/g1_vla/src/g1_vla_server_node.cpp
@@ -42,17 +42,18 @@ G1VlaServer::G1VlaServer(const rclcpp::NodeOptions& options)
 {
     engine_service_ =
         declare_parameter<std::string>("engine_service", "/g1_vla_engine/get_action_chunk");
-    engine_timeout_s_ = declare_parameter<double>("engine_timeout_s", 10.0);
+    declare_parameter<double>("engine_timeout_s", 10.0);
     // A chunk that opens away from where the arm actually is means the policy misread the state.
-    max_start_jump_rad_ = declare_parameter<double>("max_start_jump_rad", 0.15);
+    declare_parameter<double>("max_start_jump_rad", 0.15);
     // Waypoints further apart than this sweep space no validity check ever looked at.
-    max_segment_step_rad_ = declare_parameter<double>("max_segment_step_rad", 0.20);
-    velocity_scaling_     = declare_parameter<double>("velocity_scaling", 0.5);
-    max_rejected_chunks_  = static_cast<int>(declare_parameter<int64_t>("max_rejected_chunks", 5));
-    timeout_s_            = declare_parameter<double>("timeout_s", 90.0);
-    chunk_exec_timeout_s_ = declare_parameter<double>("chunk_exec_timeout_s", 10.0);
-    success_lift_m_       = declare_parameter<double>("success_lift_m", 0.05);
-    object_timeout_s_     = declare_parameter<double>("object_timeout_ms", 1000.0) / 1000.0;
+    declare_parameter<double>("max_segment_step_rad", 0.20);
+    declare_parameter<double>("velocity_scaling", 0.5);
+    declare_parameter<int64_t>("max_rejected_chunks", 5);
+    declare_parameter<double>("timeout_s", 90.0);
+    declare_parameter<double>("chunk_exec_timeout_s", 10.0);
+    declare_parameter<double>("success_lift_m", 0.05);
+    declare_parameter<double>("object_timeout_ms", 1000.0);
+    refreshTunables();
 
     objects_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
         "/objects",
@@ -194,6 +195,19 @@ void G1VlaServer::initialize()
         "grasp server ready, engine at '%s', arm velocity limit %.2f rad/s",
         engine_service_.c_str(),
         limits_.at("right_elbow_joint"));
+}
+
+void G1VlaServer::refreshTunables()
+{
+    engine_timeout_s_     = get_parameter("engine_timeout_s").as_double();
+    max_start_jump_rad_   = get_parameter("max_start_jump_rad").as_double();
+    max_segment_step_rad_ = get_parameter("max_segment_step_rad").as_double();
+    velocity_scaling_     = get_parameter("velocity_scaling").as_double();
+    max_rejected_chunks_  = static_cast<int>(get_parameter("max_rejected_chunks").as_int());
+    timeout_s_            = get_parameter("timeout_s").as_double();
+    chunk_exec_timeout_s_ = get_parameter("chunk_exec_timeout_s").as_double();
+    success_lift_m_       = get_parameter("success_lift_m").as_double();
+    object_timeout_s_     = get_parameter("object_timeout_ms").as_double() / 1000.0;
 }
 
 bool G1VlaServer::acquire()
@@ -510,6 +524,8 @@ void G1VlaServer::executeGrasp(const std::shared_ptr<GoalHandle>& goal_handle)
 {
     const std::shared_ptr<const Grasp::Goal> goal   = goal_handle->get_goal();
     auto                                     result = std::make_shared<Grasp::Result>();
+
+    refreshTunables();
 
     auto feedback   = std::make_shared<Grasp::Feedback>();
     feedback->phase = Grasp::Feedback::PHASE_PREPARING;

--- a/workspace/src/g1_vla/src/mock_engine_node.cpp
+++ b/workspace/src/g1_vla/src/mock_engine_node.cpp
@@ -18,18 +18,12 @@ G1VlaMockEngine::G1VlaMockEngine(const rclcpp::NodeOptions& options)
 {
     joint_names_ =
         declare_parameter<std::vector<std::string>>("joint_names", std::vector<std::string>{});
-    target_positions_ =
-        declare_parameter<std::vector<double>>("target_positions", std::vector<double>{});
+    declare_parameter<std::vector<double>>("target_positions", std::vector<double>{});
     steps_per_chunk_ = static_cast<int>(declare_parameter<int64_t>("steps_per_chunk", 8));
     action_dt_s_     = declare_parameter<double>("action_dt_s", 0.1);
     // Small enough that consecutive waypoints stay inside the gate's segment-step budget, which
     // is what makes per-waypoint collision checking meaningful.
-    step_rad_ = declare_parameter<double>("step_rad", 0.05);
-
-    if (joint_names_.size() != target_positions_.size())
-    {
-        throw std::runtime_error("joint_names and target_positions must be the same length");
-    }
+    declare_parameter<double>("step_rad", 0.05);
 
     joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
         "/joint_states",
@@ -60,6 +54,17 @@ void G1VlaMockEngine::onGetActionChunk(
     const GetActionChunk::Request::SharedPtr&  request,
     const GetActionChunk::Response::SharedPtr& response)
 {
+    // Read per request, not cached: a test switches the target mid-run to point the walk
+    // somewhere the gate must refuse.
+    const std::vector<double> target   = get_parameter("target_positions").as_double_array();
+    const double              step_rad = get_parameter("step_rad").as_double();
+    if (target.size() != joint_names_.size())
+    {
+        response->ok      = false;
+        response->message = "target_positions is not as long as joint_names";
+        return;
+    }
+
     std::vector<double> current;
     current.reserve(joint_names_.size());
     {
@@ -83,8 +88,8 @@ void G1VlaMockEngine::onGetActionChunk(
         trajectory_msgs::msg::JointTrajectoryPoint point;
         for (std::size_t i = 0; i < joint_names_.size(); ++i)
         {
-            const double remaining = target_positions_[i] - current[i];
-            current[i] += std::clamp(remaining, -step_rad_, step_rad_);
+            const double remaining = target[i] - current[i];
+            current[i] += std::clamp(remaining, -step_rad, step_rad);
             point.positions.push_back(current[i]);
         }
         const double t                = action_dt_s_ * step;

--- a/workspace/src/g1_vla/test/test_vla_grasp_mock.launch.py
+++ b/workspace/src/g1_vla/test/test_vla_grasp_mock.launch.py
@@ -1,0 +1,197 @@
+"""Headless sim integration test: the gate executes what is safe and refuses what is not.
+
+The acceptance gate for this package, and the half no unit test can reach. `test_chunk_utils`
+proves the arithmetic; only a running stack proves that the arithmetic is wired to a real
+planning scene, to real controllers, and that a refusal happens BEFORE the arm moves rather than
+after.
+
+Both halves matter and the second one matters more. A gate that never rejects anything passes a
+happy-path test perfectly while protecting nothing, so the second case aims the engine at a pose
+measured to self-collide and asserts the arm is still where it started.
+
+Run via `colcon test --packages-select g1_vla`.
+"""
+
+import os
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from rcl_interfaces.srv import SetParameters
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import JointState
+
+from g1_msgs.action import Grasp
+
+# Same budget as the manipulation suite: simulator, move_group, the skills, the object pipeline
+# and a delayed acquire behind all of it.
+STACK_SETTLE_S = 55.0
+READY_TIMEOUT_S = STACK_SETTLE_S + 30.0
+
+# Short on purpose. Nothing here should ever grasp the cube, so both cases end on this or on the
+# rejection limit, and the server's 90 s default would only make the suite slow.
+GOAL_TIMEOUT_S = 20.0
+MAX_REJECTED = 5
+
+WATCHED = ["right_shoulder_pitch_joint", "right_shoulder_roll_joint", "right_elbow_joint"]
+# Measured against this scene: the arm self-collides with the torso from about roll 0.1, so a
+# walk toward 0.6 is refused from the first chunk that reaches it.
+BLOCKED_TARGET = [0.06, 0.6, 0.09]
+
+
+@launch_testing.ready_to_test_action_timeout(READY_TIMEOUT_S)
+def generate_test_description():
+    bringup = get_package_share_directory("g1_bringup")
+    stack = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(bringup, "launch", "bringup.launch.py")),
+        launch_arguments={
+            "moveit": "true",
+            "manipulation": "true",
+            "vla": "true",
+            "vla_engine": "mock",
+            # FAST-LIO cannot work in this scene: the bench is at arm's length with the pelvis
+            # pinned, so the Mid360 returns nothing and no odom is ever published.
+            "odometry": "ground_truth",
+            "world": "manipulation",
+            "pin_pelvis": "true",
+            "activate_arm": "true",
+            "activate_arm_delay_s": "40.0",
+            "headless": "true",
+            "rviz": "false",
+        }.items(),
+    )
+    return LaunchDescription(
+        [stack, TimerAction(period=STACK_SETTLE_S, actions=[launch_testing.actions.ReadyToTest()])]
+    )
+
+
+class TestVlaGraspMock(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_vla_grasp_mock")
+        cls.joints = {}
+
+        def _on_joints(msg):
+            for name, position in zip(msg.name, msg.position, strict=False):
+                cls.joints[name] = position
+
+        cls.node.create_subscription(JointState, "/joint_states", _on_joints, 20)
+        cls.grasp = ActionClient(cls.node, Grasp, "/g1_vla_server/grasp")
+        cls.server_params = cls.node.create_client(
+            SetParameters, "/g1_vla_server/set_parameters"
+        )
+        cls.engine_params = cls.node.create_client(
+            SetParameters, "/g1_vla_mock_engine/set_parameters"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+    def _set_params(self, client, parameters):
+        self.assertTrue(client.wait_for_service(timeout_sec=30.0), client.srv_name)
+        request = SetParameters.Request()
+        request.parameters = [p.to_parameter_msg() for p in parameters]
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=30.0)
+        self.assertIsNotNone(future.result(), f"{client.srv_name} never answered")
+        for result in future.result().results:
+            self.assertTrue(result.successful, result.reason)
+
+    def _watched(self):
+        return [self.joints[name] for name in WATCHED]
+
+    def _run_grasp(self, timeout_s):
+        goal = Grasp.Goal()
+        goal.instruction = "pick up the red cube"
+        goal.object_id = "red_cube"
+        goal.arm = "right"
+        handle_future = self.grasp.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self.node, handle_future, timeout_sec=30.0)
+        handle = handle_future.result()
+        self.assertIsNotNone(handle, "the grasp server never answered")
+        self.assertTrue(handle.accepted, "the grasp server rejected the goal")
+        result_future = handle.get_result_async()
+        rclpy.spin_until_future_complete(self.node, result_future, timeout_sec=timeout_s)
+        self.assertIsNotNone(result_future.result(), "the grasp goal never finished")
+        return result_future.result().result
+
+    def test_01_the_stack_is_up(self):
+        self.assertTrue(
+            self.grasp.wait_for_server(timeout_sec=90.0), "/g1_vla_server/grasp never appeared"
+        )
+        end = time.time() + 60.0
+        while time.time() < end and len(self.joints) < 40:
+            rclpy.spin_once(self.node, timeout_sec=0.2)
+        self.assertGreaterEqual(len(self.joints), 40, "joint states never arrived")
+
+        # Shorter than the server's own default so the free-space case ends on the timeout
+        # rather than on the suite's.
+        self._set_params(
+            self.server_params,
+            [
+                Parameter("timeout_s", Parameter.Type.DOUBLE, GOAL_TIMEOUT_S),
+                Parameter("max_rejected_chunks", Parameter.Type.INTEGER, MAX_REJECTED),
+            ],
+        )
+
+    def test_02_valid_chunks_reach_the_controllers(self):
+        before = self._watched()
+        result = self._run_grasp(GOAL_TIMEOUT_S + 60.0)
+
+        # Never a success: the mock walks the arm through free space and does not grasp
+        # anything, so the object never lifts. What is being tested is the path in between.
+        self.assertIn("executed", result.message)
+        self.assertIn("0 rejected", result.message, f"a free-space walk was refused: {result.message}")
+        self.assertNotIn("[0 executed", result.message, f"nothing ran: {result.message}")
+
+        self._spin(2.0)
+        moved = max(abs(a - b) for a, b in zip(self._watched(), before, strict=True))
+        self.assertGreater(moved, 0.05, "the arm did not move for chunks that passed the gate")
+
+    def test_03_a_blocked_chunk_is_refused_before_the_arm_moves(self):
+        self._set_params(
+            self.engine_params,
+            [Parameter("target_positions", Parameter.Type.DOUBLE_ARRAY, BLOCKED_TARGET)],
+        )
+        self._spin(10.0)
+        before = self._watched()
+
+        result = self._run_grasp(GOAL_TIMEOUT_S + 60.0)
+
+        self.assertFalse(result.success, result.message)
+        self.assertTrue(
+            result.message.startswith("blocked:"),
+            f"expected a blocked abort, got: {result.message}",
+        )
+        self.assertIn("in collision", result.message)
+        self.assertIn(f"[0 executed, {MAX_REJECTED} rejected]", result.message)
+
+        # The claim this whole package exists to make: refused before moving, not after.
+        # The bar is 0.1 rad rather than zero because the arms run position-only on a soft gain
+        # and the measured pose keeps trailing the commanded one by a few hundredths of a radian
+        # after motion stops -- the same drift moveit_controllers.yaml sets a 0.05 start
+        # tolerance for. One executed chunk would be 0.24 rad, so the two are not close.
+        self._spin(2.0)
+        moved = max(abs(a - b) for a, b in zip(self._watched(), before, strict=True))
+        self.assertLess(moved, 0.1, f"the arm moved {moved:.3f} rad on a refused chunk")
+
+
+# No post-shutdown exit-code check, matching the other sim suites: move_group segfaults in its
+# own destructor on this MoveIt and ros2_control_node leaves 130 on SIGINT. Asserting on that
+# tests their teardown, not this gate.


### PR DESCRIPTION
Makes the skill runnable end to end and adds the test that decides whether the gate is real.

- `g1_orchestration`: a `Grasp` leaf beside `Pick` and `trees/vla_grasp_in_place.xml`, same scene and same shape as the classical tree so the two are comparable. Palette regenerated.
- `g1_bringup`: `vla:=true` and `vla_engine:=mock|groot`, with `vla` requiring `manipulation`.
- `g1_vla/test/test_vla_grasp_mock.launch.py`: full stack, mock engine. One case walks the arm through free space and asserts chunks reached the controllers; the other aims the engine at a pose measured to self-collide and asserts the arm is still where it started.

Three things the test caught that review would not have:

The mock config would have been refused for speed. 0.05 rad per 0.1 s is 0.5 rad/s against the arm 0.8 limit, a ratio of 0.625 over a `velocity_scaling` of 0.5, so every chunk from the stand-in engine would have been rejected and the pipeline would have looked broken. 0.03 per step is 0.375.

The gate tunables were cached at construction, so `ros2 param set` silently did nothing: the test asked for a 20 s `timeout_s` and the server ran 96 chunks on its 90 s default. They are re-read at the start of each goal now, which is the right behaviour anyway for numbers whose value is found by watching the robot.

The "did not move" assertion cannot be written as zero. A 0.02 rad bar failed one run in three on 0.033 rad of pure settling while the gate itself reported `0 executed, 5 rejected` -- the arms run position-only on a soft gain and the measured pose trails, which is what `allowed_start_tolerance: 0.05` exists for. It is 0.1 rad now, against a 0.24 rad chunk.

The blocked case uses a self-collision rather than the octomap, because that is deterministic and is not covered by the grasp exemption, so it stays a rejection for the right reason. Octomap blocking is already covered by `test_octomap_blocks_a_plan`.

Verified: full gate green (14 packages, `-LE simulator`); the sim test three consecutive times, each reporting `24 executed, 0 rejected` then `0 executed, 5 rejected: blocked`.