### PR TITLE
Add MoveIt Servo as a second execution mode for validated chunks

### DIFF
--- a/workspace/src/g1_bringup/launch/bringup.launch.py
+++ b/workspace/src/g1_bringup/launch/bringup.launch.py
@@ -27,7 +27,7 @@ from launch.actions import (
     TimerAction,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import EqualsSubstitution, LaunchConfiguration
 
 BRINGUP_SHARE = get_package_share_directory("g1_bringup")
 
@@ -151,7 +151,10 @@ def _navigation(mode, want_nav):
 def _moveit():
     """Sim-free by design, and it activates nothing: executing a plan still needs the ordered
     acquire in scripts/activate_arm."""
-    return _include(os.path.join(_share("g1_moveit_config"), "launch", "move_group.launch.py"))
+    return _include(
+        os.path.join(_share("g1_moveit_config"), "launch", "move_group.launch.py"),
+        servo=EqualsSubstitution(LaunchConfiguration("vla_execution_mode"), "servo"),
+    )
 
 
 def _manipulation():
@@ -165,6 +168,7 @@ def _vla():
     return _include(
         os.path.join(_share("g1_vla"), "launch", "vla.launch.py"),
         engine=LaunchConfiguration("vla_engine"),
+        execution_mode=LaunchConfiguration("vla_execution_mode"),
     )
 
 
@@ -305,6 +309,14 @@ def generate_launch_description():
             default_value="mock",
             description="Which policy engine answers with vla:=true. 'mock' needs no model; "
             "'groot' talks to a policy server running outside the container.",
+        ),
+        DeclareLaunchArgument(
+            "vla_execution_mode",
+            default_value="trajectory",
+            choices=["trajectory", "servo"],
+            description="How the grasp skill executes a validated chunk. 'servo' streams it "
+            "through MoveIt Servo, which adds proximity slowdown while the arm is moving, and "
+            "starts a servo_node alongside move_group.",
         ),
         DeclareLaunchArgument(
             "object_source",

--- a/workspace/src/g1_moveit_config/config/servo.yaml
+++ b/workspace/src/g1_moveit_config/config/servo.yaml
@@ -1,0 +1,65 @@
+# MoveIt Servo: the streaming command path for the arms.
+#
+# A second way into the same arm_trajectory_controller move_group already drives, not a second
+# command path: servo publishes onto the controller's trajectory topic, so the ownership chain
+# is unchanged and only one thing streams at a time.
+#
+# What it adds over a planned trajectory is reaction. A plan is checked once and then executed
+# blind; servo re-checks proximity while the arm is moving and scales the command down, which is
+# what a learned policy driving into a scene that can change actually needs.
+
+# Both arms, matching arm_trajectory_controller's 14 joints. active_subgroup can narrow this to
+# one arm at runtime. Only joint commands are used, so the missing kinematics entry on this
+# group in g1.srdf does not matter -- Cartesian input is what would need a solver.
+move_group_name: both_arms
+
+publish_period: 0.01
+# A stale command must stop the arm rather than repeat. This is the dead-man for anything
+# streaming into servo, so it stays well under a second.
+incoming_command_timeout: 0.1
+max_expected_latency: 0.1
+
+# Commands arrive as real rad/s rather than joystick-style [-1, 1], so the numbers in a chunk
+# and the numbers on the wire are the same quantity.
+command_in_type: speed_units
+scale:
+  linear: 0.2
+  rotational: 0.8
+  joint: 0.5
+
+joint_command_in_topic: ~/delta_joint_cmds
+cartesian_command_in_topic: ~/delta_twist_cmds
+joint_topic: /joint_states
+status_topic: ~/status
+command_out_topic: /arm_trajectory_controller/joint_trajectory
+command_out_type: trajectory_msgs/JointTrajectory
+
+# The controller claims position alone.
+publish_joint_positions: true
+publish_joint_velocities: false
+publish_joint_accelerations: false
+
+use_smoothing: true
+smoothing_filter_plugin_name: online_signal_smoothing::AccelerationLimitedPlugin
+
+# move_group owns the primary scene; a second primary would advertise a competing
+# /get_planning_scene and the two would answer different callers differently.
+is_primary_planning_scene_monitor: false
+monitored_planning_scene_topic: /monitored_planning_scene
+
+check_collisions: true
+# NOT the default. The scene obstacle here is the octomap the depth camera builds, so leaving
+# this false would give a collision monitor that never sees the bench and never slows down.
+check_octomap_collisions: true
+collision_check_rate: 10.0
+self_collision_proximity_threshold: 0.01
+scene_collision_proximity_threshold: 0.02
+
+lower_singularity_threshold: 17.0
+hard_stop_singularity_threshold: 30.0
+leaving_singularity_threshold_multiplier: 2.0
+
+# Matches the arm's own margin habit elsewhere: the measured pose trails the commanded one on a
+# position-only joint, so a zero margin reads a joint at its limit as already past it.
+joint_limit_margins: [0.12]
+halt_all_joints_in_joint_mode: true

--- a/workspace/src/g1_moveit_config/launch/move_group.launch.py
+++ b/workspace/src/g1_moveit_config/launch/move_group.launch.py
@@ -9,11 +9,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_param_builder import ParameterBuilder
 from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 
 DESCRIPTION_SHARE = get_package_share_directory("g1_description")
 CONFIG_SHARE = get_package_share_directory("g1_moveit_config")
+
+# Both arms: matches arm_trajectory_controller's 14 joints, and servo.yaml's move_group_name.
+SERVO_GROUP = "both_arms"
 
 
 def _config(name):
@@ -44,8 +51,52 @@ def _moveit_config():
     )
 
 
+def _servo_config():
+    """Deliberately without sensors_3d. Handed the sensor config, servo starts a second octomap
+    updater on the same camera: double the CPU, and a map that can disagree with the one
+    move_group checks against. It consumes move_group's scene over /monitored_planning_scene
+    instead."""
+    return (
+        MoveItConfigsBuilder("g1", package_name="g1_moveit_config")
+        .robot_description(
+            file_path=os.path.join(DESCRIPTION_SHARE, "urdf", "g1_lowcmd.urdf.xacro")
+        )
+        .robot_description_semantic(file_path=_config("g1.srdf"))
+        .robot_description_kinematics(file_path=_config("kinematics.yaml"))
+        .joint_limits(file_path=_config("joint_limits.yaml"))
+        .planning_pipelines(pipelines=["ompl"], default_planning_pipeline="ompl")
+        .to_moveit_configs()
+    )
+
+
+def _servo():
+    """Off unless asked for. Servo streams onto the same controller topic move_group executes
+    through, so running it alongside a planned motion would put two writers on one controller."""
+    return Node(
+        package="moveit_servo",
+        executable="servo_node",
+        name="servo_node",
+        output="screen",
+        condition=IfCondition(LaunchConfiguration("servo")),
+        parameters=[
+            _servo_config().to_dict(),
+            # Servo reads its own settings from under this key, not from the node root.
+            {"moveit_servo": ParameterBuilder("g1_moveit_config").yaml("config/servo.yaml").to_dict()},
+            # The acceleration-limiting smoother is a separate plugin and takes these at the
+            # node root; without them it fails to configure and servo starts with no smoothing.
+            {"update_period": 0.01, "planning_group_name": SERVO_GROUP},
+        ],
+    )
+
+
 def generate_launch_description():
     return LaunchDescription([
+        DeclareLaunchArgument(
+            "servo",
+            default_value="false",
+            description="Also start MoveIt Servo, the streaming command path for the arms. "
+            "Off by default: it and a planned motion would both drive the same controller.",
+        ),
         Node(
             package="moveit_ros_move_group",
             executable="move_group",
@@ -58,4 +109,5 @@ def generate_launch_description():
                 {"publish_robot_description_semantic": True},
             ],
         ),
+        _servo(),
     ])

--- a/workspace/src/g1_moveit_config/package.xml
+++ b/workspace/src/g1_moveit_config/package.xml
@@ -17,10 +17,12 @@
   <exec_depend>g1_description</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch_param_builder</exec_depend>
   <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_servo</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <!-- The kinematics plugin both arm groups load; see config/kinematics.yaml for why not KDL. -->

--- a/workspace/src/g1_vla/CMakeLists.txt
+++ b/workspace/src/g1_vla/CMakeLists.txt
@@ -87,6 +87,10 @@ if(BUILD_TESTING)
   set_tests_properties(test_vla_grasp_mock PROPERTIES
     LABELS simulator RESOURCE_LOCK mujoco_sim COST 95)
 
+  add_launch_test(test/test_vla_grasp_servo.launch.py TARGET test_vla_grasp_servo TIMEOUT 500)
+  set_tests_properties(test_vla_grasp_servo PROPERTIES
+    LABELS simulator RESOURCE_LOCK mujoco_sim COST 90)
+
   g1_add_lint_tests()
 endif()
 

--- a/workspace/src/g1_vla/README.md
+++ b/workspace/src/g1_vla/README.md
@@ -54,7 +54,6 @@ is the `engine` launch argument.
 
 | Parameter | Default | Meaning |
 |---|---|---|
-| `engine_service` | `/g1_vla_engine/get_action_chunk` | Where the chunks come from |
 | `engine_timeout_s` | 10.0 | How long one chunk request may take |
 | `max_start_jump_rad` | 0.15 | Largest gap allowed between the measured pose and a chunk's first waypoint |
 | `max_segment_step_rad` | 0.20 | Largest move allowed between consecutive waypoints |
@@ -64,15 +63,38 @@ is the `engine` launch argument.
 | `chunk_exec_timeout_s` | 10.0 | Per-controller deadline for one chunk |
 | `success_lift_m` | 0.05 | Rise in the object's height that counts as a grasp |
 | `object_timeout_ms` | 1000.0 | How stale an `/objects` pose may be |
+| `servo_topic` | `/servo_node/delta_joint_cmds` | Where jog commands go in servo mode |
+| `servo_publish_rate` | 50.0 | Jog commands per second while streaming a chunk |
 
 These are re-read at the start of every goal, so changing one with `ros2 param set` takes effect
 on the next grasp rather than needing a restart.
+
+`engine_service` and `execution_mode` are launch arguments and are deliberately absent from that
+file: a key set there under this node's name would beat the launch's own override, which ROS
+writes under the `/**` wildcard, because node-specific always wins over a wildcard.
 
 `config/g1_vla_mock_engine.yaml`: `joint_names`, `target_positions`, `steps_per_chunk`,
 `action_dt_s`, `step_rad`.
 
 The server reads velocity limits from `robot_description_planning.joint_limits`, which the launch
 supplies from `g1_moveit_config`. It logs the resolved arm limit at startup.
+
+## Execution modes
+
+`execution_mode` is a launch argument, not a config key. `trajectory` sends each validated chunk
+to the controllers as a `FollowJointTrajectory` goal and waits. `servo` streams the arm's share
+as jog commands into a running `servo_node` instead, which adds proximity-based slowdown while
+the arm is moving; the hands keep the trajectory path either way, since they are outside servo's
+group. Validation is identical in both, and a refused chunk is never streamed.
+
+Servo mode needs `servo_node` running, which `g1_bringup` starts with
+`vla_execution_mode:=servo`.
+
+The two modes differ in what they guarantee about the path. Trajectory mode executes the
+validated waypoints. Servo mode steers toward them: jog commands are integrated by the servo,
+which tracks velocity rather than position, so the arm can end up a little off the checked path.
+Servo's own collision monitor covers that, decelerating and halting on proximity while the arm is
+moving. Prefer trajectory mode unless that reaction is what you want.
 
 ## Failure behaviour
 
@@ -107,3 +129,4 @@ every key the server reports and refuses to serve until each one is mapped.
 | `test_chunk_utils` | Chunk shape, the start-jump, segment-step and velocity checks, and the controller split |
 | `test_groot_adapter` | The adapter against a stub policy server: wire protocol, key mapping, and action integration. No simulator or GPU. |
 | `test_vla_grasp_mock` | Sim, `-L simulator`. Valid chunks reach the controllers and move the arm; a chunk aimed at a colliding pose is refused with the arm still where it started. |
+| `test_vla_grasp_servo` | Sim, `-L simulator`. The same two claims under the servo backend, plus servo halting for a collision while the arm is already moving. |

--- a/workspace/src/g1_vla/config/g1_vla_server.yaml
+++ b/workspace/src/g1_vla/config/g1_vla_server.yaml
@@ -1,7 +1,5 @@
 g1_vla_server:
   ros__parameters:
-    # Whichever engine is launched remaps its own ~/get_action_chunk onto this name.
-    engine_service: /g1_vla_engine/get_action_chunk
     engine_timeout_s: 10.0
 
     # A chunk opening this far from the measured pose means the policy misread the state, and
@@ -21,3 +19,9 @@ g1_vla_server:
     # How far the object has to rise before the grasp counts. Measured off /objects, as a delta.
     success_lift_m: 0.05
     object_timeout_ms: 1000.0
+
+    # execution_mode is a launch argument, not a key here . "trajectory" sends each
+    # validated chunk to the controllers and waits; "servo" streams the arm's share as jog
+    # commands instead, which adds proximity slowdown while the arm is moving.
+    servo_topic: /servo_node/delta_joint_cmds
+    servo_publish_rate: 50.0

--- a/workspace/src/g1_vla/include/g1_vla/chunk_utils.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/chunk_utils.hpp
@@ -65,6 +65,23 @@ startJump(const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& me
     const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured,
     const JointMap& limits);
 
+/**
+ * @brief Velocity that carries the arm from where it is now to the waypoint due after @p t.
+ *
+ * Closed-loop on purpose. Jog commands are integrated by the servo, which tracks velocity and
+ * never looks at position, so a velocity computed once per chunk lets error accumulate and the
+ * arm ends up somewhere the gate never validated. Aiming at the next waypoint from the measured
+ * pose on every tick keeps the streamed motion on the path that was checked.
+ *
+ * @param measured Where the arm is right now, not where the chunk started.
+ * @param min_dt Floor on the time left to the waypoint, so a tick landing on one does not
+ *        divide by zero.
+ * @return Empty at or past the chunk's last waypoint, which is the caller's signal to stop.
+ */
+[[nodiscard]] std::vector<double> trackingVelocity(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured, double t,
+    double min_dt);
+
 }  // namespace g1_vla
 
 #endif  // G1_VLA__CHUNK_UTILS_HPP_

--- a/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
+++ b/workspace/src/g1_vla/include/g1_vla/g1_vla_server_node.hpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <control_msgs/msg/joint_jog.hpp>
 #include <cstdint>
 #include <g1_msgs/action/grasp.hpp>
 #include <g1_msgs/srv/get_action_chunk.hpp>
@@ -23,6 +24,7 @@
 #include <moveit_msgs/srv/apply_planning_scene.hpp>
 #include <moveit_msgs/srv/get_planning_scene.hpp>
 #include <moveit_msgs/srv/get_state_validity.hpp>
+#include <moveit_msgs/srv/servo_command_type.hpp>
 #include <mutex>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
@@ -115,6 +117,29 @@ private:
     /// Splits the chunk across the controllers, sends it, and waits for all of them.
     bool executeChunk(const JointTrajectory& chunk, std::string& why);
 
+    /**
+     * @brief Streams the arm's share of a chunk as jog commands instead of a trajectory.
+     *
+     * Servo re-checks proximity while the arm is moving and scales the command down, which the
+     * trajectory path cannot: a trajectory is validated once and then executed blind. Only the
+     * arm goes this way, because the hands are not in servo's group.
+     *
+     * @return false if the chunk names a joint that is not being measured.
+     */
+    bool streamArmServo(const JointTrajectory& arm_slice, std::string& why);
+
+    /**
+     * @brief Puts servo into joint-jog mode, once per goal.
+     *
+     * Servo starts with no command type selected and silently refuses every jog until one is
+     * chosen, which reads as a policy whose commands do nothing.
+     */
+    bool selectServoJointJog(std::string& why);
+
+    /// Caps a tracking correction at the same speed the chunk was validated against.
+    [[nodiscard]] std::vector<double> clampToLimits(
+        const std::vector<std::string>& joints, const std::vector<double>& velocities) const;
+
     /// Cancels anything still running on the controllers.
     void cancelAll();
 
@@ -142,6 +167,8 @@ private:
     rclcpp::Client<moveit_msgs::srv::GetPlanningScene>::SharedPtr   get_scene_;
     rclcpp::Client<moveit_msgs::srv::ApplyPlanningScene>::SharedPtr apply_scene_;
     rclcpp_action::Server<Grasp>::SharedPtr                         grasp_server_;
+    rclcpp::Publisher<control_msgs::msg::JointJog>::SharedPtr       servo_pub_;
+    rclcpp::Client<moveit_msgs::srv::ServoCommandType>::SharedPtr   servo_command_type_;
 
     robot_model_loader::RobotModelLoaderPtr model_loader_;
     moveit::core::RobotModelConstPtr        model_;
@@ -159,6 +186,9 @@ private:
     double      chunk_exec_timeout_s_{ 10.0 };
     double      success_lift_m_{ 0.05 };
     double      object_timeout_s_{ 1.0 };
+    /// "trajectory" or "servo".
+    std::string execution_mode_;
+    double      servo_publish_rate_{ 50.0 };
 
     /// One goal at a time: two would drive overlapping joints through the same controllers.
     std::atomic<bool> busy_{ false };

--- a/workspace/src/g1_vla/launch/vla.launch.py
+++ b/workspace/src/g1_vla/launch/vla.launch.py
@@ -51,7 +51,10 @@ def _server():
         parameters=[
             _moveit_config().to_dict(),
             _config(SHARE, "g1_vla_server.yaml"),
-            {"engine_service": ENGINE_SERVICE},
+            {
+                "engine_service": ENGINE_SERVICE,
+                "execution_mode": LaunchConfiguration("execution_mode"),
+            },
         ],
     )
 
@@ -83,6 +86,13 @@ def _groot_engine():
 def generate_launch_description():
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "execution_mode",
+                default_value="trajectory",
+                choices=["trajectory", "servo"],
+                description="How a validated chunk is executed. 'servo' streams it as jog "
+                "commands and needs a servo_node running.",
+            ),
             DeclareLaunchArgument(
                 "engine",
                 default_value="mock",

--- a/workspace/src/g1_vla/src/chunk_utils.cpp
+++ b/workspace/src/g1_vla/src/chunk_utils.cpp
@@ -147,4 +147,32 @@ std::optional<double> maxVelocityRatio(
     return worst;
 }
 
+std::vector<double> trackingVelocity(
+    const trajectory_msgs::msg::JointTrajectory& chunk, const JointMap& measured, double t,
+    double min_dt)
+{
+    for (const trajectory_msgs::msg::JointTrajectoryPoint& point : chunk.points)
+    {
+        const double point_t = seconds(point.time_from_start);
+        if (t >= point_t)
+        {
+            continue;
+        }
+        const double        dt = std::max(point_t - t, min_dt);
+        std::vector<double> velocities;
+        velocities.reserve(chunk.joint_names.size());
+        for (std::size_t i = 0; i < chunk.joint_names.size(); ++i)
+        {
+            const auto it = measured.find(chunk.joint_names[i]);
+            if (it == measured.end())
+            {
+                return {};
+            }
+            velocities.push_back((point.positions[i] - it->second) / dt);
+        }
+        return velocities;
+    }
+    return {};
+}
+
 }  // namespace g1_vla

--- a/workspace/src/g1_vla/src/g1_vla_server_node.cpp
+++ b/workspace/src/g1_vla/src/g1_vla_server_node.cpp
@@ -53,6 +53,10 @@ G1VlaServer::G1VlaServer(const rclcpp::NodeOptions& options)
     declare_parameter<double>("chunk_exec_timeout_s", 10.0);
     declare_parameter<double>("success_lift_m", 0.05);
     declare_parameter<double>("object_timeout_ms", 1000.0);
+    // "servo" needs a servo_node running; move_group.launch.py starts one with servo:=true.
+    declare_parameter<std::string>("execution_mode", "trajectory");
+    declare_parameter<std::string>("servo_topic", "/servo_node/delta_joint_cmds");
+    declare_parameter<double>("servo_publish_rate", 50.0);
     refreshTunables();
 
     objects_sub_ = create_subscription<vision_msgs::msg::Detection3DArray>(
@@ -68,6 +72,11 @@ G1VlaServer::G1VlaServer(const rclcpp::NodeOptions& options)
     validity_    = create_client<moveit_msgs::srv::GetStateValidity>("/check_state_validity");
     get_scene_   = create_client<moveit_msgs::srv::GetPlanningScene>("/get_planning_scene");
     apply_scene_ = create_client<moveit_msgs::srv::ApplyPlanningScene>("/apply_planning_scene");
+    servo_pub_   = create_publisher<control_msgs::msg::JointJog>(
+        get_parameter("servo_topic").as_string(),
+        rclcpp::QoS(rclcpp::KeepLast(1)));
+    servo_command_type_ =
+        create_client<moveit_msgs::srv::ServoCommandType>("/servo_node/switch_command_type");
 }
 
 G1VlaServer::~G1VlaServer()
@@ -192,7 +201,8 @@ void G1VlaServer::initialize()
     // check means anything, and it has two very different plausible values.
     RCLCPP_INFO(
         get_logger(),
-        "grasp server ready, engine at '%s', arm velocity limit %.2f rad/s",
+        "grasp server ready in %s mode, engine at '%s', arm velocity limit %.2f rad/s",
+        execution_mode_.c_str(),
         engine_service_.c_str(),
         limits_.at("right_elbow_joint"));
 }
@@ -208,6 +218,8 @@ void G1VlaServer::refreshTunables()
     chunk_exec_timeout_s_ = get_parameter("chunk_exec_timeout_s").as_double();
     success_lift_m_       = get_parameter("success_lift_m").as_double();
     object_timeout_s_     = get_parameter("object_timeout_ms").as_double() / 1000.0;
+    execution_mode_       = get_parameter("execution_mode").as_string();
+    servo_publish_rate_   = get_parameter("servo_publish_rate").as_double();
 }
 
 bool G1VlaServer::acquire()
@@ -366,10 +378,19 @@ std::string G1VlaServer::checkWaypoints(const JointTrajectory& chunk, const std:
         {
             return "/check_state_validity did not answer";
         }
-        if (!future.get()->valid)
+        const auto response = future.get();
+        if (!response->valid)
         {
+            // Naming the pair matters: "waypoint 3 is in collision" gives an operator nothing to
+            // act on, and the two likely causes, the scene and the robot itself, want opposite
+            // responses.
+            const std::string what = response->contacts.empty() ?
+                                         "" :
+                                         " (" + response->contacts.front().contact_body_1 +
+                                             " against " +
+                                             response->contacts.front().contact_body_2 + ")";
             return "waypoint " + std::to_string(p) + " of " + std::to_string(chunk.points.size()) +
-                   " is in collision";
+                   " is in collision" + what;
         }
     }
     return {};
@@ -381,11 +402,21 @@ bool G1VlaServer::executeChunk(const JointTrajectory& chunk, std::string& why)
     std::vector<std::shared_future<GoalHandleFJT::WrappedResult>> results;
     std::vector<std::string>                                      sent_to;
 
+    const bool      servoing = execution_mode_ == "servo";
+    JointTrajectory arm_slice;
+
     for (const ControllerTarget& controller : controllers_)
     {
         const JointTrajectory slice = splitByController(chunk, controller.joints);
         if (slice.joint_names.empty())
         {
+            continue;
+        }
+        // Servo owns the arm group when it is running, so the arm's share is streamed below
+        // rather than sent as a trajectory. The hands are outside that group either way.
+        if (servoing && controller.name == "arm_trajectory_controller")
+        {
+            arm_slice = slice;
             continue;
         }
         if (!controller.client->action_server_is_ready())
@@ -406,9 +437,15 @@ bool G1VlaServer::executeChunk(const JointTrajectory& chunk, std::string& why)
         sent_to.push_back(controller.name);
     }
 
-    if (results.empty())
+    if (results.empty() && arm_slice.joint_names.empty())
     {
         why = "the chunk names no joint any controller owns";
+        return false;
+    }
+
+    // Streamed before the hand goals are awaited, so a chunk driving both moves them together.
+    if (!arm_slice.joint_names.empty() && !streamArmServo(arm_slice, why))
+    {
         return false;
     }
 
@@ -426,6 +463,83 @@ bool G1VlaServer::executeChunk(const JointTrajectory& chunk, std::string& why)
             return false;
         }
     }
+    return true;
+}
+
+std::vector<double> G1VlaServer::clampToLimits(
+    const std::vector<std::string>& joints, const std::vector<double>& velocities) const
+{
+    std::vector<double> clamped;
+    clamped.reserve(velocities.size());
+    for (std::size_t i = 0; i < velocities.size(); ++i)
+    {
+        // Correcting a large error would otherwise ask for a speed the chunk was never checked
+        // at, which is the one thing the gate exists to prevent.
+        const auto   limit_it = limits_.find(joints[i]);
+        const double cap = limit_it == limits_.end() ? 0.0 : limit_it->second * velocity_scaling_;
+        clamped.push_back(std::clamp(velocities[i], -cap, cap));
+    }
+    return clamped;
+}
+
+bool G1VlaServer::selectServoJointJog(std::string& why)
+{
+    if (!servo_command_type_->service_is_ready())
+    {
+        why = "servo is not running; execution_mode is 'servo' but nothing serves "
+              "/servo_node/switch_command_type";
+        return false;
+    }
+    auto request          = std::make_shared<moveit_msgs::srv::ServoCommandType::Request>();
+    request->command_type = moveit_msgs::srv::ServoCommandType::Request::JOINT_JOG;
+    auto future           = servo_command_type_->async_send_request(request);
+    if (!settled(future, 5.0) || !future.get()->success)
+    {
+        why = "servo refused to switch to joint-jog mode";
+        return false;
+    }
+    return true;
+}
+
+bool G1VlaServer::streamArmServo(const JointTrajectory& arm_slice, std::string& why)
+{
+    const double tick = 1.0 / servo_publish_rate_;
+    if (trackingVelocity(arm_slice, measuredJoints(), 0.0, tick).empty())
+    {
+        why = "the chunk names an arm joint that is not being measured";
+        return false;
+    }
+
+    const auto period = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+        std::chrono::duration<double>(tick));
+    const auto start = std::chrono::steady_clock::now();
+
+    // Paced off the wall clock rather than a sleep per iteration: servo integrates however long
+    // each command was actually in force, so a loop that drifts late travels further.
+    for (auto next = start;; next += period)
+    {
+        // Re-read every tick. The velocity is a correction toward the next validated waypoint,
+        // so tracking error is cancelled rather than accumulated.
+        const std::vector<double> velocities = trackingVelocity(
+            arm_slice,
+            measuredJoints(),
+            std::chrono::duration<double>(next - start).count(),
+            tick);
+        if (velocities.empty())
+        {
+            break;
+        }
+        control_msgs::msg::JointJog jog;
+        jog.header.stamp = now();
+        jog.joint_names  = arm_slice.joint_names;
+        jog.velocities   = clampToLimits(arm_slice.joint_names, velocities);
+        jog.duration     = tick;
+        servo_pub_->publish(jog);
+        std::this_thread::sleep_until(next + period);
+    }
+
+    // Nothing is published to stop with. Servo halts on its own once incoming_command_timeout
+    // passes without a command, which is the same dead-man that covers this process dying.
     return true;
 }
 
@@ -447,6 +561,11 @@ G1VlaServer::Outcome G1VlaServer::runGrasp(
     Outcome                                  outcome;
     auto                                     feedback = std::make_shared<Grasp::Feedback>();
     feedback->phase                                   = Grasp::Feedback::PHASE_ACTING;
+
+    if (execution_mode_ == "servo" && !selectServoJointJog(outcome.message))
+    {
+        return outcome;
+    }
 
     const rclcpp::Time deadline            = now() + rclcpp::Duration::from_seconds(timeout_s_);
     int                consecutive_rejects = 0;

--- a/workspace/src/g1_vla/test/test_chunk_utils.cpp
+++ b/workspace/src/g1_vla/test/test_chunk_utils.cpp
@@ -20,6 +20,7 @@ using g1_vla::maxSegmentStep;
 using g1_vla::maxVelocityRatio;
 using g1_vla::splitByController;
 using g1_vla::startJump;
+using g1_vla::trackingVelocity;
 using g1_vla::wellFormed;
 using trajectory_msgs::msg::JointTrajectory;
 using trajectory_msgs::msg::JointTrajectoryPoint;
@@ -185,4 +186,57 @@ TEST(VelocityRatio, FailsWhenAJointHasNoUsableLimit)
                      measured,
                      { { "right_elbow_joint", 1.0 }, { "right_shoulder_pitch_joint", 0.0 } })
                      .has_value());
+}
+
+TEST(TrackingVelocity, AimsAtTheNextWaypointFromWhereTheArmIs)
+{
+    const JointMap        measured = { { "right_elbow_joint", 0.0 },
+                                       { "right_shoulder_pitch_joint", 0.0 } };
+    const JointTrajectory chunk    = chunkOf(kArm, { { 0.02, 0.0 }, { 0.02, 0.05 } }, 0.1);
+
+    // 0.02 rad away, 0.1 s left to get there.
+    EXPECT_THAT(
+        trackingVelocity(chunk, measured, 0.0, 0.02),
+        testing::ElementsAre(testing::DoubleNear(0.2, 1e-9), testing::DoubleNear(0.0, 1e-9)));
+    // Half way through the segment the arm has not moved, so the command doubles to still make
+    // the waypoint on time. An open-loop velocity would have kept sending 0.2 and fallen short.
+    EXPECT_THAT(
+        trackingVelocity(chunk, measured, 0.05, 0.02),
+        testing::ElementsAre(testing::DoubleNear(0.4, 1e-9), testing::DoubleNear(0.0, 1e-9)));
+}
+
+TEST(TrackingVelocity, CorrectsAnArmThatHasDriftedPastTheWaypoint)
+{
+    // Overshot the first waypoint: the command has to point back.
+    const JointMap        measured = { { "right_elbow_joint", 0.05 },
+                                       { "right_shoulder_pitch_joint", 0.0 } };
+    const JointTrajectory chunk    = chunkOf(kArm, { { 0.02, 0.0 } }, 0.1);
+
+    EXPECT_LT(trackingVelocity(chunk, measured, 0.0, 0.02).front(), 0.0);
+}
+
+TEST(TrackingVelocity, FloorsTheTimeLeftSoALateTickDoesNotDivideByZero)
+{
+    const JointMap        measured = { { "right_elbow_joint", 0.0 },
+                                       { "right_shoulder_pitch_joint", 0.0 } };
+    const JointTrajectory chunk    = chunkOf(kArm, { { 0.02, 0.0 } }, 0.1);
+
+    const std::vector<double> velocities = trackingVelocity(chunk, measured, 0.0999, 0.02);
+    ASSERT_EQ(velocities.size(), 2U);
+    EXPECT_NEAR(velocities[0], 1.0, 1e-9);
+}
+
+TEST(TrackingVelocity, IsEmptyOnceTheChunkIsDone)
+{
+    const JointMap        measured = { { "right_elbow_joint", 0.0 },
+                                       { "right_shoulder_pitch_joint", 0.0 } };
+    const JointTrajectory chunk    = chunkOf(kArm, { { 0.02, 0.0 } }, 0.1);
+
+    EXPECT_TRUE(trackingVelocity(chunk, measured, 0.1, 0.02).empty());
+    EXPECT_TRUE(trackingVelocity(chunk, measured, 5.0, 0.02).empty());
+}
+
+TEST(TrackingVelocity, IsEmptyWhenAJointWasNotMeasured)
+{
+    EXPECT_TRUE(trackingVelocity(chunkOf(kArm, { { 0.02, 0.0 } }, 0.1), {}, 0.0, 0.02).empty());
 }

--- a/workspace/src/g1_vla/test/test_vla_grasp_servo.launch.py
+++ b/workspace/src/g1_vla/test/test_vla_grasp_servo.launch.py
@@ -1,0 +1,230 @@
+"""Headless sim integration test: the same gate, executing through MoveIt Servo.
+
+test_vla_grasp_mock covers the trajectory path. This covers what the servo path adds and what it
+gives up.
+
+What it does NOT assert is that the arm follows the validated waypoints. It does not: jog
+commands are integrated by the servo, which tracks velocity and never position, and the arm keeps
+moving for up to incoming_command_timeout after a chunk's stream ends. The validated positions
+are a reference the arm is steered toward. Asserting otherwise here would be encoding a promise
+this execution mode does not make.
+
+Servo brings its own collision monitor on top, which decelerates during motion rather than
+refusing beforehand. The last case pins that separately, because a servo whose monitor is
+misconfigured looks identical to one that works right up until something moves into the arm.
+
+Run via `colcon test --packages-select g1_vla`.
+"""
+
+import os
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+from control_msgs.msg import JointJog
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from moveit_msgs.msg import ServoStatus
+from moveit_msgs.srv import ServoCommandType
+from rcl_interfaces.srv import SetParameters
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import JointState
+
+from g1_msgs.action import Grasp
+
+STACK_SETTLE_S = 55.0
+READY_TIMEOUT_S = STACK_SETTLE_S + 30.0
+GOAL_TIMEOUT_S = 8.0
+MAX_REJECTED = 5
+
+WATCHED = ["right_shoulder_pitch_joint", "right_shoulder_roll_joint", "right_elbow_joint"]
+# Same measured self-collision the trajectory suite uses: the arm meets the torso from about
+# roll 0.1, and that is unaffected by the hand's octomap exemption.
+BLOCKED_TARGET = [0.06, 0.6, 0.09]
+
+
+@launch_testing.ready_to_test_action_timeout(READY_TIMEOUT_S)
+def generate_test_description():
+    bringup = get_package_share_directory("g1_bringup")
+    stack = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(bringup, "launch", "bringup.launch.py")),
+        launch_arguments={
+            "moveit": "true",
+            "manipulation": "true",
+            "vla": "true",
+            "vla_engine": "mock",
+            "vla_execution_mode": "servo",
+            "odometry": "ground_truth",
+            "world": "manipulation",
+            "pin_pelvis": "true",
+            "activate_arm": "true",
+            "activate_arm_delay_s": "40.0",
+            "headless": "true",
+            "rviz": "false",
+        }.items(),
+    )
+    return LaunchDescription(
+        [stack, TimerAction(period=STACK_SETTLE_S, actions=[launch_testing.actions.ReadyToTest()])]
+    )
+
+
+class TestVlaGraspServo(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_vla_grasp_servo")
+        cls.joints = {}
+        cls.jogs = 0
+
+        def _on_joints(msg):
+            for name, position in zip(msg.name, msg.position, strict=False):
+                cls.joints[name] = position
+
+        def _on_jog(_msg):
+            cls.jogs += 1
+
+        cls.node.create_subscription(JointState, "/joint_states", _on_joints, 20)
+        cls.node.create_subscription(JointJog, "/servo_node/delta_joint_cmds", _on_jog, 50)
+        cls.grasp = ActionClient(cls.node, Grasp, "/g1_vla_server/grasp")
+        cls.server_params = cls.node.create_client(SetParameters, "/g1_vla_server/set_parameters")
+        cls.engine_params = cls.node.create_client(
+            SetParameters, "/g1_vla_mock_engine/set_parameters"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin(self, seconds):
+        end = time.time() + seconds
+        while time.time() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+    def _set_params(self, client, parameters):
+        self.assertTrue(client.wait_for_service(timeout_sec=30.0), client.srv_name)
+        request = SetParameters.Request()
+        request.parameters = [p.to_parameter_msg() for p in parameters]
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=30.0)
+        self.assertIsNotNone(future.result(), f"{client.srv_name} never answered")
+        for result in future.result().results:
+            self.assertTrue(result.successful, result.reason)
+
+    def _watched(self):
+        return [self.joints[name] for name in WATCHED]
+
+    def _run_grasp(self, timeout_s):
+        goal = Grasp.Goal()
+        goal.instruction = "pick up the red cube"
+        goal.object_id = "red_cube"
+        goal.arm = "right"
+        handle_future = self.grasp.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self.node, handle_future, timeout_sec=30.0)
+        handle = handle_future.result()
+        self.assertIsNotNone(handle, "the grasp server never answered")
+        self.assertTrue(handle.accepted, "the grasp server rejected the goal")
+        result_future = handle.get_result_async()
+        rclpy.spin_until_future_complete(self.node, result_future, timeout_sec=timeout_s)
+        self.assertIsNotNone(result_future.result(), "the grasp goal never finished")
+        return result_future.result().result
+
+    def test_01_the_stack_is_up_with_servo(self):
+        self.assertTrue(
+            self.grasp.wait_for_server(timeout_sec=90.0), "/g1_vla_server/grasp never appeared"
+        )
+        end = time.time() + 60.0
+        while time.time() < end and len(self.joints) < 40:
+            rclpy.spin_once(self.node, timeout_sec=0.2)
+        self.assertGreaterEqual(len(self.joints), 40, "joint states never arrived")
+        self._set_params(
+            self.server_params,
+            [
+                Parameter("timeout_s", Parameter.Type.DOUBLE, GOAL_TIMEOUT_S),
+                Parameter("max_rejected_chunks", Parameter.Type.INTEGER, MAX_REJECTED),
+            ],
+        )
+
+    def test_02_validated_chunks_are_streamed_as_jog_commands(self):
+        before = self._watched()
+        self.__class__.jogs = 0
+
+        result = self._run_grasp(GOAL_TIMEOUT_S + 60.0)
+
+        self.assertNotIn("[0 executed", result.message, f"nothing ran: {result.message}")
+        # The backend actually in use, not just the parameter: nothing publishes here in
+        # trajectory mode, so a zero count would mean the mode never took effect.
+        self.assertGreater(self.jogs, 50, "no jog commands were streamed")
+
+        self._spin(2.0)
+        moved = max(abs(a - b) for a, b in zip(self._watched(), before, strict=True))
+        self.assertGreater(moved, 0.05, "the arm did not move for chunks that passed the gate")
+
+    def test_03_a_blocked_chunk_is_never_streamed(self):
+        self._set_params(
+            self.engine_params,
+            [Parameter("target_positions", Parameter.Type.DOUBLE_ARRAY, BLOCKED_TARGET)],
+        )
+        # Long enough for the previous case's motion to stop entirely, servo included.
+        self._spin(10.0)
+        self.__class__.jogs = 0
+
+        result = self._run_grasp(GOAL_TIMEOUT_S + 60.0)
+
+        self.assertFalse(result.success, result.message)
+        self.assertTrue(
+            result.message.startswith("blocked:"),
+            f"expected a blocked abort, got: {result.message}",
+        )
+        self.assertIn(f"{MAX_REJECTED} rejected]", result.message)
+        # Direct evidence, and better than the trajectory suite can get: in servo mode nothing
+        # reaches the arm except through this topic, so a zero count is proof that a refused
+        # chunk was never streamed.
+        self.assertEqual(self.jogs, 0, "a refused chunk was streamed anyway")
+
+
+    def test_04_servo_halts_for_a_collision_while_moving(self):
+        """The layer servo adds over the gate: reacting during motion, not before it.
+
+        Driven directly rather than through a chunk. The gate would refuse this motion outright,
+        which is the point: what is under test here is the second line of defence.
+        """
+        switch = self.node.create_client(ServoCommandType, "/servo_node/switch_command_type")
+        self.assertTrue(switch.wait_for_service(timeout_sec=30.0), "servo is not running")
+        request = ServoCommandType.Request()
+        request.command_type = ServoCommandType.Request.JOINT_JOG
+        future = switch.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=20.0)
+        self.assertTrue(future.result().success, "servo refused joint-jog mode")
+
+        codes = set()
+        self.node.create_subscription(
+            ServoStatus, "/servo_node/status", lambda msg: codes.add(msg.code), 20
+        )
+        jog = self.node.create_publisher(JointJog, "/servo_node/delta_joint_cmds", 10)
+
+        self._spin(1.0)
+        before = self.joints["right_shoulder_roll_joint"]
+        end = time.time() + 14.0
+        while time.time() < end:
+            message = JointJog()
+            message.header.stamp = self.node.get_clock().now().to_msg()
+            message.joint_names = ["right_shoulder_roll_joint"]
+            # Toward the torso, which the arm meets at about 0.1 rad.
+            message.velocities = [0.25]
+            message.duration = 0.02
+            jog.publish(message)
+            rclpy.spin_once(self.node, timeout_sec=0.02)
+        self._spin(2.0)
+
+        self.assertIn(ServoStatus.HALT_FOR_COLLISION, codes, f"servo never halted; saw {codes}")
+        # Stopped short of contact rather than at it: 14 s at 0.25 rad/s would be 3.5 rad if
+        # nothing intervened, and the collision starts at about 0.1.
+        travelled = self.joints["right_shoulder_roll_joint"] - before
+        self.assertLess(travelled, 0.12, f"servo let the arm travel {travelled:.3f} rad")


### PR DESCRIPTION
The gate can now stream a validated chunk through MoveIt Servo instead of sending it as a trajectory. Off by default.

- `g1_moveit_config`: `config/servo.yaml` and a `servo:=false` argument on `move_group.launch.py`.
- `g1_vla`: `execution_mode: trajectory|servo`, closed-loop jog streaming, and a sim test.
- `g1_bringup`: `vla_execution_mode:=trajectory|servo` drives both.

Four things worth knowing, all found by running it:

Servo 2.12.4 starts with no command type selected and silently refuses every jog until one is chosen, logging only "Command type has not been set". The gate calls `/servo_node/switch_command_type` once per goal. Its `check_octomap_collisions` also defaults to false, and the obstacle here is the octomap, so the default gives a collision monitor that never sees the bench.

A node-named key in a package yaml beats a launch override. `execution_mode` set under `g1_vla_server:` won over the launch argument, because launch writes overrides under the `/**` wildcard and node-specific always wins over a wildcard regardless of file order. The symptom was a server reporting trajectory mode while every argument said servo. Keys the launch owns are now out of that file with a comment saying why.

Servo must not be handed the sensor config, or it starts a second octomap updater on the same camera: double the CPU and a map that can disagree with the one the gate validates against.

Servo mode does not follow the validated waypoints exactly. Jog commands are integrated as velocity, never position, and servo keeps moving for up to `incoming_command_timeout` after a stream ends. I made the streaming closed-loop, which reduced the drift but cannot remove it. So the servo suite asserts what this mode actually guarantees, and gets better evidence for the central claim than the trajectory suite can: nothing reaches the arm except through the jog topic, so a zero message count during a refused goal is direct proof nothing was streamed. Trajectory mode stays the default and the README says why.

The reactive layer is real and measured: jogging into the torso produced DECELERATE then HALT_FOR_COLLISION, stopping the arm at 0.073 rad against a 3.5 rad command.

Verified: full gate green (14 packages, `-LE simulator`); both sim suites three consecutive times.